### PR TITLE
Add automation coverage queue

### DIFF
--- a/app/Livewire/AutomationCoverageQueue.php
+++ b/app/Livewire/AutomationCoverageQueue.php
@@ -12,6 +12,7 @@ class AutomationCoverageQueue extends Component
         $properties = WebProperty::query()
             ->with([
                 'primaryDomain',
+                'primaryDomain.tags',
                 'primaryDomain.latestSeoBaseline',
                 'repositories',
                 'analyticsSources',

--- a/app/Livewire/AutomationCoverageQueue.php
+++ b/app/Livewire/AutomationCoverageQueue.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\WebProperty;
+use Livewire\Component;
+
+class AutomationCoverageQueue extends Component
+{
+    public function render(): \Illuminate\View\View
+    {
+        $properties = WebProperty::query()
+            ->with([
+                'primaryDomain',
+                'primaryDomain.latestSeoBaseline',
+                'repositories',
+                'analyticsSources',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain.tags',
+            ])
+            ->orderBy('name')
+            ->get();
+
+        $queues = [
+            'needsController' => [],
+            'needsMatomoBinding' => [],
+            'needsSearchConsoleMapping' => [],
+            'needsOnboarding' => [],
+            'importStale' => [],
+            'needsBaselineSync' => [],
+            'manualCsvPending' => [],
+            'complete' => [],
+            'excluded' => [],
+        ];
+
+        foreach ($properties as $property) {
+            $automation = $property->automationCoverageSummary();
+            $primaryDomain = $property->primaryDomainModel();
+            $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+                ? $primaryDomain->latestSeoBaseline
+                : $primaryDomain?->latestSeoBaseline()->first();
+
+            $row = [
+                'property' => $property,
+                'automation' => $automation,
+                'primary_domain' => $property->primaryDomainName(),
+                'repository' => $property->repositories->first(),
+                'matomo_source' => $property->primaryAnalyticsSource('matomo'),
+                'search_console_coverage' => $property->primaryAnalyticsSource('matomo')?->latestSearchConsoleCoverage,
+                'latest_baseline' => $latestBaseline,
+            ];
+
+            match ($automation['status']) {
+                'needs_controller' => $queues['needsController'][] = $row,
+                'needs_matomo_binding' => $queues['needsMatomoBinding'][] = $row,
+                'needs_search_console_mapping' => $queues['needsSearchConsoleMapping'][] = $row,
+                'needs_onboarding' => $queues['needsOnboarding'][] = $row,
+                'import_stale' => $queues['importStale'][] = $row,
+                'needs_baseline_sync' => $queues['needsBaselineSync'][] = $row,
+                'manual_csv_pending' => $queues['manualCsvPending'][] = $row,
+                'complete' => $queues['complete'][] = $row,
+                default => $queues['excluded'][] = $row,
+            };
+        }
+
+        return view('livewire.automation-coverage-queue', [
+            'needsController' => collect($queues['needsController']),
+            'needsMatomoBinding' => collect($queues['needsMatomoBinding']),
+            'needsSearchConsoleMapping' => collect($queues['needsSearchConsoleMapping']),
+            'needsOnboarding' => collect($queues['needsOnboarding']),
+            'importStale' => collect($queues['importStale']),
+            'needsBaselineSync' => collect($queues['needsBaselineSync']),
+            'manualCsvPending' => collect($queues['manualCsvPending']),
+            'complete' => collect($queues['complete']),
+            'excluded' => collect($queues['excluded']),
+            'stats' => [
+                'required' => count($queues['needsController'])
+                    + count($queues['needsMatomoBinding'])
+                    + count($queues['needsSearchConsoleMapping'])
+                    + count($queues['needsOnboarding'])
+                    + count($queues['importStale'])
+                    + count($queues['needsBaselineSync'])
+                    + count($queues['manualCsvPending'])
+                    + count($queues['complete']),
+                'needs_controller' => count($queues['needsController']),
+                'needs_matomo_binding' => count($queues['needsMatomoBinding']),
+                'needs_search_console_mapping' => count($queues['needsSearchConsoleMapping']),
+                'needs_onboarding' => count($queues['needsOnboarding']),
+                'import_stale' => count($queues['importStale']),
+                'needs_baseline_sync' => count($queues['needsBaselineSync']),
+                'manual_csv_pending' => count($queues['manualCsvPending']),
+                'complete' => count($queues['complete']),
+                'excluded' => count($queues['excluded']),
+            ],
+        ]);
+    }
+}

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -351,10 +351,96 @@ class WebProperty extends Model
             'domains' => $this->domainSummaries(),
             'repositories' => $this->repositorySummaries(),
             'analytics_sources' => $this->analyticsSourceSummaries(),
+            'coverage_summary' => $this->fullCoverageSummary(),
+            'automation_summary' => $this->automationCoverageSummary(),
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{eligible: bool, reason: string|null}
+     */
+    public function coverageEligibility(): array
+    {
+        if ($this->status !== 'active') {
+            return ['eligible' => false, 'reason' => 'property is not active'];
+        }
+
+        if ($this->property_type === 'domain_asset') {
+            return ['eligible' => false, 'reason' => 'property is a domain asset'];
+        }
+
+        $domain = $this->primaryDomainModel();
+        if (! $domain instanceof Domain) {
+            return ['eligible' => false, 'reason' => 'no primary domain linked'];
+        }
+
+        $manualExclusionTagName = (string) config('domain_monitor.coverage_tags.manual_exclusion_tag.name', '');
+        if ($manualExclusionTagName !== '') {
+            $domainTags = $domain->relationLoaded('tags')
+                ? $domain->tags
+                : $domain->tags()->get();
+
+            if ($domainTags->contains(fn (DomainTag $tag): bool => $tag->name === $manualExclusionTagName)) {
+                return ['eligible' => false, 'reason' => 'primary domain is manually excluded from fleet coverage'];
+            }
+        }
+
+        if (! $domain->is_active) {
+            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
+        }
+
+        if ($domain->isParkedForHosting()) {
+            return ['eligible' => false, 'reason' => 'primary domain is parked'];
+        }
+
+        if ($domain->isEmailOnly()) {
+            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
+        }
+
+        return ['eligible' => true, 'reason' => null];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function repositoryCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $repositories = $this->relationLoaded('repositories')
+            ? $this->repositories
+            : $this->repositories()->get();
+
+        $primaryRepository = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
+            ->first();
+
+        if (! $primaryRepository instanceof PropertyRepository) {
+            return [
+                'status' => 'needs_repository',
+                'label' => 'Needs repository',
+                'reason' => 'eligible property has no linked repository/controller surface',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'primary repository %s is linked',
+                $primaryRepository->repo_name
+            ),
         ];
     }
 
@@ -375,32 +461,7 @@ class WebProperty extends Model
      */
     public function matomoEligibility(): array
     {
-        if ($this->status !== 'active') {
-            return ['eligible' => false, 'reason' => 'property is not active'];
-        }
-
-        if ($this->property_type === 'domain_asset') {
-            return ['eligible' => false, 'reason' => 'property is a domain asset'];
-        }
-
-        $domain = $this->primaryDomainModel();
-        if (! $domain instanceof Domain) {
-            return ['eligible' => false, 'reason' => 'no primary domain linked'];
-        }
-
-        if (! $domain->is_active) {
-            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
-        }
-
-        if ($domain->isParkedForHosting()) {
-            return ['eligible' => false, 'reason' => 'primary domain is parked'];
-        }
-
-        if ($domain->isEmailOnly()) {
-            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
-        }
-
-        return ['eligible' => true, 'reason' => null];
+        return $this->coverageEligibility();
     }
 
     /**
@@ -450,6 +511,375 @@ class WebProperty extends Model
             'status' => 'bound_attention',
             'label' => 'Needs attention',
             'reason' => $audit->summary,
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function searchConsoleCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $matomoSource = $this->primaryAnalyticsSource('matomo');
+        if (! $matomoSource instanceof PropertyAnalyticsSource) {
+            return [
+                'status' => 'needs_matomo',
+                'label' => 'Needs Matomo',
+                'reason' => 'Search Console coverage depends on a primary Matomo binding',
+            ];
+        }
+
+        $coverage = $matomoSource->relationLoaded('latestSearchConsoleCoverage')
+            ? $matomoSource->latestSearchConsoleCoverage
+            : $matomoSource->latestSearchConsoleCoverage()->first();
+
+        if (! $coverage instanceof SearchConsoleCoverageStatus || $coverage->mapping_state === 'not_mapped') {
+            return [
+                'status' => 'needs_property',
+                'label' => 'Needs Search Console',
+                'reason' => 'Matomo is linked but no Search Console property is mapped yet',
+            ];
+        }
+
+        if ($coverage->freshnessState() === 'never_imported') {
+            return [
+                'status' => 'needs_import',
+                'label' => 'Needs import',
+                'reason' => 'Search Console property is mapped but no data has been imported yet',
+            ];
+        }
+
+        if ($coverage->freshnessState() === 'stale') {
+            return [
+                'status' => 'stale_import',
+                'label' => 'Import stale',
+                'reason' => 'Search Console coverage import is stale',
+            ];
+        }
+
+        if ($coverage->mapping_state === 'url_prefix') {
+            return [
+                'status' => 'url_prefix_only',
+                'label' => 'URL prefix only',
+                'reason' => 'Search Console is mapped as a URL prefix instead of a domain property',
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'needs_baseline',
+                'label' => 'Needs baseline',
+                'reason' => 'Search Console is mapped but no SEO baseline has been imported yet',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'domain property is mapped and fresh for %s',
+                $coverage->property_uri ?? $primaryDomain->domain ?? $this->slug
+            ),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   required: bool,
+     *   status: string,
+     *   label: string,
+     *   reason: string|null,
+     *   reasons: array<int, string>,
+     *   checks: array<string, array{status: string, label: string, reason: string|null}>
+     * }
+     */
+    public function fullCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        $checks = [
+            'repository' => $this->repositoryCoverageSummary(),
+            'matomo' => $this->matomoCoverageSummary(),
+            'search_console' => $this->searchConsoleCoverageSummary(),
+        ];
+
+        if (! $eligibility['eligible']) {
+            return [
+                'required' => false,
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+                'reasons' => array_filter([$eligibility['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $gapReasons = collect($checks)
+            ->reject(fn (array $check): bool => $check['status'] === 'covered')
+            ->pluck('reason')
+            ->filter(fn ($reason): bool => is_string($reason) && $reason !== '')
+            ->values()
+            ->all();
+
+        if ($gapReasons === []) {
+            return [
+                'required' => true,
+                'status' => 'complete',
+                'label' => 'Complete',
+                'reason' => 'repository, Matomo, and Search Console coverage are all in place',
+                'reasons' => [],
+                'checks' => $checks,
+            ];
+        }
+
+        return [
+            'required' => true,
+            'status' => 'gap',
+            'label' => 'Gap',
+            'reason' => $gapReasons[0],
+            'reasons' => $gapReasons,
+            'checks' => $checks,
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function baselineSyncSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $searchConsole = $this->searchConsoleCoverageSummary();
+        if ($searchConsole['status'] !== 'covered') {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => $searchConsole['reason'],
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'needs_sync',
+                'label' => 'Needs baseline sync',
+                'reason' => 'Search Console data is ready, but no Domain Monitor SEO baseline has been synced yet',
+            ];
+        }
+
+        if ($latestBaseline->captured_at->lt(now()->subDays(30))) {
+            return [
+                'status' => 'stale',
+                'label' => 'Baseline stale',
+                'reason' => 'The latest Domain Monitor SEO baseline is older than 30 days',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'latest SEO baseline captured %s',
+                $latestBaseline->captured_at->toDateString()
+            ),
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function manualCsvCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $baseline = $this->baselineSyncSummary();
+        if ($baseline['status'] !== 'covered') {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => $baseline['reason'],
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => 'No SEO baseline is available yet',
+            ];
+        }
+
+        if ($latestBaseline->import_method === 'matomo_plus_manual_csv') {
+            return [
+                'status' => 'covered',
+                'label' => 'Covered',
+                'reason' => 'Manual Search Console CSV evidence has been imported',
+            ];
+        }
+
+        return [
+            'status' => 'pending',
+            'label' => 'Manual CSV pending',
+            'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
+        ];
+    }
+
+    /**
+     * @return array{
+     *   required: bool,
+     *   status: string,
+     *   label: string,
+     *   reason: string|null,
+     *   reasons: array<int, string>,
+     *   checks: array<string, array{status: string, label: string, reason: string|null}>
+     * }
+     */
+    public function automationCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        $checks = [
+            'repository' => $this->repositoryCoverageSummary(),
+            'matomo' => $this->matomoCoverageSummary(),
+            'search_console' => $this->searchConsoleCoverageSummary(),
+            'baseline_sync' => $this->baselineSyncSummary(),
+            'manual_csv' => $this->manualCsvCoverageSummary(),
+        ];
+
+        if (! $eligibility['eligible']) {
+            return [
+                'required' => false,
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+                'reasons' => array_filter([$eligibility['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $repository = $checks['repository'];
+        if ($repository['status'] !== 'covered') {
+            return [
+                'required' => true,
+                'status' => 'needs_controller',
+                'label' => 'Needs controller',
+                'reason' => $repository['reason'],
+                'reasons' => array_filter([$repository['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $matomo = $checks['matomo'];
+        if ($matomo['status'] !== 'covered') {
+            return [
+                'required' => true,
+                'status' => 'needs_matomo_binding',
+                'label' => 'Needs Matomo',
+                'reason' => $matomo['reason'],
+                'reasons' => array_filter([$matomo['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $searchConsole = $checks['search_console'];
+        if (in_array($searchConsole['status'], ['needs_matomo', 'needs_property', 'url_prefix_only'], true)) {
+            return [
+                'required' => true,
+                'status' => 'needs_search_console_mapping',
+                'label' => 'Needs Search Console',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        if ($searchConsole['status'] === 'needs_import') {
+            return [
+                'required' => true,
+                'status' => 'needs_onboarding',
+                'label' => 'Needs onboarding',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        if ($searchConsole['status'] === 'stale_import') {
+            return [
+                'required' => true,
+                'status' => 'import_stale',
+                'label' => 'Import stale',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $baseline = $checks['baseline_sync'];
+        if (in_array($baseline['status'], ['needs_sync', 'stale'], true)) {
+            return [
+                'required' => true,
+                'status' => 'needs_baseline_sync',
+                'label' => 'Needs baseline sync',
+                'reason' => $baseline['reason'],
+                'reasons' => array_filter([$baseline['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $manualCsv = $checks['manual_csv'];
+        if ($manualCsv['status'] === 'pending') {
+            return [
+                'required' => true,
+                'status' => 'manual_csv_pending',
+                'label' => 'Manual CSV pending',
+                'reason' => $manualCsv['reason'],
+                'reasons' => array_filter([$manualCsv['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        return [
+            'required' => true,
+            'status' => 'complete',
+            'label' => 'Complete',
+            'reason' => 'All automatic coverage checks are in place and only optional manual evidence remains complete',
+            'reasons' => [],
+            'checks' => $checks,
         ];
     }
 

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -573,25 +573,12 @@ class WebProperty extends Model
             ];
         }
 
-        $primaryDomain = $this->primaryDomainModel();
-        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
-            ? $primaryDomain->latestSeoBaseline
-            : $primaryDomain?->latestSeoBaseline()->first();
-
-        if (! $latestBaseline instanceof DomainSeoBaseline) {
-            return [
-                'status' => 'needs_baseline',
-                'label' => 'Needs baseline',
-                'reason' => 'Search Console is mapped but no SEO baseline has been imported yet',
-            ];
-        }
-
         return [
             'status' => 'covered',
             'label' => 'Covered',
             'reason' => sprintf(
                 'domain property is mapped and fresh for %s',
-                $coverage->property_uri ?? $primaryDomain->domain ?? $this->slug
+                $coverage->property_uri ?? $this->primaryDomainName() ?? $this->slug
             ),
         ];
     }

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -351,8 +351,6 @@ class WebProperty extends Model
             'domains' => $this->domainSummaries(),
             'repositories' => $this->repositorySummaries(),
             'analytics_sources' => $this->analyticsSourceSummaries(),
-            'coverage_summary' => $this->fullCoverageSummary(),
-            'automation_summary' => $this->automationCoverageSummary(),
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
@@ -461,7 +459,32 @@ class WebProperty extends Model
      */
     public function matomoEligibility(): array
     {
-        return $this->coverageEligibility();
+        if ($this->status !== 'active') {
+            return ['eligible' => false, 'reason' => 'property is not active'];
+        }
+
+        if ($this->property_type === 'domain_asset') {
+            return ['eligible' => false, 'reason' => 'property is a domain asset'];
+        }
+
+        $domain = $this->primaryDomainModel();
+        if (! $domain instanceof Domain) {
+            return ['eligible' => false, 'reason' => 'no primary domain linked'];
+        }
+
+        if (! $domain->is_active) {
+            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
+        }
+
+        if ($domain->isParkedForHosting()) {
+            return ['eligible' => false, 'reason' => 'primary domain is parked'];
+        }
+
+        if ($domain->isEmailOnly()) {
+            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
+        }
+
+        return ['eligible' => true, 'reason' => null];
     }
 
     /**

--- a/resources/views/automation-coverage/index.blade.php
+++ b/resources/views/automation-coverage/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Automation Coverage
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <livewire:automation-coverage-queue />
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/livewire/automation-coverage-queue.blade.php
+++ b/resources/views/livewire/automation-coverage-queue.blade.php
@@ -1,0 +1,116 @@
+<div class="space-y-6">
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="p-6">
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Automation Coverage</h3>
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                Track the full website automation checklist in one place: controller coverage, Matomo verification, Search Console onboarding, baseline sync, and optional manual CSV evidence.
+            </p>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-9 gap-4">
+        @foreach([
+            ['id' => 'required', 'label' => 'Required'],
+            ['id' => 'needs_controller', 'label' => 'Needs Controller'],
+            ['id' => 'needs_matomo_binding', 'label' => 'Needs Matomo'],
+            ['id' => 'needs_search_console_mapping', 'label' => 'Needs SC'],
+            ['id' => 'needs_onboarding', 'label' => 'Needs Onboarding'],
+            ['id' => 'import_stale', 'label' => 'Import Stale'],
+            ['id' => 'needs_baseline_sync', 'label' => 'Needs Baseline'],
+            ['id' => 'manual_csv_pending', 'label' => 'CSV Pending'],
+            ['id' => 'complete', 'label' => 'Complete'],
+        ] as $stat)
+            <div class="rounded-lg bg-white dark:bg-gray-800 shadow-sm p-4">
+                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $stat['label'] }}</div>
+                <div class="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats[$stat['id']] }}</div>
+            </div>
+        @endforeach
+    </div>
+
+    @php
+        $sections = [
+            ['title' => 'Needs Controller', 'items' => $needsController, 'tone' => 'amber'],
+            ['title' => 'Needs Matomo Binding', 'items' => $needsMatomoBinding, 'tone' => 'red'],
+            ['title' => 'Needs Search Console Mapping', 'items' => $needsSearchConsoleMapping, 'tone' => 'blue'],
+            ['title' => 'Needs Onboarding', 'items' => $needsOnboarding, 'tone' => 'violet'],
+            ['title' => 'Import Stale', 'items' => $importStale, 'tone' => 'red'],
+            ['title' => 'Needs Baseline Sync', 'items' => $needsBaselineSync, 'tone' => 'indigo'],
+            ['title' => 'Manual CSV Pending', 'items' => $manualCsvPending, 'tone' => 'yellow'],
+            ['title' => 'Complete', 'items' => $complete, 'tone' => 'emerald'],
+            ['title' => 'Excluded', 'items' => $excluded, 'tone' => 'gray'],
+        ];
+    @endphp
+
+    @foreach($sections as $section)
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="p-6">
+                <div class="flex items-center justify-between">
+                    <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ $section['title'] }}</h4>
+                    <span class="text-sm text-gray-500 dark:text-gray-400">{{ $section['items']->count() }} properties</span>
+                </div>
+
+                <div class="mt-4 space-y-3">
+                    @if($section['items']->isEmpty())
+                        <p class="text-sm text-gray-500 dark:text-gray-400">No properties in this queue right now.</p>
+                    @else
+                        @foreach($section['items'] as $item)
+                            @php
+                                $toneClasses = match ($section['tone']) {
+                                    'amber' => 'border-amber-200 dark:border-amber-800 bg-amber-50/60 dark:bg-amber-900/10 text-amber-800 dark:text-amber-200',
+                                    'blue' => 'border-blue-200 dark:border-blue-800 bg-blue-50/60 dark:bg-blue-900/10 text-blue-800 dark:text-blue-200',
+                                    'red' => 'border-red-200 dark:border-red-800 bg-red-50/60 dark:bg-red-900/10 text-red-800 dark:text-red-200',
+                                    'violet' => 'border-violet-200 dark:border-violet-800 bg-violet-50/60 dark:bg-violet-900/10 text-violet-800 dark:text-violet-200',
+                                    'indigo' => 'border-indigo-200 dark:border-indigo-800 bg-indigo-50/60 dark:bg-indigo-900/10 text-indigo-800 dark:text-indigo-200',
+                                    'yellow' => 'border-yellow-200 dark:border-yellow-800 bg-yellow-50/60 dark:bg-yellow-900/10 text-yellow-800 dark:text-yellow-200',
+                                    'emerald' => 'border-emerald-200 dark:border-emerald-800 bg-emerald-50/60 dark:bg-emerald-900/10 text-emerald-800 dark:text-emerald-200',
+                                    default => 'border-gray-200 dark:border-gray-700 bg-gray-50/60 dark:bg-gray-900/10 text-gray-700 dark:text-gray-300',
+                                };
+                            @endphp
+                            <div class="rounded-lg border p-4 {{ $toneClasses }}">
+                                <div class="flex flex-wrap items-center justify-between gap-3">
+                                    <div>
+                                        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $item['property']->name }}</div>
+                                        <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                            {{ $item['primary_domain'] ?? 'No primary domain' }}
+                                            @if($item['matomo_source'])
+                                                · Matomo {{ $item['matomo_source']->external_id }}
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <a href="{{ route('web-properties.show', $item['property']->slug) }}" wire:navigate class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                        Open property
+                                    </a>
+                                </div>
+
+                                <div class="mt-2 text-sm">{{ $item['automation']['reason'] }}</div>
+
+                                @if($item['repository'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        Controller: {{ $item['repository']->repo_name }}
+                                    </div>
+                                @endif
+
+                                @if($item['search_console_coverage'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        {{ $item['search_console_coverage']->mappingStateLabel() }}
+                                        @if($item['search_console_coverage']->property_uri)
+                                            · {{ $item['search_console_coverage']->property_uri }}
+                                        @endif
+                                        · {{ $item['search_console_coverage']->freshnessLabel() }}
+                                    </div>
+                                @endif
+
+                                @if($item['latest_baseline'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        Latest baseline {{ $item['latest_baseline']->captured_at->format('Y-m-d') }}
+                                        · {{ $item['latest_baseline']->importMethodLabel() }}
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -42,6 +42,9 @@ new class extends Component
                     <x-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                         {{ __('Matomo Coverage') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
+                        {{ __('Automation') }}
+                    </x-nav-link>
                     <x-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                         {{ __('Search Console') }}
                     </x-nav-link>
@@ -117,6 +120,9 @@ new class extends Component
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                 {{ __('Matomo Coverage') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
+                {{ __('Automation') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                 {{ __('Search Console') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return view('matomo-coverage.index');
     })->name('matomo-coverage.index');
 
+    Route::get('/automation-coverage', function () {
+        return view('automation-coverage.index');
+    })->name('automation-coverage.index');
+
     Route::get('/search-console-coverage', function () {
         return view('search-console-coverage.index');
     })->name('search-console-coverage.index');

--- a/tests/Feature/AutomationCoverageQueueTest.php
+++ b/tests/Feature/AutomationCoverageQueueTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\AutomationCoverageQueue;
+use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
 use App\Models\DomainSeoBaseline;
 use App\Models\PropertyAnalyticsSource;
@@ -11,6 +13,8 @@ use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class AutomationCoverageQueueTest extends TestCase
@@ -29,32 +33,38 @@ class AutomationCoverageQueueTest extends TestCase
         $prefixProperty = $this->makeProperty('prefix.example.au', 'Prefix Only');
         $this->attachRepository($prefixProperty);
         $prefixSource = $this->attachMatomo($prefixProperty, '32');
+        $this->attachInstallAudit($prefixProperty, $prefixSource);
         $this->attachCoverage($prefixProperty, $prefixSource, 'url_prefix', now()->subDay()->toDateString());
 
         $needsOnboarding = $this->makeProperty('needs-onboarding.example.au', 'Needs Onboarding');
         $this->attachRepository($needsOnboarding);
         $needsOnboardingSource = $this->attachMatomo($needsOnboarding, '33');
+        $this->attachInstallAudit($needsOnboarding, $needsOnboardingSource);
         $this->attachCoverage($needsOnboarding, $needsOnboardingSource, 'domain_property', null);
 
         $staleProperty = $this->makeProperty('stale.example.au', 'Stale Import');
         $this->attachRepository($staleProperty);
         $staleSource = $this->attachMatomo($staleProperty, '34');
+        $this->attachInstallAudit($staleProperty, $staleSource);
         $this->attachCoverage($staleProperty, $staleSource, 'domain_property', now()->subDays(10)->toDateString());
 
         $needsBaseline = $this->makeProperty('baseline.example.au', 'Needs Baseline');
         $this->attachRepository($needsBaseline);
         $needsBaselineSource = $this->attachMatomo($needsBaseline, '35');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
         $this->attachCoverage($needsBaseline, $needsBaselineSource, 'domain_property', now()->subDay()->toDateString());
 
         $csvPending = $this->makeProperty('csv-pending.example.au', 'CSV Pending');
         $this->attachRepository($csvPending);
         $csvPendingSource = $this->attachMatomo($csvPending, '36');
+        $this->attachInstallAudit($csvPending, $csvPendingSource);
         $this->attachCoverage($csvPending, $csvPendingSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($csvPending, $csvPendingSource, 'matomo_api');
 
         $complete = $this->makeProperty('complete.example.au', 'Complete Site');
         $this->attachRepository($complete);
         $completeSource = $this->attachMatomo($complete, '37');
+        $this->attachInstallAudit($complete, $completeSource);
         $this->attachCoverage($complete, $completeSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($complete, $completeSource, 'matomo_plus_manual_csv');
 
@@ -91,6 +101,31 @@ class AutomationCoverageQueueTest extends TestCase
         $response->assertSee('Complete Site');
         $response->assertSee('Parked Site');
         $response->assertSee('Manual CSV Pending');
+
+        $this->assertSame('needs_baseline_sync', $needsBaseline->fresh()->automationCoverageSummary()['status']);
+
+        Livewire::test(AutomationCoverageQueue::class)
+            ->assertViewHas('stats', function (array $stats): bool {
+                return $stats['required'] === 8
+                    && $stats['needs_controller'] === 1
+                    && $stats['needs_matomo_binding'] === 1
+                    && $stats['needs_search_console_mapping'] === 1
+                    && $stats['needs_onboarding'] === 1
+                    && $stats['import_stale'] === 1
+                    && $stats['needs_baseline_sync'] === 1
+                    && $stats['manual_csv_pending'] === 1
+                    && $stats['complete'] === 1
+                    && $stats['excluded'] === 1;
+            })
+            ->assertViewHas('needsBaselineSync', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'Needs Baseline');
+            })
+            ->assertViewHas('manualCsvPending', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'CSV Pending');
+            })
+            ->assertViewHas('complete', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'Complete Site');
+            });
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty
@@ -140,6 +175,22 @@ class AutomationCoverageQueueTest extends TestCase
             'external_name' => $property->name,
             'is_primary' => true,
             'status' => 'active',
+        ]);
+    }
+
+    private function attachInstallAudit(WebProperty $property, PropertyAnalyticsSource $source): void
+    {
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $source->external_id,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://'.$property->primaryDomainName().'/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
         ]);
     }
 

--- a/tests/Feature/AutomationCoverageQueueTest.php
+++ b/tests/Feature/AutomationCoverageQueueTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AutomationCoverageQueueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_automation_coverage_queue(): void
+    {
+        $user = User::factory()->create();
+
+        $needsController = $this->makeProperty('no-controller.example.au', 'No Controller');
+
+        $needsMatomo = $this->makeProperty('no-matomo.example.au', 'No Matomo');
+        $this->attachRepository($needsMatomo);
+
+        $prefixProperty = $this->makeProperty('prefix.example.au', 'Prefix Only');
+        $this->attachRepository($prefixProperty);
+        $prefixSource = $this->attachMatomo($prefixProperty, '32');
+        $this->attachCoverage($prefixProperty, $prefixSource, 'url_prefix', now()->subDay()->toDateString());
+
+        $needsOnboarding = $this->makeProperty('needs-onboarding.example.au', 'Needs Onboarding');
+        $this->attachRepository($needsOnboarding);
+        $needsOnboardingSource = $this->attachMatomo($needsOnboarding, '33');
+        $this->attachCoverage($needsOnboarding, $needsOnboardingSource, 'domain_property', null);
+
+        $staleProperty = $this->makeProperty('stale.example.au', 'Stale Import');
+        $this->attachRepository($staleProperty);
+        $staleSource = $this->attachMatomo($staleProperty, '34');
+        $this->attachCoverage($staleProperty, $staleSource, 'domain_property', now()->subDays(10)->toDateString());
+
+        $needsBaseline = $this->makeProperty('baseline.example.au', 'Needs Baseline');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '35');
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, 'domain_property', now()->subDay()->toDateString());
+
+        $csvPending = $this->makeProperty('csv-pending.example.au', 'CSV Pending');
+        $this->attachRepository($csvPending);
+        $csvPendingSource = $this->attachMatomo($csvPending, '36');
+        $this->attachCoverage($csvPending, $csvPendingSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($csvPending, $csvPendingSource, 'matomo_api');
+
+        $complete = $this->makeProperty('complete.example.au', 'Complete Site');
+        $this->attachRepository($complete);
+        $completeSource = $this->attachMatomo($complete, '37');
+        $this->attachCoverage($complete, $completeSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($complete, $completeSource, 'matomo_plus_manual_csv');
+
+        $excludedDomain = Domain::factory()->create([
+            'domain' => 'parked.example.au',
+            'is_active' => true,
+            'platform' => 'Parked',
+        ]);
+        $excludedProperty = WebProperty::factory()->create([
+            'slug' => 'parked-site',
+            'name' => 'Parked Site',
+            'status' => 'active',
+            'property_type' => 'domain_asset',
+            'primary_domain_id' => $excludedDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $excludedProperty->id,
+            'domain_id' => $excludedDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/automation-coverage');
+
+        $response->assertOk();
+        $response->assertSee('Automation Coverage');
+        $response->assertSee('No Controller');
+        $response->assertSee('No Matomo');
+        $response->assertSee('Prefix Only');
+        $response->assertSee('Needs Onboarding');
+        $response->assertSee('Stale Import');
+        $response->assertSee('Needs Baseline');
+        $response->assertSee('CSV Pending');
+        $response->assertSee('Complete Site');
+        $response->assertSee('Parked Site');
+        $response->assertSee('Manual CSV Pending');
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+
+    private function attachRepository(WebProperty $property): void
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachMatomo(WebProperty $property, string $externalId): PropertyAnalyticsSource
+    {
+        return PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $externalId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachCoverage(WebProperty $property, PropertyAnalyticsSource $source, string $mappingState, ?string $latestMetricDate): void
+    {
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => $mappingState,
+            'property_uri' => $mappingState === 'domain_property'
+                ? 'sc-domain:'.$property->primaryDomainName()
+                : 'https://'.$property->primaryDomainName().'/',
+            'property_type' => $mappingState === 'domain_property' ? 'domain' : 'url-prefix',
+            'latest_metric_date' => $latestMetricDate,
+            'checked_at' => now(),
+        ]);
+    }
+
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'manual_checkpoint',
+            'captured_at' => now()->subDay(),
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.5,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a single automation coverage queue page for controller, Matomo, Search Console, baseline sync, and manual CSV checklist states
- extend `WebProperty` with automation-oriented coverage summaries that roll up the existing repo, Matomo, and Search Console signals
- add a focused feature test for the new automation queue states

## Testing
- `./vendor/bin/phpunit tests/Feature/AutomationCoverageQueueTest.php tests/Feature/MatomoCoverageQueueTest.php tests/Feature/SearchConsoleCoverageQueueTest.php`
- `./vendor/bin/phpstan analyse app/Models/WebProperty.php --memory-limit=2G`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
