### PR TITLE
Add coverage tag sync automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,12 @@ jobs:
         run: |
           chmod +x ./scripts/check-production-env.sh
 
-          if APP_ENV=production HORIZON_ALLOWED_EMAILS= ./scripts/check-production-env.sh; then
+          if APP_ENV=production APP_URL=https://example.com QUEUE_CONNECTION=redis HORIZON_ALLOWED_EMAILS= ./scripts/check-production-env.sh; then
             echo "::error::Expected production guard to fail when HORIZON_ALLOWED_EMAILS is empty."
             exit 1
           fi
 
-          APP_ENV=production HORIZON_ALLOWED_EMAILS=ops@example.com ./scripts/check-production-env.sh
+          APP_ENV=production APP_URL=https://example.com QUEUE_CONNECTION=redis HORIZON_ALLOWED_EMAILS=ops@example.com ./scripts/check-production-env.sh
 
       - name: Pint (style)
         if: ${{ matrix.run-quality }}

--- a/app/Console/Commands/RefreshShouldFixQueue.php
+++ b/app/Console/Commands/RefreshShouldFixQueue.php
@@ -31,7 +31,11 @@ class RefreshShouldFixQueue extends Command
     {
         $domains = Domain::query()
             ->where('is_active', true)
-            ->with(['platform', 'webProperties:id,slug,name'])
+            ->with([
+                'platform',
+                'webProperties:id,slug,name,property_type,status',
+                'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+            ])
             ->withLatestCheckStatuses()
             ->withCount([
                 'alerts as open_critical_alerts_count' => fn ($query) => $query

--- a/app/Console/Commands/SyncCoverageTags.php
+++ b/app/Console/Commands/SyncCoverageTags.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Domain;
+use App\Models\DomainTag;
+use App\Models\WebProperty;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class SyncCoverageTags extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'coverage:sync-tags
+                            {--dry-run : Preview tag changes without writing them}
+                            {--domain=* : Limit sync to one or more primary domain names}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync fleet coverage tags onto primary domains using repository, Matomo, and Search Console coverage state';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $tagConfig = (array) config('domain_monitor.coverage_tags', []);
+        $managedTagDefinitions = collect((array) ($tagConfig['tags'] ?? []))
+            ->map(fn ($tag): ?array => $this->normalizeTagDefinition($tag))
+            ->filter();
+
+        $manualExclusionTag = (array) ($tagConfig['manual_exclusion_tag'] ?? []);
+        $manualExclusionDefinition = $this->normalizeTagDefinition($manualExclusionTag) !== null
+            ? collect([
+                'manual_exclusion' => $this->normalizeTagDefinition($manualExclusionTag),
+            ])
+            : collect();
+
+        $tagDefinitions = $managedTagDefinitions->merge($manualExclusionDefinition);
+
+        if ($managedTagDefinitions->isEmpty()) {
+            $this->warn('No coverage tags are configured.');
+
+            return self::SUCCESS;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $targetDomains = collect((array) $this->option('domain'))
+            ->filter(fn ($domain) => is_string($domain) && $domain !== '')
+            ->map(fn (string $domain) => mb_strtolower(trim($domain)))
+            ->values();
+
+        $tagDefinitionsArray = $tagDefinitions->all();
+        $tagIds = $this->ensureTags($tagDefinitionsArray, $dryRun);
+
+        $properties = WebProperty::query()
+            ->with([
+                'primaryDomain.tags',
+                'primaryDomain.latestSeoBaseline',
+                'repositories',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain',
+            ])
+            ->orderBy('name')
+            ->get()
+            ->filter(function (WebProperty $property) use ($targetDomains): bool {
+                if ($targetDomains->isEmpty()) {
+                    return true;
+                }
+
+                $domainName = $property->primaryDomainName();
+
+                return is_string($domainName) && $targetDomains->contains(mb_strtolower($domainName));
+            })
+            ->values();
+
+        if ($properties->isEmpty()) {
+            $this->warn('No matching web properties found.');
+
+            return self::SUCCESS;
+        }
+
+        $coverageTagNames = $managedTagDefinitions->pluck('name')->values();
+
+        $rows = [];
+        $requiredCount = 0;
+        $completeCount = 0;
+        $gapCount = 0;
+        $excludedCount = 0;
+        $domainsChanged = 0;
+
+        foreach ($properties as $property) {
+            $domain = $property->primaryDomainModel();
+            if (! $domain instanceof Domain) {
+                continue;
+            }
+
+            $summary = $property->fullCoverageSummary();
+            $desiredTagNames = $this->desiredTagNames($summary, $managedTagDefinitions->all());
+            $currentCoverageTagNames = $domain->tags
+                ->pluck('name')
+                ->intersect($coverageTagNames)
+                ->values();
+
+            $attachNames = $desiredTagNames->diff($currentCoverageTagNames)->values();
+            $detachNames = $currentCoverageTagNames->diff($desiredTagNames)->values();
+
+            if ($summary['required']) {
+                $requiredCount++;
+            }
+
+            if ($summary['status'] === 'complete') {
+                $completeCount++;
+            } elseif ($summary['status'] === 'gap') {
+                $gapCount++;
+            } else {
+                $excludedCount++;
+            }
+
+            if ($attachNames->isNotEmpty() || $detachNames->isNotEmpty()) {
+                $domainsChanged++;
+            }
+
+            $rows[] = [
+                $domain->domain,
+                $property->slug,
+                $summary['label'],
+                $desiredTagNames->implode(', '),
+                $summary['reason'] ?? '-',
+            ];
+
+            if ($dryRun) {
+                if ($attachNames->isNotEmpty()) {
+                    $this->line(sprintf(
+                        '[dry-run] %s attach %s',
+                        $domain->domain,
+                        $attachNames->implode(', ')
+                    ));
+                }
+
+                if ($detachNames->isNotEmpty()) {
+                    $this->line(sprintf(
+                        '[dry-run] %s detach %s',
+                        $domain->domain,
+                        $detachNames->implode(', ')
+                    ));
+                }
+
+                continue;
+            }
+
+            if ($attachNames->isNotEmpty()) {
+                $domain->tags()->syncWithoutDetaching(
+                    $attachNames
+                        ->map(fn (string $name): string => $tagIds[$name])
+                        ->all()
+                );
+            }
+
+            if ($detachNames->isNotEmpty()) {
+                $domain->tags()->detach(
+                    $detachNames
+                        ->map(fn (string $name): string => $tagIds[$name])
+                        ->all()
+                );
+            }
+        }
+
+        $this->table(
+            ['Domain', 'Property', 'Coverage', 'Desired tags', 'Reason'],
+            $rows
+        );
+
+        $this->table(
+            ['Metric', 'Value'],
+            [
+                ['properties_considered', (string) $properties->count()],
+                ['coverage_required', (string) $requiredCount],
+                ['coverage_complete', (string) $completeCount],
+                ['coverage_gaps', (string) $gapCount],
+                ['coverage_excluded', (string) $excludedCount],
+                ['domains_changed', (string) $domainsChanged],
+                ['dry_run', $dryRun ? 'true' : 'false'],
+            ]
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<int|string, array{name: string, priority: int, color: string|null, description: string|null}>  $tagDefinitions
+     * @return array<string, string>
+     */
+    private function ensureTags(array $tagDefinitions, bool $dryRun): array
+    {
+        $tagIds = [];
+
+        foreach ($tagDefinitions as $definition) {
+            $existingTag = DomainTag::withTrashed()->where('name', $definition['name'])->first();
+
+            if ($dryRun) {
+                $tagIds[$definition['name']] = $existingTag instanceof DomainTag ? $existingTag->id : $definition['name'];
+
+                continue;
+            }
+
+            $tag = $existingTag ?? new DomainTag(['name' => $definition['name']]);
+            $tag->fill([
+                'priority' => $definition['priority'],
+                'color' => $definition['color'],
+                'description' => $definition['description'],
+            ]);
+            $tag->save();
+
+            if ($tag->trashed()) {
+                $tag->restore();
+            }
+
+            $tagIds[$definition['name']] = $tag->id;
+        }
+
+        return $tagIds;
+    }
+
+    /**
+     * @param  array{
+     *   required: bool,
+     *   status: string
+     * }  $summary
+     * @param  array<int|string, array{name: string, priority: int, color: string|null, description: string|null}>  $tagDefinitions
+     * @return Collection<int, string>
+     */
+    private function desiredTagNames(array $summary, array $tagDefinitions): Collection
+    {
+        $requiredTag = $tagDefinitions['required'] ?? null;
+        $completeTag = $tagDefinitions['complete'] ?? null;
+        $gapTag = $tagDefinitions['gap'] ?? null;
+        $map = [
+            'required' => is_array($requiredTag) ? $requiredTag['name'] : '',
+            'complete' => is_array($completeTag) ? $completeTag['name'] : '',
+            'gap' => is_array($gapTag) ? $gapTag['name'] : '',
+        ];
+
+        if (! $summary['required']) {
+            return collect();
+        }
+
+        $tagNames = [$map['required']];
+
+        if ($summary['status'] === 'complete') {
+            $tagNames[] = $map['complete'];
+        } else {
+            $tagNames[] = $map['gap'];
+        }
+
+        /** @var array<int, string> $filteredTagNames */
+        $filteredTagNames = array_values(array_filter(
+            $tagNames,
+            fn (string $name): bool => $name !== ''
+        ));
+
+        return collect($filteredTagNames);
+    }
+
+    /**
+     * @return array{name: string, priority: int, color: string|null, description: string|null}|null
+     */
+    private function normalizeTagDefinition(mixed $tag): ?array
+    {
+        if (! is_array($tag) || ! is_string($tag['name'] ?? null)) {
+            return null;
+        }
+
+        return [
+            'name' => $tag['name'],
+            'priority' => (int) ($tag['priority'] ?? 0),
+            'color' => is_string($tag['color'] ?? null) ? $tag['color'] : null,
+            'description' => is_string($tag['description'] ?? null) ? $tag['description'] : null,
+        ];
+    }
+}

--- a/app/Console/Commands/SyncCoverageTags.php
+++ b/app/Console/Commands/SyncCoverageTags.php
@@ -57,10 +57,11 @@ class SyncCoverageTags extends Command
             ->map(fn (string $domain) => mb_strtolower(trim($domain)))
             ->values();
 
-        $tagDefinitionsArray = $tagDefinitions->all();
-        $tagIds = $this->ensureTags($tagDefinitionsArray, $dryRun);
-
         $properties = WebProperty::query()
+            ->when(
+                $targetDomains->isNotEmpty(),
+                fn ($query) => $query->whereHas('primaryDomain', fn ($domainQuery) => $domainQuery->whereIn('domain', $targetDomains->all()))
+            )
             ->with([
                 'primaryDomain.tags',
                 'primaryDomain.latestSeoBaseline',
@@ -69,17 +70,12 @@ class SyncCoverageTags extends Command
                 'analyticsSources.latestSearchConsoleCoverage',
                 'propertyDomains.domain',
             ])
+            ->orderBy('primary_domain_id')
             ->orderBy('name')
             ->get()
-            ->filter(function (WebProperty $property) use ($targetDomains): bool {
-                if ($targetDomains->isEmpty()) {
-                    return true;
-                }
-
-                $domainName = $property->primaryDomainName();
-
-                return is_string($domainName) && $targetDomains->contains(mb_strtolower($domainName));
-            })
+            ->groupBy(fn (WebProperty $property): string => (string) ($property->primary_domain_id ?? $property->id))
+            ->map(fn (Collection $group): ?WebProperty => $this->authoritativePropertyForPrimaryDomain($group))
+            ->filter()
             ->values();
 
         if ($properties->isEmpty()) {
@@ -88,6 +84,8 @@ class SyncCoverageTags extends Command
             return self::SUCCESS;
         }
 
+        $tagDefinitionsArray = $tagDefinitions->all();
+        $tagIds = $this->ensureTags($tagDefinitionsArray, $dryRun);
         $coverageTagNames = $managedTagDefinitions->pluck('name')->values();
 
         $rows = [];
@@ -268,6 +266,58 @@ class SyncCoverageTags extends Command
         ));
 
         return collect($filteredTagNames);
+    }
+
+    /**
+     * @param  Collection<int, WebProperty>  $properties
+     */
+    private function authoritativePropertyForPrimaryDomain(Collection $properties): ?WebProperty
+    {
+        $canonicalProperties = $properties->filter(
+            fn (WebProperty $property): bool => $this->isCanonicalForPrimaryDomain($property)
+        );
+
+        $candidates = $canonicalProperties->isNotEmpty() ? $canonicalProperties : $properties;
+
+        $controllerBackedCandidates = $candidates->filter(
+            fn (WebProperty $property): bool => $this->hasControllerPath($property)
+        );
+
+        if ($controllerBackedCandidates->isNotEmpty()) {
+            $candidates = $controllerBackedCandidates;
+        }
+
+        /** @var WebProperty|null $property */
+        $property = $candidates->sortBy('name')->first();
+
+        return $property;
+    }
+
+    private function isCanonicalForPrimaryDomain(WebProperty $property): bool
+    {
+        if (! $property->primary_domain_id) {
+            return false;
+        }
+
+        $links = $property->relationLoaded('propertyDomains')
+            ? $property->propertyDomains
+            : $property->propertyDomains()->get();
+
+        return $links->contains(
+            fn ($link): bool => (string) $link->domain_id === (string) $property->primary_domain_id
+                && (bool) $link->is_canonical
+        );
+    }
+
+    private function hasControllerPath(WebProperty $property): bool
+    {
+        $repositories = $property->relationLoaded('repositories')
+            ? $property->repositories
+            : $property->repositories()->get();
+
+        return $repositories->contains(
+            fn ($repository): bool => is_string($repository->local_path) && trim($repository->local_path) !== ''
+        );
     }
 
     /**

--- a/app/Livewire/AutomationCoverageQueue.php
+++ b/app/Livewire/AutomationCoverageQueue.php
@@ -12,6 +12,7 @@ class AutomationCoverageQueue extends Component
         $properties = WebProperty::query()
             ->with([
                 'primaryDomain',
+                'primaryDomain.tags',
                 'primaryDomain.latestSeoBaseline',
                 'repositories',
                 'analyticsSources',

--- a/app/Livewire/AutomationCoverageQueue.php
+++ b/app/Livewire/AutomationCoverageQueue.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\WebProperty;
+use Livewire\Component;
+
+class AutomationCoverageQueue extends Component
+{
+    public function render(): \Illuminate\View\View
+    {
+        $properties = WebProperty::query()
+            ->with([
+                'primaryDomain',
+                'primaryDomain.latestSeoBaseline',
+                'repositories',
+                'analyticsSources',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain.tags',
+            ])
+            ->orderBy('name')
+            ->get();
+
+        $queues = [
+            'needsController' => [],
+            'needsMatomoBinding' => [],
+            'needsSearchConsoleMapping' => [],
+            'needsOnboarding' => [],
+            'importStale' => [],
+            'needsBaselineSync' => [],
+            'manualCsvPending' => [],
+            'complete' => [],
+            'excluded' => [],
+        ];
+
+        foreach ($properties as $property) {
+            $automation = $property->automationCoverageSummary();
+            $primaryDomain = $property->primaryDomainModel();
+            $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+                ? $primaryDomain->latestSeoBaseline
+                : $primaryDomain?->latestSeoBaseline()->first();
+
+            $row = [
+                'property' => $property,
+                'automation' => $automation,
+                'primary_domain' => $property->primaryDomainName(),
+                'repository' => $property->repositories->first(),
+                'matomo_source' => $property->primaryAnalyticsSource('matomo'),
+                'search_console_coverage' => $property->primaryAnalyticsSource('matomo')?->latestSearchConsoleCoverage,
+                'latest_baseline' => $latestBaseline,
+            ];
+
+            match ($automation['status']) {
+                'needs_controller' => $queues['needsController'][] = $row,
+                'needs_matomo_binding' => $queues['needsMatomoBinding'][] = $row,
+                'needs_search_console_mapping' => $queues['needsSearchConsoleMapping'][] = $row,
+                'needs_onboarding' => $queues['needsOnboarding'][] = $row,
+                'import_stale' => $queues['importStale'][] = $row,
+                'needs_baseline_sync' => $queues['needsBaselineSync'][] = $row,
+                'manual_csv_pending' => $queues['manualCsvPending'][] = $row,
+                'complete' => $queues['complete'][] = $row,
+                default => $queues['excluded'][] = $row,
+            };
+        }
+
+        return view('livewire.automation-coverage-queue', [
+            'needsController' => collect($queues['needsController']),
+            'needsMatomoBinding' => collect($queues['needsMatomoBinding']),
+            'needsSearchConsoleMapping' => collect($queues['needsSearchConsoleMapping']),
+            'needsOnboarding' => collect($queues['needsOnboarding']),
+            'importStale' => collect($queues['importStale']),
+            'needsBaselineSync' => collect($queues['needsBaselineSync']),
+            'manualCsvPending' => collect($queues['manualCsvPending']),
+            'complete' => collect($queues['complete']),
+            'excluded' => collect($queues['excluded']),
+            'stats' => [
+                'required' => count($queues['needsController'])
+                    + count($queues['needsMatomoBinding'])
+                    + count($queues['needsSearchConsoleMapping'])
+                    + count($queues['needsOnboarding'])
+                    + count($queues['importStale'])
+                    + count($queues['needsBaselineSync'])
+                    + count($queues['manualCsvPending'])
+                    + count($queues['complete']),
+                'needs_controller' => count($queues['needsController']),
+                'needs_matomo_binding' => count($queues['needsMatomoBinding']),
+                'needs_search_console_mapping' => count($queues['needsSearchConsoleMapping']),
+                'needs_onboarding' => count($queues['needsOnboarding']),
+                'import_stale' => count($queues['importStale']),
+                'needs_baseline_sync' => count($queues['needsBaselineSync']),
+                'manual_csv_pending' => count($queues['manualCsvPending']),
+                'complete' => count($queues['complete']),
+                'excluded' => count($queues['excluded']),
+            ],
+        ]);
+    }
+}

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -351,10 +351,96 @@ class WebProperty extends Model
             'domains' => $this->domainSummaries(),
             'repositories' => $this->repositorySummaries(),
             'analytics_sources' => $this->analyticsSourceSummaries(),
+            'coverage_summary' => $this->fullCoverageSummary(),
+            'automation_summary' => $this->automationCoverageSummary(),
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{eligible: bool, reason: string|null}
+     */
+    public function coverageEligibility(): array
+    {
+        if ($this->status !== 'active') {
+            return ['eligible' => false, 'reason' => 'property is not active'];
+        }
+
+        if ($this->property_type === 'domain_asset') {
+            return ['eligible' => false, 'reason' => 'property is a domain asset'];
+        }
+
+        $domain = $this->primaryDomainModel();
+        if (! $domain instanceof Domain) {
+            return ['eligible' => false, 'reason' => 'no primary domain linked'];
+        }
+
+        $manualExclusionTagName = (string) config('domain_monitor.coverage_tags.manual_exclusion_tag.name', '');
+        if ($manualExclusionTagName !== '') {
+            $domainTags = $domain->relationLoaded('tags')
+                ? $domain->tags
+                : $domain->tags()->get();
+
+            if ($domainTags->contains(fn (DomainTag $tag): bool => $tag->name === $manualExclusionTagName)) {
+                return ['eligible' => false, 'reason' => 'primary domain is manually excluded from fleet coverage'];
+            }
+        }
+
+        if (! $domain->is_active) {
+            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
+        }
+
+        if ($domain->isParkedForHosting()) {
+            return ['eligible' => false, 'reason' => 'primary domain is parked'];
+        }
+
+        if ($domain->isEmailOnly()) {
+            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
+        }
+
+        return ['eligible' => true, 'reason' => null];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function repositoryCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $repositories = $this->relationLoaded('repositories')
+            ? $this->repositories
+            : $this->repositories()->get();
+
+        $primaryRepository = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
+            ->first();
+
+        if (! $primaryRepository instanceof PropertyRepository) {
+            return [
+                'status' => 'needs_repository',
+                'label' => 'Needs repository',
+                'reason' => 'eligible property has no linked repository/controller surface',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'primary repository %s is linked',
+                $primaryRepository->repo_name
+            ),
         ];
     }
 
@@ -375,32 +461,7 @@ class WebProperty extends Model
      */
     public function matomoEligibility(): array
     {
-        if ($this->status !== 'active') {
-            return ['eligible' => false, 'reason' => 'property is not active'];
-        }
-
-        if ($this->property_type === 'domain_asset') {
-            return ['eligible' => false, 'reason' => 'property is a domain asset'];
-        }
-
-        $domain = $this->primaryDomainModel();
-        if (! $domain instanceof Domain) {
-            return ['eligible' => false, 'reason' => 'no primary domain linked'];
-        }
-
-        if (! $domain->is_active) {
-            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
-        }
-
-        if ($domain->isParkedForHosting()) {
-            return ['eligible' => false, 'reason' => 'primary domain is parked'];
-        }
-
-        if ($domain->isEmailOnly()) {
-            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
-        }
-
-        return ['eligible' => true, 'reason' => null];
+        return $this->coverageEligibility();
     }
 
     /**
@@ -450,6 +511,375 @@ class WebProperty extends Model
             'status' => 'bound_attention',
             'label' => 'Needs attention',
             'reason' => $audit->summary,
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function searchConsoleCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $matomoSource = $this->primaryAnalyticsSource('matomo');
+        if (! $matomoSource instanceof PropertyAnalyticsSource) {
+            return [
+                'status' => 'needs_matomo',
+                'label' => 'Needs Matomo',
+                'reason' => 'Search Console coverage depends on a primary Matomo binding',
+            ];
+        }
+
+        $coverage = $matomoSource->relationLoaded('latestSearchConsoleCoverage')
+            ? $matomoSource->latestSearchConsoleCoverage
+            : $matomoSource->latestSearchConsoleCoverage()->first();
+
+        if (! $coverage instanceof SearchConsoleCoverageStatus || $coverage->mapping_state === 'not_mapped') {
+            return [
+                'status' => 'needs_property',
+                'label' => 'Needs Search Console',
+                'reason' => 'Matomo is linked but no Search Console property is mapped yet',
+            ];
+        }
+
+        if ($coverage->freshnessState() === 'never_imported') {
+            return [
+                'status' => 'needs_import',
+                'label' => 'Needs import',
+                'reason' => 'Search Console property is mapped but no data has been imported yet',
+            ];
+        }
+
+        if ($coverage->freshnessState() === 'stale') {
+            return [
+                'status' => 'stale_import',
+                'label' => 'Import stale',
+                'reason' => 'Search Console coverage import is stale',
+            ];
+        }
+
+        if ($coverage->mapping_state === 'url_prefix') {
+            return [
+                'status' => 'url_prefix_only',
+                'label' => 'URL prefix only',
+                'reason' => 'Search Console is mapped as a URL prefix instead of a domain property',
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'needs_baseline',
+                'label' => 'Needs baseline',
+                'reason' => 'Search Console is mapped but no SEO baseline has been imported yet',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'domain property is mapped and fresh for %s',
+                $coverage->property_uri ?? $primaryDomain->domain ?? $this->slug
+            ),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   required: bool,
+     *   status: string,
+     *   label: string,
+     *   reason: string|null,
+     *   reasons: array<int, string>,
+     *   checks: array<string, array{status: string, label: string, reason: string|null}>
+     * }
+     */
+    public function fullCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        $checks = [
+            'repository' => $this->repositoryCoverageSummary(),
+            'matomo' => $this->matomoCoverageSummary(),
+            'search_console' => $this->searchConsoleCoverageSummary(),
+        ];
+
+        if (! $eligibility['eligible']) {
+            return [
+                'required' => false,
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+                'reasons' => array_filter([$eligibility['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $gapReasons = collect($checks)
+            ->reject(fn (array $check): bool => $check['status'] === 'covered')
+            ->pluck('reason')
+            ->filter(fn ($reason): bool => is_string($reason) && $reason !== '')
+            ->values()
+            ->all();
+
+        if ($gapReasons === []) {
+            return [
+                'required' => true,
+                'status' => 'complete',
+                'label' => 'Complete',
+                'reason' => 'repository, Matomo, and Search Console coverage are all in place',
+                'reasons' => [],
+                'checks' => $checks,
+            ];
+        }
+
+        return [
+            'required' => true,
+            'status' => 'gap',
+            'label' => 'Gap',
+            'reason' => $gapReasons[0],
+            'reasons' => $gapReasons,
+            'checks' => $checks,
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function baselineSyncSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $searchConsole = $this->searchConsoleCoverageSummary();
+        if ($searchConsole['status'] !== 'covered') {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => $searchConsole['reason'],
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'needs_sync',
+                'label' => 'Needs baseline sync',
+                'reason' => 'Search Console data is ready, but no Domain Monitor SEO baseline has been synced yet',
+            ];
+        }
+
+        if ($latestBaseline->captured_at->lt(now()->subDays(30))) {
+            return [
+                'status' => 'stale',
+                'label' => 'Baseline stale',
+                'reason' => 'The latest Domain Monitor SEO baseline is older than 30 days',
+            ];
+        }
+
+        return [
+            'status' => 'covered',
+            'label' => 'Covered',
+            'reason' => sprintf(
+                'latest SEO baseline captured %s',
+                $latestBaseline->captured_at->toDateString()
+            ),
+        ];
+    }
+
+    /**
+     * @return array{status: string, label: string, reason: string|null}
+     */
+    public function manualCsvCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        if (! $eligibility['eligible']) {
+            return [
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+            ];
+        }
+
+        $baseline = $this->baselineSyncSummary();
+        if ($baseline['status'] !== 'covered') {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => $baseline['reason'],
+            ];
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
+            ? $primaryDomain->latestSeoBaseline
+            : $primaryDomain?->latestSeoBaseline()->first();
+
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            return [
+                'status' => 'blocked',
+                'label' => 'Blocked',
+                'reason' => 'No SEO baseline is available yet',
+            ];
+        }
+
+        if ($latestBaseline->import_method === 'matomo_plus_manual_csv') {
+            return [
+                'status' => 'covered',
+                'label' => 'Covered',
+                'reason' => 'Manual Search Console CSV evidence has been imported',
+            ];
+        }
+
+        return [
+            'status' => 'pending',
+            'label' => 'Manual CSV pending',
+            'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
+        ];
+    }
+
+    /**
+     * @return array{
+     *   required: bool,
+     *   status: string,
+     *   label: string,
+     *   reason: string|null,
+     *   reasons: array<int, string>,
+     *   checks: array<string, array{status: string, label: string, reason: string|null}>
+     * }
+     */
+    public function automationCoverageSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        $checks = [
+            'repository' => $this->repositoryCoverageSummary(),
+            'matomo' => $this->matomoCoverageSummary(),
+            'search_console' => $this->searchConsoleCoverageSummary(),
+            'baseline_sync' => $this->baselineSyncSummary(),
+            'manual_csv' => $this->manualCsvCoverageSummary(),
+        ];
+
+        if (! $eligibility['eligible']) {
+            return [
+                'required' => false,
+                'status' => 'excluded',
+                'label' => 'Excluded',
+                'reason' => $eligibility['reason'],
+                'reasons' => array_filter([$eligibility['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $repository = $checks['repository'];
+        if ($repository['status'] !== 'covered') {
+            return [
+                'required' => true,
+                'status' => 'needs_controller',
+                'label' => 'Needs controller',
+                'reason' => $repository['reason'],
+                'reasons' => array_filter([$repository['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $matomo = $checks['matomo'];
+        if ($matomo['status'] !== 'covered') {
+            return [
+                'required' => true,
+                'status' => 'needs_matomo_binding',
+                'label' => 'Needs Matomo',
+                'reason' => $matomo['reason'],
+                'reasons' => array_filter([$matomo['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $searchConsole = $checks['search_console'];
+        if (in_array($searchConsole['status'], ['needs_matomo', 'needs_property', 'url_prefix_only'], true)) {
+            return [
+                'required' => true,
+                'status' => 'needs_search_console_mapping',
+                'label' => 'Needs Search Console',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        if ($searchConsole['status'] === 'needs_import') {
+            return [
+                'required' => true,
+                'status' => 'needs_onboarding',
+                'label' => 'Needs onboarding',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        if ($searchConsole['status'] === 'stale_import') {
+            return [
+                'required' => true,
+                'status' => 'import_stale',
+                'label' => 'Import stale',
+                'reason' => $searchConsole['reason'],
+                'reasons' => array_filter([$searchConsole['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $baseline = $checks['baseline_sync'];
+        if (in_array($baseline['status'], ['needs_sync', 'stale'], true)) {
+            return [
+                'required' => true,
+                'status' => 'needs_baseline_sync',
+                'label' => 'Needs baseline sync',
+                'reason' => $baseline['reason'],
+                'reasons' => array_filter([$baseline['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        $manualCsv = $checks['manual_csv'];
+        if ($manualCsv['status'] === 'pending') {
+            return [
+                'required' => true,
+                'status' => 'manual_csv_pending',
+                'label' => 'Manual CSV pending',
+                'reason' => $manualCsv['reason'],
+                'reasons' => array_filter([$manualCsv['reason']]),
+                'checks' => $checks,
+            ];
+        }
+
+        return [
+            'required' => true,
+            'status' => 'complete',
+            'label' => 'Complete',
+            'reason' => 'All automatic coverage checks are in place and only optional manual evidence remains complete',
+            'reasons' => [],
+            'checks' => $checks,
         ];
     }
 

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -573,25 +573,12 @@ class WebProperty extends Model
             ];
         }
 
-        $primaryDomain = $this->primaryDomainModel();
-        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
-            ? $primaryDomain->latestSeoBaseline
-            : $primaryDomain?->latestSeoBaseline()->first();
-
-        if (! $latestBaseline instanceof DomainSeoBaseline) {
-            return [
-                'status' => 'needs_baseline',
-                'label' => 'Needs baseline',
-                'reason' => 'Search Console is mapped but no SEO baseline has been imported yet',
-            ];
-        }
-
         return [
             'status' => 'covered',
             'label' => 'Covered',
             'reason' => sprintf(
                 'domain property is mapped and fresh for %s',
-                $coverage->property_uri ?? $primaryDomain->domain ?? $this->slug
+                $coverage->property_uri ?? $this->primaryDomainName() ?? $this->slug
             ),
         ];
     }

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -351,8 +351,6 @@ class WebProperty extends Model
             'domains' => $this->domainSummaries(),
             'repositories' => $this->repositorySummaries(),
             'analytics_sources' => $this->analyticsSourceSummaries(),
-            'coverage_summary' => $this->fullCoverageSummary(),
-            'automation_summary' => $this->automationCoverageSummary(),
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
@@ -461,7 +459,32 @@ class WebProperty extends Model
      */
     public function matomoEligibility(): array
     {
-        return $this->coverageEligibility();
+        if ($this->status !== 'active') {
+            return ['eligible' => false, 'reason' => 'property is not active'];
+        }
+
+        if ($this->property_type === 'domain_asset') {
+            return ['eligible' => false, 'reason' => 'property is a domain asset'];
+        }
+
+        $domain = $this->primaryDomainModel();
+        if (! $domain instanceof Domain) {
+            return ['eligible' => false, 'reason' => 'no primary domain linked'];
+        }
+
+        if (! $domain->is_active) {
+            return ['eligible' => false, 'reason' => 'primary domain is inactive'];
+        }
+
+        if ($domain->isParkedForHosting()) {
+            return ['eligible' => false, 'reason' => 'primary domain is parked'];
+        }
+
+        if ($domain->isEmailOnly()) {
+            return ['eligible' => false, 'reason' => 'primary domain is email-only'];
+        }
+
+        return ['eligible' => true, 'reason' => null];
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -57,7 +57,7 @@ class DashboardIssueQueueService
 
         return [
             'source_system' => 'domain-monitor-priority-queue',
-            'contract_version' => 1,
+            'contract_version' => 2,
             'generated_at' => now()->toIso8601String(),
             'recent_failures_hours' => $recentFailuresHours,
             'stats' => $stats,
@@ -82,16 +82,20 @@ class DashboardIssueQueueService
             }
 
             $property = $this->primaryProperty($domain);
-            [$mustFixReasons, $shouldFixReasons] = $this->issueReasonsForDomain($domain, $property);
+            $coverageStatus = $this->controlCoverageStatus($domain, $property);
+            [$mustFixReasons, $shouldFixReasons] = $this->issueReasonsForDomain(
+                $domain,
+                $this->controlCoverageReasonForStatus($coverageStatus)
+            );
 
             if ($mustFixReasons !== []) {
-                $mustFixDomains->push($this->makeQueueItem($domain, $property, $mustFixReasons, $shouldFixReasons));
+                $mustFixDomains->push($this->makeQueueItem($domain, $property, $coverageStatus, $mustFixReasons, $shouldFixReasons));
 
                 continue;
             }
 
             if ($shouldFixReasons !== []) {
-                $shouldFixDomains->push($this->makeQueueItem($domain, $property, $shouldFixReasons));
+                $shouldFixDomains->push($this->makeQueueItem($domain, $property, $coverageStatus, $shouldFixReasons));
             }
         }
 
@@ -108,7 +112,7 @@ class DashboardIssueQueueService
     /**
      * @return array{0: array<int, string>, 1: array<int, string>}
      */
-    private function issueReasonsForDomain(Domain $domain, ?WebProperty $property): array
+    private function issueReasonsForDomain(Domain $domain, ?string $coverageReason): array
     {
         $mustFix = [];
         $shouldFix = [];
@@ -148,8 +152,6 @@ class DashboardIssueQueueService
             $daysUntilExpiry = max(0, now()->startOfDay()->diffInDays($domain->expires_at->copy()->startOfDay(), false));
             $shouldFix[] = "Domain expires in {$daysUntilExpiry} days";
         }
-
-        $coverageReason = $this->controlCoverageReason($domain, $property);
 
         if ($coverageReason !== null) {
             $shouldFix[] = $coverageReason;
@@ -194,10 +196,13 @@ class DashboardIssueQueueService
      * @param  array<int, string>  $secondaryReasons
      * @return array<string, mixed>
      */
-    private function makeQueueItem(Domain $domain, ?WebProperty $property, array $primaryReasons, array $secondaryReasons = []): array
-    {
-        $coverageStatus = $this->controlCoverageStatus($domain, $property);
-
+    private function makeQueueItem(
+        Domain $domain,
+        ?WebProperty $property,
+        string $coverageStatus,
+        array $primaryReasons,
+        array $secondaryReasons = []
+    ): array {
         return $this->enrichQueueItem($domain, $property, [
             'id' => $domain->id,
             'domain' => $domain->domain,
@@ -280,9 +285,11 @@ class DashboardIssueQueueService
 
     private function primaryProperty(Domain $domain): ?WebProperty
     {
+        $canonicalProperties = $domain->webProperties
+            ->filter(fn (WebProperty $entry): bool => (bool) data_get($entry, 'pivot.is_canonical', false));
+
         /** @var WebProperty|null $property */
-        $property = $domain->webProperties
-            ->sortByDesc(fn (WebProperty $entry): int => (bool) data_get($entry, 'pivot.is_canonical', false) ? 1 : 0)
+        $property = ($canonicalProperties->isNotEmpty() ? $canonicalProperties : $domain->webProperties)
             ->sortBy('name')
             ->first();
 
@@ -382,9 +389,9 @@ class DashboardIssueQueueService
         return $hasControllerPath ? 'controlled' : 'missing_local_path';
     }
 
-    private function controlCoverageReason(Domain $domain, ?WebProperty $property): ?string
+    private function controlCoverageReasonForStatus(string $coverageStatus): ?string
     {
-        return match ($this->controlCoverageStatus($domain, $property)) {
+        return match ($coverageStatus) {
             'missing_property' => 'Public site is not linked to a web property',
             'missing_repository' => 'Fleet controller access is missing',
             'missing_local_path' => 'Fleet controller path is missing',

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -4,6 +4,8 @@ namespace App\Services;
 
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\WebProperty;
+use App\Models\WebsitePlatform;
 use Illuminate\Support\Collection;
 
 class DashboardIssueQueueService
@@ -32,7 +34,11 @@ class DashboardIssueQueueService
 
         $domains = Domain::query()
             ->where('is_active', true)
-            ->with(['platform', 'webProperties:id,slug,name'])
+            ->with([
+                'platform',
+                'webProperties:id,slug,name,property_type,status',
+                'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+            ])
             ->withLatestCheckStatuses()
             ->withCount([
                 'alerts as open_critical_alerts_count' => fn ($query) => $query
@@ -57,6 +63,7 @@ class DashboardIssueQueueService
             'stats' => $stats,
             'must_fix' => $mustFixDomains->all(),
             'should_fix' => $shouldFixDomains->all(),
+            'derived' => $this->buildDerivedSummary($mustFixDomains, $shouldFixDomains),
         ];
     }
 
@@ -74,16 +81,17 @@ class DashboardIssueQueueService
                 continue;
             }
 
-            [$mustFixReasons, $shouldFixReasons] = $this->issueReasonsForDomain($domain);
+            $property = $this->primaryProperty($domain);
+            [$mustFixReasons, $shouldFixReasons] = $this->issueReasonsForDomain($domain, $property);
 
             if ($mustFixReasons !== []) {
-                $mustFixDomains->push($this->makeQueueItem($domain, $mustFixReasons, $shouldFixReasons));
+                $mustFixDomains->push($this->makeQueueItem($domain, $property, $mustFixReasons, $shouldFixReasons));
 
                 continue;
             }
 
             if ($shouldFixReasons !== []) {
-                $shouldFixDomains->push($this->makeQueueItem($domain, $shouldFixReasons));
+                $shouldFixDomains->push($this->makeQueueItem($domain, $property, $shouldFixReasons));
             }
         }
 
@@ -100,7 +108,7 @@ class DashboardIssueQueueService
     /**
      * @return array{0: array<int, string>, 1: array<int, string>}
      */
-    private function issueReasonsForDomain(Domain $domain): array
+    private function issueReasonsForDomain(Domain $domain, ?WebProperty $property): array
     {
         $mustFix = [];
         $shouldFix = [];
@@ -139,6 +147,12 @@ class DashboardIssueQueueService
         if ($domain->expires_at && $domain->expires_at->isFuture() && $domain->expires_at->lte(now()->addDays(30)->endOfDay())) {
             $daysUntilExpiry = max(0, now()->startOfDay()->diffInDays($domain->expires_at->copy()->startOfDay(), false));
             $shouldFix[] = "Domain expires in {$daysUntilExpiry} days";
+        }
+
+        $coverageReason = $this->controlCoverageReason($domain, $property);
+
+        if ($coverageReason !== null) {
+            $shouldFix[] = $coverageReason;
         }
 
         return [
@@ -180,16 +194,16 @@ class DashboardIssueQueueService
      * @param  array<int, string>  $secondaryReasons
      * @return array<string, mixed>
      */
-    private function makeQueueItem(Domain $domain, array $primaryReasons, array $secondaryReasons = []): array
+    private function makeQueueItem(Domain $domain, ?WebProperty $property, array $primaryReasons, array $secondaryReasons = []): array
     {
-        $property = $domain->webProperties->sortBy('name')->first();
+        $coverageStatus = $this->controlCoverageStatus($domain, $property);
 
-        return [
+        return $this->enrichQueueItem($domain, $property, [
             'id' => $domain->id,
             'domain' => $domain->domain,
             'web_property_slug' => $property?->slug,
             'web_property_name' => $property?->name,
-            'platform' => $domain->platform,
+            'platform' => $this->domainPlatform($domain),
             'hosting_provider' => $domain->hosting_provider,
             'is_email_only' => $domain->isEmailOnly(),
             'is_parked' => $domain->isParkedForHosting(),
@@ -197,9 +211,12 @@ class DashboardIssueQueueService
             'secondary_reasons' => $secondaryReasons,
             'primary_reason_count' => count($primaryReasons),
             'secondary_reason_count' => count($secondaryReasons),
+            'coverage_required' => $this->requiresControlCoverage($domain, $property),
+            'coverage_status' => $coverageStatus,
+            'coverage_gap' => in_array($coverageStatus, ['missing_property', 'missing_repository', 'missing_local_path'], true),
             'updated_at_human' => $domain->updated_at?->diffForHumans(),
             'updated_at_iso' => $domain->updated_at?->toIso8601String() ?? now()->toIso8601String(),
-        ];
+        ]);
     }
 
     private function formatAlertReason(int $count, string $label): string
@@ -207,5 +224,317 @@ class DashboardIssueQueueService
         $suffix = $count === 1 ? 'alert' : 'alerts';
 
         return "{$count} {$label} {$suffix}";
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $mustFixDomains
+     * @param  Collection<int, array<string, mixed>>  $shouldFixDomains
+     * @return array<string, mixed>
+     */
+    private function buildDerivedSummary(Collection $mustFixDomains, Collection $shouldFixDomains): array
+    {
+        $issueFamilyCounts = [];
+        $controlCounts = [];
+        $platformProfileCounts = [];
+        $standardGapCandidates = 0;
+        $coverageGapCandidates = 0;
+
+        foreach ($mustFixDomains->concat($shouldFixDomains) as $item) {
+            $issueFamily = is_string($item['issue_family'] ?? null) ? $item['issue_family'] : null;
+            $controlId = is_string($item['control_id'] ?? null) ? $item['control_id'] : null;
+            $platformProfile = is_string($item['platform_profile'] ?? null) ? $item['platform_profile'] : null;
+
+            if (($item['is_standard_gap'] ?? false) === true) {
+                $standardGapCandidates++;
+            }
+
+            if (($item['coverage_gap'] ?? false) === true) {
+                $coverageGapCandidates++;
+            }
+
+            $this->incrementCount($issueFamilyCounts, $issueFamily);
+            $this->incrementCount($controlCounts, $controlId);
+            $this->incrementCount($platformProfileCounts, $platformProfile);
+        }
+
+        return [
+            'standard_gap_candidates' => $standardGapCandidates,
+            'coverage_gap_candidates' => $coverageGapCandidates,
+            'issue_family_counts' => $issueFamilyCounts,
+            'control_counts' => $controlCounts,
+            'platform_profile_counts' => $platformProfileCounts,
+        ];
+    }
+
+    /**
+     * @param  array<string, int>  $counts
+     */
+    private function incrementCount(array &$counts, ?string $key): void
+    {
+        if (! is_string($key) || $key === '') {
+            return;
+        }
+
+        $counts[$key] = ($counts[$key] ?? 0) + 1;
+    }
+
+    private function primaryProperty(Domain $domain): ?WebProperty
+    {
+        /** @var WebProperty|null $property */
+        $property = $domain->webProperties
+            ->sortByDesc(fn (WebProperty $entry): int => (bool) data_get($entry, 'pivot.is_canonical', false) ? 1 : 0)
+            ->sortBy('name')
+            ->first();
+
+        return $property;
+    }
+
+    private function domainPlatform(Domain $domain): ?string
+    {
+        $platformRelation = $domain->relationLoaded('platform') ? $domain->getRelation('platform') : null;
+
+        if ($platformRelation instanceof WebsitePlatform && is_string($platformRelation->platform_type) && $platformRelation->platform_type !== '') {
+            return $platformRelation->platform_type;
+        }
+
+        return $domain->platform;
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function enrichQueueItem(Domain $domain, ?WebProperty $property, array $item): array
+    {
+        $standards = config('domain_monitor.priority_queue_standards', []);
+        $issueFamilies = $this->deriveIssueFamilies($domain);
+        if (($item['coverage_gap'] ?? false) === true) {
+            $issueFamilies[] = 'control.coverage_required';
+        }
+        $issueFamily = $issueFamilies[0] ?? null;
+        $controlId = $this->controlIdForIssueFamilies($issueFamilies, is_array($standards) ? $standards : []);
+        $hostProfile = $this->deriveHostProfile($domain);
+        $platformProfile = $this->derivePlatformProfile($domain, $hostProfile);
+        $controlProfile = $this->deriveControlProfile($property, $platformProfile);
+        $controlConfig = is_string($controlId) && isset($standards['controls'][$controlId]) && is_array($standards['controls'][$controlId])
+            ? $standards['controls'][$controlId]
+            : [];
+        $defaultBaselineSurface = is_string(data_get($standards, 'platform_profiles.'.$platformProfile.'.baseline_surface'))
+            ? data_get($standards, 'platform_profiles.'.$platformProfile.'.baseline_surface')
+            : null;
+        $configuredRolloutScope = is_string($controlConfig['rollout_scope'] ?? null)
+            ? $controlConfig['rollout_scope']
+            : null;
+        $rolloutScope = $configuredRolloutScope
+            ?? (($controlId && $defaultBaselineSurface) ? 'fleet' : 'domain_only');
+        $baselineSurface = $rolloutScope === 'fleet' ? $defaultBaselineSurface : null;
+
+        $item['issue_family'] = $issueFamily;
+        $item['issue_families'] = $issueFamilies;
+        $item['control_id'] = $controlId;
+        $item['platform_profile'] = $platformProfile;
+        $item['host_profile'] = $hostProfile;
+        $item['control_profile'] = $controlProfile;
+        $item['baseline_surface'] = $baselineSurface;
+        $item['property_match_confidence'] = $property ? 'high' : 'none';
+        $item['rollout_scope'] = $rolloutScope;
+        $item['is_standard_gap'] = $rolloutScope === 'fleet';
+
+        return $item;
+    }
+
+    private function requiresControlCoverage(Domain $domain, ?WebProperty $property): bool
+    {
+        if ($domain->isParkedForHosting() || $domain->isEmailOnly()) {
+            return false;
+        }
+
+        if ($property === null) {
+            return true;
+        }
+
+        return $property->status === 'active'
+            && in_array($property->property_type, ['marketing_site', 'website', 'app'], true);
+    }
+
+    private function controlCoverageStatus(Domain $domain, ?WebProperty $property): string
+    {
+        if (! $this->requiresControlCoverage($domain, $property)) {
+            return 'not_required';
+        }
+
+        if ($property === null) {
+            return 'missing_property';
+        }
+
+        $repositories = $property->relationLoaded('repositories')
+            ? $property->getRelation('repositories')
+            : $property->repositories()->get();
+
+        if ($repositories->isEmpty()) {
+            return 'missing_repository';
+        }
+
+        $hasControllerPath = $repositories->contains(
+            fn ($repository): bool => is_string($repository->local_path) && trim($repository->local_path) !== ''
+        );
+
+        return $hasControllerPath ? 'controlled' : 'missing_local_path';
+    }
+
+    private function controlCoverageReason(Domain $domain, ?WebProperty $property): ?string
+    {
+        return match ($this->controlCoverageStatus($domain, $property)) {
+            'missing_property' => 'Public site is not linked to a web property',
+            'missing_repository' => 'Fleet controller access is missing',
+            'missing_local_path' => 'Fleet controller path is missing',
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function deriveIssueFamilies(Domain $domain): array
+    {
+        $families = [];
+
+        if ((int) ($domain->open_critical_alerts_count ?? 0) > 0 || (int) ($domain->open_warning_alerts_count ?? 0) > 0) {
+            $families[] = 'alerts.open';
+        }
+
+        if ($domain->eligibility_valid === false) {
+            $families[] = 'domain.eligibility';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'uptime')) {
+            $families[] = 'health.uptime';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'http')) {
+            $families[] = 'health.http';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'ssl')) {
+            $families[] = 'transport.tls';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'dns')) {
+            $families[] = 'dns.health';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'email_security')) {
+            $families[] = 'email.security_baseline';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'security_headers')) {
+            $families[] = 'security.headers_baseline';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'seo')) {
+            $families[] = 'seo.fundamentals';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'reputation')) {
+            $families[] = 'reputation.health';
+        }
+
+        if ($this->matchesCheckStatus($domain, 'broken_links')) {
+            $families[] = 'seo.broken_links';
+        }
+
+        if ($domain->expires_at && $domain->expires_at->isFuture() && $domain->expires_at->lte(now()->addDays(30)->endOfDay())) {
+            $families[] = 'domain.expiry';
+        }
+
+        return array_values(array_unique($families));
+    }
+
+    private function matchesCheckStatus(Domain $domain, string $checkType): bool
+    {
+        $status = $domain->{'latest_'.$checkType.'_status'} ?? null;
+
+        return is_string($status) && in_array($status, ['warn', 'fail'], true);
+    }
+
+    /**
+     * @param  array<int, string>  $issueFamilies
+     * @param  array<string, mixed>  $standards
+     */
+    private function controlIdForIssueFamilies(array $issueFamilies, array $standards): ?string
+    {
+        $controls = data_get($standards, 'controls', []);
+
+        if (! is_array($controls)) {
+            return null;
+        }
+
+        foreach ($issueFamilies as $family) {
+            foreach ($controls as $controlId => $controlConfig) {
+                $mappedFamilies = data_get($controlConfig, 'issue_families', []);
+
+                if (is_array($mappedFamilies) && in_array($family, $mappedFamilies, true)) {
+                    return is_string($controlId) ? $controlId : null;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function deriveHostProfile(Domain $domain): string
+    {
+        $combined = strtolower(trim(implode(' ', array_filter([
+            $domain->hosting_provider,
+            $this->domainPlatform($domain),
+        ]))));
+
+        if (str_contains($combined, 'vercel')) {
+            return 'vercel_astro';
+        }
+
+        if (str_contains($combined, 'cloudflare')) {
+            return 'cloudflare_static';
+        }
+
+        if (str_contains($combined, 'synergy wholesale') || str_contains($combined, 'litespeed') || str_contains($combined, 'ventra')) {
+            return 'ventra_litespeed_wordpress';
+        }
+
+        return 'unknown_hosting';
+    }
+
+    private function derivePlatformProfile(Domain $domain, string $hostProfile): string
+    {
+        $platform = strtolower((string) ($this->domainPlatform($domain) ?? ''));
+
+        if (str_contains($platform, 'astro') || $hostProfile === 'vercel_astro') {
+            return 'astro_marketing_managed';
+        }
+
+        if (str_contains($platform, 'wordpress')) {
+            return $hostProfile === 'ventra_litespeed_wordpress'
+                ? 'wordpress_house_managed'
+                : 'wordpress_legacy_unmanaged';
+        }
+
+        return 'external_static_unmanaged';
+    }
+
+    private function deriveControlProfile(?WebProperty $property, string $platformProfile): ?string
+    {
+        if ($platformProfile === 'astro_marketing_managed') {
+            return 'astro_core';
+        }
+
+        if (in_array($platformProfile, ['wordpress_house_managed', 'wordpress_legacy_unmanaged'], true)) {
+            return 'leadgen_wordpress_core';
+        }
+
+        if ($property && in_array($property->property_type, ['marketing_site', 'website', 'app'], true)) {
+            return 'marketing_site_core';
+        }
+
+        return null;
     }
 }

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -118,6 +118,11 @@ return [
                 'slug' => 'discountbackloading-com-au',
                 'name' => 'discountbackloading.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -131,6 +136,11 @@ return [
                 'slug' => 'backloading-au-com-au',
                 'name' => 'backloading-au.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -144,6 +154,11 @@ return [
                 'slug' => 'backloadingremovals-com-au',
                 'name' => 'backloadingremovals.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -157,6 +172,11 @@ return [
                 'slug' => 'interstatecarcarriers-com-au',
                 'name' => 'interstatecarcarriers.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -170,6 +190,11 @@ return [
                 'slug' => 'mover-com-au',
                 'name' => 'mover.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -183,6 +208,11 @@ return [
                 'slug' => 'perthinterstateremovalists-com-au',
                 'name' => 'perthinterstateremovalists.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -196,6 +226,11 @@ return [
                 'slug' => 'interstate-car-transport-com-au',
                 'name' => 'interstate-car-transport.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -209,6 +244,11 @@ return [
                 'slug' => 'wemove-com-au',
                 'name' => 'wemove.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -222,6 +262,11 @@ return [
                 'slug' => 'backloading-services-com-au',
                 'name' => 'backloading-services.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -249,6 +294,11 @@ return [
                 'slug' => 'interstate-removals-com-au',
                 'name' => 'interstate-removals.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -258,10 +308,25 @@ return [
                     ],
                 ],
             ],
+            'beauy.com.au' => [
+                'slug' => 'beauy-com-au',
+                'name' => 'beauy.com.au',
+                'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
+            ],
             'removalsinterstate.com.au' => [
                 'slug' => 'removalsinterstate-com-au',
                 'name' => 'removalsinterstate.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -275,6 +340,11 @@ return [
                 'slug' => 'allianceremovals-com-au',
                 'name' => 'allianceremovals.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -288,6 +358,11 @@ return [
                 'slug' => 'movemycar-com-au',
                 'name' => 'movemycar.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -301,6 +376,11 @@ return [
                 'slug' => 'supercheapcartransport-com-au',
                 'name' => 'supercheapcartransport.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -314,6 +394,11 @@ return [
                 'slug' => 'cartransportaus-com-au',
                 'name' => 'cartransportaus.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => '_wp-house',
+                    'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+                    'framework' => 'WordPress',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -400,6 +485,11 @@ return [
                 'slug' => 'transportnondrivablecars-com-au',
                 'name' => 'transportnondrivablecars.com.au',
                 'property_type' => 'website',
+                'repository' => [
+                    'repo_name' => 'transportnondrivablecars-com-au-php',
+                    'local_path' => '/Users/jasonhill/Projects/websites/transportnondrivablecars-com-au-php',
+                    'framework' => 'Custom PHP',
+                ],
                 'analytics_sources' => [
                     [
                         'provider' => 'matomo',
@@ -408,6 +498,106 @@ return [
                         'workspace_path' => '/Users/jasonhill/Projects/2026 Projects/Matamo ',
                     ],
                 ],
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Priority Queue Standards
+    |--------------------------------------------------------------------------
+    |
+    | The dashboard queue should start to describe recurring issue families
+    | and which managed platform baselines they belong to. Keep this narrow
+    | and operationally useful: enough to identify fleet-standard gaps without
+    | pretending every incident is fully auto-classified.
+    |
+    */
+    'priority_queue_standards' => [
+        'platform_profiles' => [
+            'wordpress_house_managed' => [
+                'baseline_surface' => 'shared_wordpress_house_and_live_host_config',
+            ],
+            'astro_marketing_managed' => [
+                'baseline_surface' => 'shared_astro_repo_conventions_and_host_config',
+            ],
+        ],
+        'controls' => [
+            'transport.uptime_health' => [
+                'issue_families' => ['health.uptime'],
+            ],
+            'transport.http_health' => [
+                'issue_families' => ['health.http'],
+            ],
+            'transport.tls' => [
+                'issue_families' => ['transport.tls'],
+            ],
+            'dns.health' => [
+                'issue_families' => ['dns.health'],
+            ],
+            'email.security_baseline' => [
+                'issue_families' => ['email.security_baseline'],
+            ],
+            'security.headers_baseline' => [
+                'issue_families' => ['security.headers_baseline'],
+            ],
+            'seo.fundamentals' => [
+                'issue_families' => ['seo.fundamentals'],
+            ],
+            'seo.broken_links' => [
+                'issue_families' => ['seo.broken_links'],
+            ],
+            'reputation.health' => [
+                'issue_families' => ['reputation.health'],
+            ],
+            'domain.eligibility' => [
+                'issue_families' => ['domain.eligibility'],
+            ],
+            'domain.expiry' => [
+                'issue_families' => ['domain.expiry'],
+            ],
+            'control.website_fleet_coverage' => [
+                'issue_families' => ['control.coverage_required'],
+                'rollout_scope' => 'domain_only',
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Coverage Tags
+    |--------------------------------------------------------------------------
+    |
+    | These tags mark which primary domains belong to the fully managed
+    | website fleet, and whether repo/controller, Matomo, and Search Console
+    | coverage are complete or still have gaps.
+    |
+    */
+    'coverage_tags' => [
+        'manual_exclusion_tag' => [
+            'name' => 'coverage.excluded',
+            'priority' => 95,
+            'color' => '#6b7280',
+            'description' => 'This domain is intentionally excluded from the managed fleet coverage baseline.',
+        ],
+        'tags' => [
+            'required' => [
+                'name' => 'coverage.required',
+                'priority' => 90,
+                'color' => '#2563eb',
+                'description' => 'This domain is in the managed website fleet and should have repository, Matomo, and Search Console coverage.',
+            ],
+            'complete' => [
+                'name' => 'coverage.complete',
+                'priority' => 80,
+                'color' => '#16a34a',
+                'description' => 'This managed domain currently has repository, Matomo, and Search Console coverage in place.',
+            ],
+            'gap' => [
+                'name' => 'coverage.gap',
+                'priority' => 85,
+                'color' => '#dc2626',
+                'description' => 'This managed domain should be fully covered, but one or more coverage controls still need attention.',
             ],
         ],
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,9 +561,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-            "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+            "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
             "cpu": [
                 "arm"
             ],
@@ -575,9 +575,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-            "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+            "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
             "cpu": [
                 "arm64"
             ],
@@ -589,9 +589,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-            "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+            "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
             "cpu": [
                 "arm64"
             ],
@@ -603,9 +603,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-            "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+            "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
             "cpu": [
                 "x64"
             ],
@@ -617,9 +617,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-            "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+            "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
             "cpu": [
                 "arm64"
             ],
@@ -631,9 +631,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-            "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+            "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
             "cpu": [
                 "x64"
             ],
@@ -645,9 +645,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-            "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+            "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
             "cpu": [
                 "arm"
             ],
@@ -659,9 +659,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-            "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+            "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
             "cpu": [
                 "arm"
             ],
@@ -673,9 +673,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-            "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+            "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
             "cpu": [
                 "arm64"
             ],
@@ -687,9 +687,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-            "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+            "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
             "cpu": [
                 "arm64"
             ],
@@ -701,9 +701,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-            "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+            "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+            "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
             "cpu": [
                 "loong64"
             ],
@@ -715,9 +729,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-            "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+            "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+            "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
             "cpu": [
                 "ppc64"
             ],
@@ -729,9 +757,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-            "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+            "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
             "cpu": [
                 "riscv64"
             ],
@@ -743,9 +771,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-            "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+            "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -757,9 +785,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-            "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+            "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
             "cpu": [
                 "s390x"
             ],
@@ -771,9 +799,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+            "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
             "cpu": [
                 "x64"
             ],
@@ -785,9 +813,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-            "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+            "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
             "cpu": [
                 "x64"
             ],
@@ -798,10 +826,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+            "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-            "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+            "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
             "cpu": [
                 "arm64"
             ],
@@ -813,9 +855,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-            "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+            "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
             "cpu": [
                 "arm64"
             ],
@@ -827,9 +869,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-            "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+            "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
             "cpu": [
                 "ia32"
             ],
@@ -841,9 +883,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+            "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
             "cpu": [
                 "x64"
             ],
@@ -855,9 +897,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-            "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+            "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
             "cpu": [
                 "x64"
             ],
@@ -2559,9 +2601,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2848,9 +2890,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-            "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+            "version": "4.60.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+            "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2864,28 +2906,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.53.3",
-                "@rollup/rollup-android-arm64": "4.53.3",
-                "@rollup/rollup-darwin-arm64": "4.53.3",
-                "@rollup/rollup-darwin-x64": "4.53.3",
-                "@rollup/rollup-freebsd-arm64": "4.53.3",
-                "@rollup/rollup-freebsd-x64": "4.53.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-                "@rollup/rollup-linux-arm64-musl": "4.53.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-musl": "4.53.3",
-                "@rollup/rollup-openharmony-arm64": "4.53.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-                "@rollup/rollup-win32-x64-gnu": "4.53.3",
-                "@rollup/rollup-win32-x64-msvc": "4.53.3",
+                "@rollup/rollup-android-arm-eabi": "4.60.0",
+                "@rollup/rollup-android-arm64": "4.60.0",
+                "@rollup/rollup-darwin-arm64": "4.60.0",
+                "@rollup/rollup-darwin-x64": "4.60.0",
+                "@rollup/rollup-freebsd-arm64": "4.60.0",
+                "@rollup/rollup-freebsd-x64": "4.60.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+                "@rollup/rollup-linux-arm64-musl": "4.60.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+                "@rollup/rollup-linux-loong64-musl": "4.60.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+                "@rollup/rollup-linux-x64-gnu": "4.60.0",
+                "@rollup/rollup-linux-x64-musl": "4.60.0",
+                "@rollup/rollup-openbsd-x64": "4.60.0",
+                "@rollup/rollup-openharmony-arm64": "4.60.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+                "@rollup/rollup-win32-x64-gnu": "4.60.0",
+                "@rollup/rollup-win32-x64-msvc": "4.60.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3147,9 +3192,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3339,9 +3384,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/resources/views/automation-coverage/index.blade.php
+++ b/resources/views/automation-coverage/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Automation Coverage
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <livewire:automation-coverage-queue />
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/livewire/automation-coverage-queue.blade.php
+++ b/resources/views/livewire/automation-coverage-queue.blade.php
@@ -1,0 +1,116 @@
+<div class="space-y-6">
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+        <div class="p-6">
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Automation Coverage</h3>
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                Track the full website automation checklist in one place: controller coverage, Matomo verification, Search Console onboarding, baseline sync, and optional manual CSV evidence.
+            </p>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-9 gap-4">
+        @foreach([
+            ['id' => 'required', 'label' => 'Required'],
+            ['id' => 'needs_controller', 'label' => 'Needs Controller'],
+            ['id' => 'needs_matomo_binding', 'label' => 'Needs Matomo'],
+            ['id' => 'needs_search_console_mapping', 'label' => 'Needs SC'],
+            ['id' => 'needs_onboarding', 'label' => 'Needs Onboarding'],
+            ['id' => 'import_stale', 'label' => 'Import Stale'],
+            ['id' => 'needs_baseline_sync', 'label' => 'Needs Baseline'],
+            ['id' => 'manual_csv_pending', 'label' => 'CSV Pending'],
+            ['id' => 'complete', 'label' => 'Complete'],
+        ] as $stat)
+            <div class="rounded-lg bg-white dark:bg-gray-800 shadow-sm p-4">
+                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $stat['label'] }}</div>
+                <div class="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats[$stat['id']] }}</div>
+            </div>
+        @endforeach
+    </div>
+
+    @php
+        $sections = [
+            ['title' => 'Needs Controller', 'items' => $needsController, 'tone' => 'amber'],
+            ['title' => 'Needs Matomo Binding', 'items' => $needsMatomoBinding, 'tone' => 'red'],
+            ['title' => 'Needs Search Console Mapping', 'items' => $needsSearchConsoleMapping, 'tone' => 'blue'],
+            ['title' => 'Needs Onboarding', 'items' => $needsOnboarding, 'tone' => 'violet'],
+            ['title' => 'Import Stale', 'items' => $importStale, 'tone' => 'red'],
+            ['title' => 'Needs Baseline Sync', 'items' => $needsBaselineSync, 'tone' => 'indigo'],
+            ['title' => 'Manual CSV Pending', 'items' => $manualCsvPending, 'tone' => 'yellow'],
+            ['title' => 'Complete', 'items' => $complete, 'tone' => 'emerald'],
+            ['title' => 'Excluded', 'items' => $excluded, 'tone' => 'gray'],
+        ];
+    @endphp
+
+    @foreach($sections as $section)
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+            <div class="p-6">
+                <div class="flex items-center justify-between">
+                    <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ $section['title'] }}</h4>
+                    <span class="text-sm text-gray-500 dark:text-gray-400">{{ $section['items']->count() }} properties</span>
+                </div>
+
+                <div class="mt-4 space-y-3">
+                    @if($section['items']->isEmpty())
+                        <p class="text-sm text-gray-500 dark:text-gray-400">No properties in this queue right now.</p>
+                    @else
+                        @foreach($section['items'] as $item)
+                            @php
+                                $toneClasses = match ($section['tone']) {
+                                    'amber' => 'border-amber-200 dark:border-amber-800 bg-amber-50/60 dark:bg-amber-900/10 text-amber-800 dark:text-amber-200',
+                                    'blue' => 'border-blue-200 dark:border-blue-800 bg-blue-50/60 dark:bg-blue-900/10 text-blue-800 dark:text-blue-200',
+                                    'red' => 'border-red-200 dark:border-red-800 bg-red-50/60 dark:bg-red-900/10 text-red-800 dark:text-red-200',
+                                    'violet' => 'border-violet-200 dark:border-violet-800 bg-violet-50/60 dark:bg-violet-900/10 text-violet-800 dark:text-violet-200',
+                                    'indigo' => 'border-indigo-200 dark:border-indigo-800 bg-indigo-50/60 dark:bg-indigo-900/10 text-indigo-800 dark:text-indigo-200',
+                                    'yellow' => 'border-yellow-200 dark:border-yellow-800 bg-yellow-50/60 dark:bg-yellow-900/10 text-yellow-800 dark:text-yellow-200',
+                                    'emerald' => 'border-emerald-200 dark:border-emerald-800 bg-emerald-50/60 dark:bg-emerald-900/10 text-emerald-800 dark:text-emerald-200',
+                                    default => 'border-gray-200 dark:border-gray-700 bg-gray-50/60 dark:bg-gray-900/10 text-gray-700 dark:text-gray-300',
+                                };
+                            @endphp
+                            <div class="rounded-lg border p-4 {{ $toneClasses }}">
+                                <div class="flex flex-wrap items-center justify-between gap-3">
+                                    <div>
+                                        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $item['property']->name }}</div>
+                                        <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                            {{ $item['primary_domain'] ?? 'No primary domain' }}
+                                            @if($item['matomo_source'])
+                                                · Matomo {{ $item['matomo_source']->external_id }}
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <a href="{{ route('web-properties.show', $item['property']->slug) }}" wire:navigate class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                        Open property
+                                    </a>
+                                </div>
+
+                                <div class="mt-2 text-sm">{{ $item['automation']['reason'] }}</div>
+
+                                @if($item['repository'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        Controller: {{ $item['repository']->repo_name }}
+                                    </div>
+                                @endif
+
+                                @if($item['search_console_coverage'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        {{ $item['search_console_coverage']->mappingStateLabel() }}
+                                        @if($item['search_console_coverage']->property_uri)
+                                            · {{ $item['search_console_coverage']->property_uri }}
+                                        @endif
+                                        · {{ $item['search_console_coverage']->freshnessLabel() }}
+                                    </div>
+                                @endif
+
+                                @if($item['latest_baseline'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        Latest baseline {{ $item['latest_baseline']->captured_at->format('Y-m-d') }}
+                                        · {{ $item['latest_baseline']->importMethodLabel() }}
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -42,6 +42,9 @@ new class extends Component
                     <x-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                         {{ __('Matomo Coverage') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
+                        {{ __('Automation') }}
+                    </x-nav-link>
                     <x-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                         {{ __('Search Console') }}
                     </x-nav-link>
@@ -117,6 +120,9 @@ new class extends Component
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                 {{ __('Matomo Coverage') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
+                {{ __('Automation') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                 {{ __('Search Console') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return view('matomo-coverage.index');
     })->name('matomo-coverage.index');
 
+    Route::get('/automation-coverage', function () {
+        return view('automation-coverage.index');
+    })->name('automation-coverage.index');
+
     Route::get('/search-console-coverage', function () {
         return view('search-console-coverage.index');
     })->name('search-console-coverage.index');

--- a/tests/Feature/AutomationCoverageQueueTest.php
+++ b/tests/Feature/AutomationCoverageQueueTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\AutomationCoverageQueue;
+use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
 use App\Models\DomainSeoBaseline;
 use App\Models\PropertyAnalyticsSource;
@@ -11,6 +13,8 @@ use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class AutomationCoverageQueueTest extends TestCase
@@ -29,32 +33,38 @@ class AutomationCoverageQueueTest extends TestCase
         $prefixProperty = $this->makeProperty('prefix.example.au', 'Prefix Only');
         $this->attachRepository($prefixProperty);
         $prefixSource = $this->attachMatomo($prefixProperty, '32');
+        $this->attachInstallAudit($prefixProperty, $prefixSource);
         $this->attachCoverage($prefixProperty, $prefixSource, 'url_prefix', now()->subDay()->toDateString());
 
         $needsOnboarding = $this->makeProperty('needs-onboarding.example.au', 'Needs Onboarding');
         $this->attachRepository($needsOnboarding);
         $needsOnboardingSource = $this->attachMatomo($needsOnboarding, '33');
+        $this->attachInstallAudit($needsOnboarding, $needsOnboardingSource);
         $this->attachCoverage($needsOnboarding, $needsOnboardingSource, 'domain_property', null);
 
         $staleProperty = $this->makeProperty('stale.example.au', 'Stale Import');
         $this->attachRepository($staleProperty);
         $staleSource = $this->attachMatomo($staleProperty, '34');
+        $this->attachInstallAudit($staleProperty, $staleSource);
         $this->attachCoverage($staleProperty, $staleSource, 'domain_property', now()->subDays(10)->toDateString());
 
         $needsBaseline = $this->makeProperty('baseline.example.au', 'Needs Baseline');
         $this->attachRepository($needsBaseline);
         $needsBaselineSource = $this->attachMatomo($needsBaseline, '35');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
         $this->attachCoverage($needsBaseline, $needsBaselineSource, 'domain_property', now()->subDay()->toDateString());
 
         $csvPending = $this->makeProperty('csv-pending.example.au', 'CSV Pending');
         $this->attachRepository($csvPending);
         $csvPendingSource = $this->attachMatomo($csvPending, '36');
+        $this->attachInstallAudit($csvPending, $csvPendingSource);
         $this->attachCoverage($csvPending, $csvPendingSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($csvPending, $csvPendingSource, 'matomo_api');
 
         $complete = $this->makeProperty('complete.example.au', 'Complete Site');
         $this->attachRepository($complete);
         $completeSource = $this->attachMatomo($complete, '37');
+        $this->attachInstallAudit($complete, $completeSource);
         $this->attachCoverage($complete, $completeSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($complete, $completeSource, 'matomo_plus_manual_csv');
 
@@ -91,6 +101,31 @@ class AutomationCoverageQueueTest extends TestCase
         $response->assertSee('Complete Site');
         $response->assertSee('Parked Site');
         $response->assertSee('Manual CSV Pending');
+
+        $this->assertSame('needs_baseline_sync', $needsBaseline->fresh()->automationCoverageSummary()['status']);
+
+        Livewire::test(AutomationCoverageQueue::class)
+            ->assertViewHas('stats', function (array $stats): bool {
+                return $stats['required'] === 8
+                    && $stats['needs_controller'] === 1
+                    && $stats['needs_matomo_binding'] === 1
+                    && $stats['needs_search_console_mapping'] === 1
+                    && $stats['needs_onboarding'] === 1
+                    && $stats['import_stale'] === 1
+                    && $stats['needs_baseline_sync'] === 1
+                    && $stats['manual_csv_pending'] === 1
+                    && $stats['complete'] === 1
+                    && $stats['excluded'] === 1;
+            })
+            ->assertViewHas('needsBaselineSync', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'Needs Baseline');
+            })
+            ->assertViewHas('manualCsvPending', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'CSV Pending');
+            })
+            ->assertViewHas('complete', function (Collection $items): bool {
+                return (bool) $items->first(fn (array $item): bool => $item['property']->name === 'Complete Site');
+            });
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty
@@ -140,6 +175,22 @@ class AutomationCoverageQueueTest extends TestCase
             'external_name' => $property->name,
             'is_primary' => true,
             'status' => 'active',
+        ]);
+    }
+
+    private function attachInstallAudit(WebProperty $property, PropertyAnalyticsSource $source): void
+    {
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $source->external_id,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://'.$property->primaryDomainName().'/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
         ]);
     }
 

--- a/tests/Feature/AutomationCoverageQueueTest.php
+++ b/tests/Feature/AutomationCoverageQueueTest.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AutomationCoverageQueueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_automation_coverage_queue(): void
+    {
+        $user = User::factory()->create();
+
+        $needsController = $this->makeProperty('no-controller.example.au', 'No Controller');
+
+        $needsMatomo = $this->makeProperty('no-matomo.example.au', 'No Matomo');
+        $this->attachRepository($needsMatomo);
+
+        $prefixProperty = $this->makeProperty('prefix.example.au', 'Prefix Only');
+        $this->attachRepository($prefixProperty);
+        $prefixSource = $this->attachMatomo($prefixProperty, '32');
+        $this->attachCoverage($prefixProperty, $prefixSource, 'url_prefix', now()->subDay()->toDateString());
+
+        $needsOnboarding = $this->makeProperty('needs-onboarding.example.au', 'Needs Onboarding');
+        $this->attachRepository($needsOnboarding);
+        $needsOnboardingSource = $this->attachMatomo($needsOnboarding, '33');
+        $this->attachCoverage($needsOnboarding, $needsOnboardingSource, 'domain_property', null);
+
+        $staleProperty = $this->makeProperty('stale.example.au', 'Stale Import');
+        $this->attachRepository($staleProperty);
+        $staleSource = $this->attachMatomo($staleProperty, '34');
+        $this->attachCoverage($staleProperty, $staleSource, 'domain_property', now()->subDays(10)->toDateString());
+
+        $needsBaseline = $this->makeProperty('baseline.example.au', 'Needs Baseline');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '35');
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, 'domain_property', now()->subDay()->toDateString());
+
+        $csvPending = $this->makeProperty('csv-pending.example.au', 'CSV Pending');
+        $this->attachRepository($csvPending);
+        $csvPendingSource = $this->attachMatomo($csvPending, '36');
+        $this->attachCoverage($csvPending, $csvPendingSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($csvPending, $csvPendingSource, 'matomo_api');
+
+        $complete = $this->makeProperty('complete.example.au', 'Complete Site');
+        $this->attachRepository($complete);
+        $completeSource = $this->attachMatomo($complete, '37');
+        $this->attachCoverage($complete, $completeSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($complete, $completeSource, 'matomo_plus_manual_csv');
+
+        $excludedDomain = Domain::factory()->create([
+            'domain' => 'parked.example.au',
+            'is_active' => true,
+            'platform' => 'Parked',
+        ]);
+        $excludedProperty = WebProperty::factory()->create([
+            'slug' => 'parked-site',
+            'name' => 'Parked Site',
+            'status' => 'active',
+            'property_type' => 'domain_asset',
+            'primary_domain_id' => $excludedDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $excludedProperty->id,
+            'domain_id' => $excludedDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/automation-coverage');
+
+        $response->assertOk();
+        $response->assertSee('Automation Coverage');
+        $response->assertSee('No Controller');
+        $response->assertSee('No Matomo');
+        $response->assertSee('Prefix Only');
+        $response->assertSee('Needs Onboarding');
+        $response->assertSee('Stale Import');
+        $response->assertSee('Needs Baseline');
+        $response->assertSee('CSV Pending');
+        $response->assertSee('Complete Site');
+        $response->assertSee('Parked Site');
+        $response->assertSee('Manual CSV Pending');
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+
+    private function attachRepository(WebProperty $property): void
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachMatomo(WebProperty $property, string $externalId): PropertyAnalyticsSource
+    {
+        return PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $externalId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachCoverage(WebProperty $property, PropertyAnalyticsSource $source, string $mappingState, ?string $latestMetricDate): void
+    {
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => $mappingState,
+            'property_uri' => $mappingState === 'domain_property'
+                ? 'sc-domain:'.$property->primaryDomainName()
+                : 'https://'.$property->primaryDomainName().'/',
+            'property_type' => $mappingState === 'domain_property' ? 'domain' : 'url-prefix',
+            'latest_metric_date' => $latestMetricDate,
+            'checked_at' => now(),
+        ]);
+    }
+
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'manual_checkpoint',
+            'captured_at' => now()->subDay(),
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.5,
+        ]);
+    }
+}

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -4,6 +4,9 @@ namespace Tests\Feature;
 
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\PropertyRepository;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -20,6 +23,30 @@ class DashboardPriorityQueueApiTest extends TestCase
             'is_active' => true,
             'platform' => 'WordPress',
             'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $mustFixProperty = WebProperty::factory()->create([
+            'slug' => 'must-fix-site',
+            'name' => 'Must Fix Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $mustFixDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $mustFixProperty->id,
+            'domain_id' => $mustFixDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $mustFixProperty->id,
+            'repo_name' => 'must-fix-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/must-fix-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
         ]);
 
         DomainCheck::factory()->create([
@@ -41,10 +68,56 @@ class DashboardPriorityQueueApiTest extends TestCase
             'hosting_provider' => 'Vercel',
         ]);
 
+        $shouldFixProperty = WebProperty::factory()->create([
+            'slug' => 'should-fix-site',
+            'name' => 'Should Fix Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $shouldFixDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $shouldFixProperty->id,
+            'domain_id' => $shouldFixDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $shouldFixProperty->id,
+            'repo_name' => 'should-fix-site-astro',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/should-fix-site-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+        ]);
+
         DomainCheck::factory()->create([
             'domain_id' => $shouldFixDomain->id,
             'check_type' => 'security_headers',
             'status' => 'warn',
+        ]);
+
+        $coverageGapDomain = Domain::factory()->create([
+            'domain' => 'coverage-gap.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Synergy Wholesale PTY',
+        ]);
+
+        $coverageGapProperty = WebProperty::factory()->create([
+            'slug' => 'coverage-gap-site',
+            'name' => 'Coverage Gap Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $coverageGapDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $coverageGapProperty->id,
+            'domain_id' => $coverageGapDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
         ]);
 
         $parkedDomain = Domain::factory()->create([
@@ -86,9 +159,16 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('source_system', 'domain-monitor-priority-queue')
             ->assertJsonPath('contract_version', 1)
             ->assertJsonPath('stats.must_fix', 1)
-            ->assertJsonPath('stats.should_fix', 2)
+            ->assertJsonPath('stats.should_fix', 3)
+            ->assertJsonPath('derived.standard_gap_candidates', 1)
+            ->assertJsonPath('derived.coverage_gap_candidates', 1)
             ->assertJsonPath('must_fix.0.domain', 'must-fix.example.com')
-            ->assertJsonPath('must_fix.0.hosting_provider', 'DreamIT Host');
+            ->assertJsonPath('must_fix.0.hosting_provider', 'DreamIT Host')
+            ->assertJsonPath('must_fix.0.issue_family', 'health.http')
+            ->assertJsonPath('must_fix.0.control_id', 'transport.http_health')
+            ->assertJsonPath('must_fix.0.platform_profile', 'wordpress_legacy_unmanaged')
+            ->assertJsonPath('must_fix.0.rollout_scope', 'domain_only')
+            ->assertJsonPath('must_fix.0.is_standard_gap', false);
 
         $mustFixDomains = collect($response->json('must_fix'));
         $shouldFixDomains = collect($response->json('should_fix'));
@@ -97,11 +177,36 @@ class DashboardPriorityQueueApiTest extends TestCase
         $this->assertFalse($mustFixDomains->contains(fn (array $item): bool => $item['domain'] === 'mail-only.example.com'));
         $this->assertTrue($shouldFixDomains->contains(fn (array $item): bool => $item['domain'] === 'mail-only.example.com'));
         $this->assertTrue($shouldFixDomains->contains(fn (array $item): bool => $item['domain'] === 'should-fix.example.com'));
+        $this->assertTrue($shouldFixDomains->contains(fn (array $item): bool => $item['domain'] === 'coverage-gap.example.com'));
 
         $emailOnly = $shouldFixDomains->firstWhere('domain', 'mail-only.example.com');
 
         $this->assertIsArray($emailOnly);
         $this->assertTrue($emailOnly['is_email_only']);
         $this->assertSame(['Email security needs review'], $emailOnly['primary_reasons']);
+
+        $astroShouldFix = $shouldFixDomains->firstWhere('domain', 'should-fix.example.com');
+
+        $this->assertIsArray($astroShouldFix);
+        $this->assertSame('security.headers_baseline', $astroShouldFix['issue_family']);
+        $this->assertSame('security.headers_baseline', $astroShouldFix['control_id']);
+        $this->assertSame('astro_marketing_managed', $astroShouldFix['platform_profile']);
+        $this->assertSame('vercel_astro', $astroShouldFix['host_profile']);
+        $this->assertSame('astro_core', $astroShouldFix['control_profile']);
+        $this->assertSame('shared_astro_repo_conventions_and_host_config', $astroShouldFix['baseline_surface']);
+        $this->assertSame('fleet', $astroShouldFix['rollout_scope']);
+        $this->assertTrue($astroShouldFix['is_standard_gap']);
+
+        $coverageGap = $shouldFixDomains->firstWhere('domain', 'coverage-gap.example.com');
+
+        $this->assertIsArray($coverageGap);
+        $this->assertSame('control.coverage_required', $coverageGap['issue_family']);
+        $this->assertSame('control.website_fleet_coverage', $coverageGap['control_id']);
+        $this->assertTrue($coverageGap['coverage_required']);
+        $this->assertSame('missing_repository', $coverageGap['coverage_status']);
+        $this->assertTrue($coverageGap['coverage_gap']);
+        $this->assertSame(['Fleet controller access is missing'], $coverageGap['primary_reasons']);
+        $this->assertSame('domain_only', $coverageGap['rollout_scope']);
+        $this->assertFalse($coverageGap['is_standard_gap']);
     }
 }

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -157,7 +157,7 @@ class DashboardPriorityQueueApiTest extends TestCase
         $response
             ->assertOk()
             ->assertJsonPath('source_system', 'domain-monitor-priority-queue')
-            ->assertJsonPath('contract_version', 1)
+            ->assertJsonPath('contract_version', 2)
             ->assertJsonPath('stats.must_fix', 1)
             ->assertJsonPath('stats.should_fix', 3)
             ->assertJsonPath('derived.standard_gap_candidates', 1)
@@ -208,5 +208,76 @@ class DashboardPriorityQueueApiTest extends TestCase
         $this->assertSame(['Fleet controller access is missing'], $coverageGap['primary_reasons']);
         $this->assertSame('domain_only', $coverageGap['rollout_scope']);
         $this->assertFalse($coverageGap['is_standard_gap']);
+    }
+
+    public function test_priority_queue_prefers_canonical_property_for_domain_metadata(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'canonical-choice.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $alphabeticalNonCanonical = WebProperty::factory()->create([
+            'slug' => 'alpha-site',
+            'name' => 'Alpha Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $alphabeticalNonCanonical->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => false,
+        ]);
+
+        $canonicalProperty = WebProperty::factory()->create([
+            'slug' => 'zeta-site',
+            'name' => 'Zeta Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $canonicalProperty->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $canonicalProperty->id,
+            'repo_name' => 'zeta-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/zeta-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $domain->id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk()->assertJsonPath('contract_version', 2);
+
+        $shouldFix = collect($response->json('should_fix'))->firstWhere('domain', 'canonical-choice.example.com');
+
+        $this->assertIsArray($shouldFix);
+        $this->assertSame('zeta-site', $shouldFix['web_property_slug']);
+        $this->assertSame('Zeta Site', $shouldFix['web_property_name']);
+        $this->assertSame('controlled', $shouldFix['coverage_status']);
+        $this->assertFalse($shouldFix['coverage_gap']);
     }
 }

--- a/tests/Feature/SyncCoverageTagsCommandTest.php
+++ b/tests/Feature/SyncCoverageTagsCommandTest.php
@@ -20,34 +20,7 @@ class SyncCoverageTagsCommandTest extends TestCase
 
     public function test_it_syncs_required_complete_and_gap_tags_onto_primary_domains(): void
     {
-        config()->set('domain_monitor.coverage_tags', [
-            'manual_exclusion_tag' => [
-                'name' => 'coverage.excluded',
-                'priority' => 95,
-                'color' => '#6b7280',
-                'description' => 'Excluded',
-            ],
-            'tags' => [
-                'required' => [
-                    'name' => 'coverage.required',
-                    'priority' => 90,
-                    'color' => '#2563eb',
-                    'description' => 'Required',
-                ],
-                'complete' => [
-                    'name' => 'coverage.complete',
-                    'priority' => 80,
-                    'color' => '#16a34a',
-                    'description' => 'Complete',
-                ],
-                'gap' => [
-                    'name' => 'coverage.gap',
-                    'priority' => 85,
-                    'color' => '#dc2626',
-                    'description' => 'Gap',
-                ],
-            ],
-        ]);
+        $this->setCoverageTagConfig();
 
         $completeDomain = Domain::factory()->create([
             'domain' => 'complete.example.au',
@@ -199,14 +172,7 @@ class SyncCoverageTagsCommandTest extends TestCase
 
     public function test_dry_run_does_not_mutate_tags(): void
     {
-        config()->set('domain_monitor.coverage_tags', [
-            'manual_exclusion_tag' => ['name' => 'coverage.excluded'],
-            'tags' => [
-                'required' => ['name' => 'coverage.required'],
-                'complete' => ['name' => 'coverage.complete'],
-                'gap' => ['name' => 'coverage.gap'],
-            ],
-        ]);
+        $this->setCoverageTagConfig();
 
         $domain = Domain::factory()->create([
             'domain' => 'dry-run.example.au',
@@ -232,5 +198,246 @@ class SyncCoverageTagsCommandTest extends TestCase
 
         $this->assertDatabaseCount('domain_tags', 0);
         $this->assertSame([], $domain->fresh()->tags()->pluck('name')->all());
+    }
+
+    public function test_domain_option_limits_mutation_to_named_primary_domains(): void
+    {
+        $this->setCoverageTagConfig();
+
+        $targetDomain = $this->createCompleteCoverageProperty('target.example.au', 'Target Site', '201');
+        $untouchedDomain = Domain::factory()->create([
+            'domain' => 'untouched.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'WordPress',
+        ]);
+        $untouchedProperty = WebProperty::factory()->create([
+            'slug' => 'untouched-site',
+            'name' => 'Untouched Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $untouchedDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $untouchedProperty->id,
+            'domain_id' => $untouchedDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $this->artisan('coverage:sync-tags', [
+            '--domain' => ['target.example.au'],
+        ])->assertSuccessful();
+
+        $this->assertSame(
+            ['coverage.complete', 'coverage.required'],
+            $targetDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+        $this->assertSame([], $untouchedDomain->fresh()->tags()->pluck('name')->all());
+    }
+
+    public function test_domain_option_with_no_matches_does_not_create_tags_or_mutate_domains(): void
+    {
+        $this->setCoverageTagConfig();
+
+        $domain = Domain::factory()->create([
+            'domain' => 'existing.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'Astro',
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => 'existing-site',
+            'name' => 'Existing Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $this->artisan('coverage:sync-tags', [
+            '--domain' => ['missing.example.au'],
+        ])->assertSuccessful();
+
+        $this->assertDatabaseCount('domain_tags', 0);
+        $this->assertSame([], $domain->fresh()->tags()->pluck('name')->all());
+    }
+
+    public function test_shared_primary_domain_uses_canonical_property_when_syncing_tags(): void
+    {
+        $this->setCoverageTagConfig();
+
+        $domain = Domain::factory()->create([
+            'domain' => 'shared.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'WordPress',
+        ]);
+
+        $nonCanonicalGapProperty = WebProperty::factory()->create([
+            'slug' => 'alpha-gap-site',
+            'name' => 'Alpha Gap Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $nonCanonicalGapProperty->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => false,
+        ]);
+
+        $canonicalCompleteProperty = WebProperty::factory()->create([
+            'slug' => 'zeta-complete-site',
+            'name' => 'Zeta Complete Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $canonicalCompleteProperty->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+        $canonicalSource = $this->attachRepositoryAndCoverage($canonicalCompleteProperty, '301');
+        $this->attachBaselineForSource($canonicalCompleteProperty, $canonicalSource, 'manual');
+
+        $this->artisan('coverage:sync-tags')->assertSuccessful();
+
+        $this->assertSame(
+            ['coverage.complete', 'coverage.required'],
+            $domain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+    }
+
+    private function setCoverageTagConfig(): void
+    {
+        config()->set('domain_monitor.coverage_tags', [
+            'manual_exclusion_tag' => [
+                'name' => 'coverage.excluded',
+                'priority' => 95,
+                'color' => '#6b7280',
+                'description' => 'Excluded',
+            ],
+            'tags' => [
+                'required' => [
+                    'name' => 'coverage.required',
+                    'priority' => 90,
+                    'color' => '#2563eb',
+                    'description' => 'Required',
+                ],
+                'complete' => [
+                    'name' => 'coverage.complete',
+                    'priority' => 80,
+                    'color' => '#16a34a',
+                    'description' => 'Complete',
+                ],
+                'gap' => [
+                    'name' => 'coverage.gap',
+                    'priority' => 85,
+                    'color' => '#dc2626',
+                    'description' => 'Gap',
+                ],
+            ],
+        ]);
+    }
+
+    private function createCompleteCoverageProperty(string $domainName, string $propertyName, string $matomoId): Domain
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'Astro',
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $propertyName,
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $source = $this->attachRepositoryAndCoverage($property, $matomoId);
+        $this->attachBaselineForSource($property, $source, 'manual');
+
+        return $domain;
+    }
+
+    private function attachRepositoryAndCoverage(WebProperty $property, string $matomoId): PropertyAnalyticsSource
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'framework' => 'Astro',
+            'is_primary' => true,
+        ]);
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $matomoId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $matomoId,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'summary' => 'Tracker matches',
+            'checked_at' => now(),
+        ]);
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $matomoId,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'property_type' => 'domain',
+            'latest_metric_date' => now()->subDay()->toDateString(),
+            'checked_at' => now(),
+        ]);
+
+        return $source;
+    }
+
+    private function attachBaselineForSource(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'source_provider' => 'search_console',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.4,
+        ]);
     }
 }

--- a/tests/Feature/SyncCoverageTagsCommandTest.php
+++ b/tests/Feature/SyncCoverageTagsCommandTest.php
@@ -1,0 +1,236 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AnalyticsInstallAudit;
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\DomainTag;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyncCoverageTagsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_syncs_required_complete_and_gap_tags_onto_primary_domains(): void
+    {
+        config()->set('domain_monitor.coverage_tags', [
+            'manual_exclusion_tag' => [
+                'name' => 'coverage.excluded',
+                'priority' => 95,
+                'color' => '#6b7280',
+                'description' => 'Excluded',
+            ],
+            'tags' => [
+                'required' => [
+                    'name' => 'coverage.required',
+                    'priority' => 90,
+                    'color' => '#2563eb',
+                    'description' => 'Required',
+                ],
+                'complete' => [
+                    'name' => 'coverage.complete',
+                    'priority' => 80,
+                    'color' => '#16a34a',
+                    'description' => 'Complete',
+                ],
+                'gap' => [
+                    'name' => 'coverage.gap',
+                    'priority' => 85,
+                    'color' => '#dc2626',
+                    'description' => 'Gap',
+                ],
+            ],
+        ]);
+
+        $completeDomain = Domain::factory()->create([
+            'domain' => 'complete.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'Astro',
+        ]);
+        $completeProperty = WebProperty::factory()->create([
+            'slug' => 'complete-site',
+            'name' => 'Complete Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $completeDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $completeProperty->id,
+            'domain_id' => $completeDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+        PropertyRepository::create([
+            'web_property_id' => $completeProperty->id,
+            'repo_name' => 'complete-site-repo',
+            'local_path' => '/tmp/complete-site-repo',
+            'framework' => 'Astro',
+            'is_primary' => true,
+        ]);
+        $completeSource = PropertyAnalyticsSource::create([
+            'web_property_id' => $completeProperty->id,
+            'provider' => 'matomo',
+            'external_id' => '101',
+            'external_name' => 'Complete Site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $completeSource->id,
+            'web_property_id' => $completeProperty->id,
+            'provider' => 'matomo',
+            'external_id' => '101',
+            'external_name' => 'Complete Site',
+            'install_verdict' => 'installed_match',
+            'summary' => 'Tracker matches',
+            'checked_at' => now(),
+        ]);
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $completeDomain->id,
+            'web_property_id' => $completeProperty->id,
+            'property_analytics_source_id' => $completeSource->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '101',
+            'matomo_site_name' => 'Complete Site',
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:complete.example.au',
+            'property_type' => 'domain',
+            'latest_metric_date' => now()->subDay()->toDateString(),
+            'checked_at' => now(),
+        ]);
+        DomainSeoBaseline::create([
+            'domain_id' => $completeDomain->id,
+            'web_property_id' => $completeProperty->id,
+            'property_analytics_source_id' => $completeSource->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'source_provider' => 'search_console',
+            'matomo_site_id' => '101',
+            'search_console_property_uri' => 'sc-domain:complete.example.au',
+            'search_type' => 'web',
+            'import_method' => 'manual',
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.4,
+        ]);
+
+        $gapDomain = Domain::factory()->create([
+            'domain' => 'gap.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'WordPress',
+        ]);
+        $gapProperty = WebProperty::factory()->create([
+            'slug' => 'gap-site',
+            'name' => 'Gap Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $gapDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $gapProperty->id,
+            'domain_id' => $gapDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $excludedDomain = Domain::factory()->create([
+            'domain' => 'parked.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'Astro',
+        ]);
+        $excludedProperty = WebProperty::factory()->create([
+            'slug' => 'parked-site',
+            'name' => 'Parked Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $excludedDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $excludedProperty->id,
+            'domain_id' => $excludedDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $wrongGapTag = DomainTag::create([
+            'name' => 'coverage.gap',
+            'priority' => 85,
+            'color' => '#dc2626',
+        ]);
+        $requiredTag = DomainTag::create([
+            'name' => 'coverage.required',
+            'priority' => 90,
+            'color' => '#2563eb',
+        ]);
+        $manualExclusionTag = DomainTag::create([
+            'name' => 'coverage.excluded',
+            'priority' => 95,
+            'color' => '#6b7280',
+        ]);
+        $excludedDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id, $manualExclusionTag->id]);
+        $completeDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id]);
+
+        $this->artisan('coverage:sync-tags')
+            ->assertSuccessful();
+
+        $this->assertSame(
+            ['coverage.complete', 'coverage.required'],
+            $completeDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+
+        $this->assertSame(
+            ['coverage.gap', 'coverage.required'],
+            $gapDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+
+        $this->assertSame(['coverage.excluded'], $excludedDomain->fresh()->tags()->pluck('name')->all());
+    }
+
+    public function test_dry_run_does_not_mutate_tags(): void
+    {
+        config()->set('domain_monitor.coverage_tags', [
+            'manual_exclusion_tag' => ['name' => 'coverage.excluded'],
+            'tags' => [
+                'required' => ['name' => 'coverage.required'],
+                'complete' => ['name' => 'coverage.complete'],
+                'gap' => ['name' => 'coverage.gap'],
+            ],
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'dry-run.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => 'dry-run-site',
+            'name' => 'Dry Run Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $this->artisan('coverage:sync-tags', ['--dry-run' => true])
+            ->assertSuccessful();
+
+        $this->assertDatabaseCount('domain_tags', 0);
+        $this->assertSame([], $domain->fresh()->tags()->pluck('name')->all());
+    }
+}


### PR DESCRIPTION
## Summary
- enrich the dashboard priority queue with derived fleet-control metadata and coverage-gap signals
- add a coverage tag sync command to stamp required, complete, and gap tags onto primary domains
- cover the new queue enrichment and tag sync flow with focused feature tests

## Testing
- ./vendor/bin/phpunit tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/SyncCoverageTagsCommandTest.php
- ./vendor/bin/phpstan analyse app/Services/DashboardIssueQueueService.php app/Console/Commands/SyncCoverageTags.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
