### PR TITLE
Add automation coverage refresh runner

### DIFF
--- a/app/Console/Commands/RefreshAutomationCoverage.php
+++ b/app/Console/Commands/RefreshAutomationCoverage.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\WebProperty;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
+
+class RefreshAutomationCoverage extends Command
+{
+    protected $signature = 'analytics:refresh-automation-coverage
+                            {--domain= : Optional domain to refresh only one property}
+                            {--skip-tags : Skip coverage tag sync after refreshing automation state}
+                            {--skip-should-fix : Skip the should-fix queue refresh after refreshing automation state}';
+
+    protected $description = 'Refresh Search Console automation coverage, sync baseline-ready domains, and update downstream fleet state.';
+
+    public function handle(): int
+    {
+        $domainFilter = $this->normalizeDomain((string) $this->option('domain'));
+
+        $this->info('Syncing Search Console coverage from Matomo...');
+
+        $coverageExitCode = Artisan::call(
+            'analytics:sync-search-console-coverage',
+            $domainFilter ? ['--domain' => $domainFilter] : []
+        );
+
+        if ($coverageExitCode !== 0) {
+            $this->error('Search Console coverage refresh failed.');
+
+            return self::FAILURE;
+        }
+
+        $baselineDomains = $this->domainsNeedingBaselineSync($domainFilter);
+        $baselineSynced = 0;
+        $baselineFailed = 0;
+
+        if ($baselineDomains->isEmpty()) {
+            $this->info('No domains currently need a Search Console baseline sync.');
+        }
+
+        foreach ($baselineDomains as $domainName) {
+            $this->line(sprintf('Syncing Search Console baseline for %s', $domainName));
+
+            $baselineExitCode = Artisan::call('analytics:sync-search-console-baseline', [
+                '--domain' => $domainName,
+            ]);
+
+            if ($baselineExitCode !== 0) {
+                $baselineFailed++;
+                $this->warn(sprintf('Baseline sync failed for %s.', $domainName));
+
+                continue;
+            }
+
+            $baselineSynced++;
+        }
+
+        if (! $this->option('skip-tags')) {
+            $this->info('Syncing coverage tags...');
+
+            $tagExitCode = Artisan::call(
+                'coverage:sync-tags',
+                $domainFilter ? ['--domain' => $domainFilter] : []
+            );
+
+            if ($tagExitCode !== 0) {
+                $this->error('Coverage tag sync failed.');
+
+                return self::FAILURE;
+            }
+        }
+
+        if (! $this->option('skip-should-fix')) {
+            $this->info('Refreshing should-fix queue...');
+
+            $queueExitCode = Artisan::call('domains:refresh-should-fix');
+
+            if ($queueExitCode !== 0) {
+                $this->error('Should-fix queue refresh failed.');
+
+                return self::FAILURE;
+            }
+        }
+
+        $this->info(sprintf(
+            'Automation refresh finished: %d baseline sync(s) completed, %d failed.',
+            $baselineSynced,
+            $baselineFailed,
+        ));
+
+        return $baselineFailed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, non-empty-string>
+     */
+    private function domainsNeedingBaselineSync(?string $domainFilter): Collection
+    {
+        return WebProperty::query()
+            ->with([
+                'primaryDomain',
+                'primaryDomain.tags',
+                'primaryDomain.latestSeoBaseline',
+                'repositories',
+                'analyticsSources',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain.tags',
+            ])
+            ->when(
+                $domainFilter,
+                fn ($query) => $query->whereHas('primaryDomain', fn ($domainQuery) => $domainQuery->where('domain', $domainFilter))
+            )
+            ->orderBy('name')
+            ->get()
+            ->filter(fn (WebProperty $property): bool => $property->automationCoverageSummary()['status'] === 'needs_baseline_sync')
+            ->map(fn (WebProperty $property): ?string => $property->primaryDomainName())
+            ->filter(fn (?string $domainName): bool => is_string($domainName) && $domainName !== '')
+            ->unique()
+            ->values();
+    }
+
+    private function normalizeDomain(string $value): ?string
+    {
+        $normalized = trim(mb_strtolower($value));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/app/Console/Commands/RefreshAutomationCoverage.php
+++ b/app/Console/Commands/RefreshAutomationCoverage.php
@@ -76,7 +76,10 @@ class RefreshAutomationCoverage extends Command
         if (! $this->option('skip-should-fix')) {
             $this->info('Refreshing should-fix queue...');
 
-            $queueExitCode = Artisan::call('domains:refresh-should-fix');
+            $queueExitCode = Artisan::call(
+                'domains:refresh-should-fix',
+                $domainFilter ? ['--domain' => $domainFilter] : []
+            );
 
             if ($queueExitCode !== 0) {
                 $this->error('Should-fix queue refresh failed.');

--- a/app/Console/Commands/RefreshShouldFixQueue.php
+++ b/app/Console/Commands/RefreshShouldFixQueue.php
@@ -8,7 +8,8 @@ use Illuminate\Console\Command;
 
 class RefreshShouldFixQueue extends Command
 {
-    protected $signature = 'domains:refresh-should-fix';
+    protected $signature = 'domains:refresh-should-fix
+                            {--domain= : Optional domain to refresh only one domain in the should-fix queue}';
 
     protected $description = 'Refresh health checks for domains currently in the dashboard should-fix queue';
 
@@ -29,8 +30,14 @@ class RefreshShouldFixQueue extends Command
 
     public function handle(DashboardIssueQueueService $queueService): int
     {
+        $domainFilter = $this->normalizeDomain((string) $this->option('domain'));
+
         $domains = Domain::query()
             ->where('is_active', true)
+            ->when(
+                $domainFilter,
+                fn ($query) => $query->where('domain', $domainFilter)
+            )
             ->with([
                 'platform',
                 'webProperties:id,slug,name,property_type,status',
@@ -95,6 +102,13 @@ class RefreshShouldFixQueue extends Command
         $this->info("Refreshed {$checksRun} check(s) across {$domainsRefreshed} should-fix domain(s).");
 
         return self::SUCCESS;
+    }
+
+    private function normalizeDomain(string $value): ?string
+    {
+        $normalized = trim(mb_strtolower($value));
+
+        return $normalized !== '' ? $normalized : null;
     }
 
     /**

--- a/routes/console.php
+++ b/routes/console.php
@@ -177,6 +177,12 @@ Schedule::command('domains:prune-monitoring-data')
     ->at('09:00')
     ->timezone('UTC');
 
+// Refresh fleet automation coverage after upstream analytics imports have had time to settle.
+Schedule::command('analytics:refresh-automation-coverage')
+    ->daily()
+    ->at('09:05')
+    ->timezone('UTC');
+
 // Prune failed queue jobs older than 14 days (336 hours)
 Schedule::command('queue:prune-failed --hours=336')
     ->daily()

--- a/tests/Feature/RefreshAutomationCoverageCommandTest.php
+++ b/tests/Feature/RefreshAutomationCoverageCommandTest.php
@@ -54,7 +54,7 @@ class RefreshAutomationCoverageCommandTest extends TestCase
 
         Artisan::shouldReceive('call')
             ->once()
-            ->with('domains:refresh-should-fix')
+            ->with('domains:refresh-should-fix', [])
             ->andReturn(0);
 
         $command = app(RefreshAutomationCoverage::class);
@@ -105,6 +105,151 @@ class RefreshAutomationCoverageCommandTest extends TestCase
             '--skip-tags' => true,
             '--skip-should-fix' => true,
         ]), new BufferedOutput));
+    }
+
+    public function test_it_scopes_all_downstream_steps_when_a_domain_is_provided(): void
+    {
+        $needsBaseline = $this->makeProperty('scoped-default.example.au', 'Scoped Default');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '39');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, now()->subDay()->toDateString());
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', ['--domain' => 'scoped-default.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-baseline', ['--domain' => 'scoped-default.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('coverage:sync-tags', ['--domain' => 'scoped-default.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('domains:refresh-should-fix', ['--domain' => 'scoped-default.example.au'])
+            ->andReturn(0);
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(0, $command->run(new ArrayInput([
+            '--domain' => 'scoped-default.example.au',
+        ]), new BufferedOutput));
+    }
+
+    public function test_it_fails_fast_when_coverage_refresh_fails(): void
+    {
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', [])
+            ->andReturn(1);
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('analytics:sync-search-console-baseline', \Mockery::any());
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('coverage:sync-tags', \Mockery::any());
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('domains:refresh-should-fix', \Mockery::any());
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(1, $command->run(new ArrayInput([]), new BufferedOutput));
+    }
+
+    public function test_it_returns_failure_when_any_baseline_sync_fails(): void
+    {
+        $needsBaseline = $this->makeProperty('baseline-fail.example.au', 'Baseline Failure');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '40');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, now()->subDay()->toDateString());
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-baseline', ['--domain' => 'baseline-fail.example.au'])
+            ->andReturn(1);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('coverage:sync-tags', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('domains:refresh-should-fix', [])
+            ->andReturn(0);
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(1, $command->run(new ArrayInput([]), new BufferedOutput));
+    }
+
+    public function test_it_fails_when_tag_sync_fails(): void
+    {
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('coverage:sync-tags', [])
+            ->andReturn(1);
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('domains:refresh-should-fix', \Mockery::any());
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(1, $command->run(new ArrayInput([]), new BufferedOutput));
+    }
+
+    public function test_it_fails_when_should_fix_refresh_fails(): void
+    {
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('coverage:sync-tags', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('domains:refresh-should-fix', [])
+            ->andReturn(1);
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(1, $command->run(new ArrayInput([]), new BufferedOutput));
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty

--- a/tests/Feature/RefreshAutomationCoverageCommandTest.php
+++ b/tests/Feature/RefreshAutomationCoverageCommandTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\RefreshAutomationCoverage;
+use App\Models\AnalyticsInstallAudit;
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+class RefreshAutomationCoverageCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_refreshes_coverage_and_syncs_baselines_for_ready_domains(): void
+    {
+        $needsBaseline = $this->makeProperty('baseline.example.au', 'Needs Baseline');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '35');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, now()->subDay()->toDateString());
+
+        $complete = $this->makeProperty('complete.example.au', 'Complete Site');
+        $this->attachRepository($complete);
+        $completeSource = $this->attachMatomo($complete, '36');
+        $this->attachInstallAudit($complete, $completeSource);
+        $this->attachCoverage($complete, $completeSource, now()->subDay()->toDateString());
+        $this->attachBaseline($complete, $completeSource, 'matomo_plus_manual_csv');
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-baseline', ['--domain' => 'baseline.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('coverage:sync-tags', [])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('domains:refresh-should-fix')
+            ->andReturn(0);
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(0, $command->run(new ArrayInput([]), new BufferedOutput));
+    }
+
+    public function test_it_scopes_to_one_domain_and_skips_post_sync_steps_when_requested(): void
+    {
+        $needsBaseline = $this->makeProperty('scoped.example.au', 'Scoped Site');
+        $this->attachRepository($needsBaseline);
+        $needsBaselineSource = $this->attachMatomo($needsBaseline, '37');
+        $this->attachInstallAudit($needsBaseline, $needsBaselineSource);
+        $this->attachCoverage($needsBaseline, $needsBaselineSource, now()->subDay()->toDateString());
+
+        $other = $this->makeProperty('other.example.au', 'Other Site');
+        $this->attachRepository($other);
+        $otherSource = $this->attachMatomo($other, '38');
+        $this->attachInstallAudit($other, $otherSource);
+        $this->attachCoverage($other, $otherSource, now()->subDay()->toDateString());
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-coverage', ['--domain' => 'scoped.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('analytics:sync-search-console-baseline', ['--domain' => 'scoped.example.au'])
+            ->andReturn(0);
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('coverage:sync-tags', ['--domain' => 'scoped.example.au']);
+
+        Artisan::shouldReceive('call')
+            ->never()
+            ->with('domains:refresh-should-fix');
+
+        $command = app(RefreshAutomationCoverage::class);
+        $command->setOutput(new OutputStyle(new ArrayInput([]), new BufferedOutput));
+        $command->setLaravel($this->app);
+
+        $this->assertSame(0, $command->run(new ArrayInput([
+            '--domain' => 'scoped.example.au',
+            '--skip-tags' => true,
+            '--skip-should-fix' => true,
+        ]), new BufferedOutput));
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+
+    private function attachRepository(WebProperty $property): void
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachMatomo(WebProperty $property, string $externalId): PropertyAnalyticsSource
+    {
+        return PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $externalId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachInstallAudit(WebProperty $property, PropertyAnalyticsSource $source): void
+    {
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $source->external_id,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://'.$property->primaryDomainName().'/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+    }
+
+    private function attachCoverage(WebProperty $property, PropertyAnalyticsSource $source, ?string $latestMetricDate): void
+    {
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'property_type' => 'domain',
+            'latest_metric_date' => $latestMetricDate,
+            'checked_at' => now(),
+        ]);
+    }
+
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'manual_checkpoint',
+            'captured_at' => now()->subDay(),
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.5,
+        ]);
+    }
+}

--- a/tests/Feature/RefreshShouldFixQueueCommandTest.php
+++ b/tests/Feature/RefreshShouldFixQueueCommandTest.php
@@ -33,7 +33,14 @@ class RefreshShouldFixQueueCommandTest extends TestCase
              *     is_valid: bool,
              *     verified: bool,
              *     score: int,
-             *     headers: array<string, array{present: bool}>,
+             *     headers: array<string, array{
+             *         name: string,
+             *         present: bool,
+             *         value: string|null,
+             *         status: string,
+             *         recommendation: string|null,
+             *         assessment: string
+             *     }>,
              *     error_message: string|null,
              *     payload: array<string, mixed>
              * }
@@ -45,8 +52,22 @@ class RefreshShouldFixQueueCommandTest extends TestCase
                     'verified' => true,
                     'score' => 100,
                     'headers' => [
-                        'strict-transport-security' => ['present' => true],
-                        'content-security-policy' => ['present' => true],
+                        'strict-transport-security' => [
+                            'name' => 'strict-transport-security',
+                            'present' => true,
+                            'value' => 'max-age=31536000',
+                            'status' => 'ok',
+                            'recommendation' => null,
+                            'assessment' => 'header present',
+                        ],
+                        'content-security-policy' => [
+                            'name' => 'content-security-policy',
+                            'present' => true,
+                            'value' => "default-src 'self'",
+                            'status' => 'ok',
+                            'recommendation' => null,
+                            'assessment' => 'header present',
+                        ],
                     ],
                     'error_message' => null,
                     'payload' => [
@@ -66,5 +87,95 @@ class RefreshShouldFixQueueCommandTest extends TestCase
 
         $this->assertNotNull($latestCheck);
         $this->assertSame('ok', $latestCheck->status);
+    }
+
+    public function test_it_can_scope_refreshes_to_one_domain(): void
+    {
+        $targetDomain = Domain::factory()->create([
+            'domain' => 'target.example.com',
+            'is_active' => true,
+        ]);
+
+        $otherDomain = Domain::factory()->create([
+            'domain' => 'other.example.com',
+            'is_active' => true,
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $targetDomain->id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $otherDomain->id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        $this->app->instance(SecurityHeadersHealthCheck::class, new class extends SecurityHeadersHealthCheck
+        {
+            public int $calls = 0;
+
+            /**
+             * @return array{
+             *     is_valid: bool,
+             *     verified: bool,
+             *     score: int,
+             *     headers: array<string, array{
+             *         name: string,
+             *         present: bool,
+             *         value: string|null,
+             *         status: string,
+             *         recommendation: string|null,
+             *         assessment: string
+             *     }>,
+             *     error_message: string|null,
+             *     payload: array<string, mixed>
+             * }
+             */
+            public function check(string $domain, int $timeout = 10): array
+            {
+                $this->calls++;
+
+                return [
+                    'is_valid' => true,
+                    'verified' => true,
+                    'score' => 100,
+                    'headers' => [
+                        'strict-transport-security' => [
+                            'name' => 'strict-transport-security',
+                            'present' => true,
+                            'value' => 'max-age=31536000',
+                            'status' => 'ok',
+                            'recommendation' => null,
+                            'assessment' => 'header present',
+                        ],
+                        'content-security-policy' => [
+                            'name' => 'content-security-policy',
+                            'present' => true,
+                            'value' => "default-src 'self'",
+                            'status' => 'ok',
+                            'recommendation' => null,
+                            'assessment' => 'header present',
+                        ],
+                    ],
+                    'error_message' => null,
+                    'payload' => [
+                        'domain' => $domain,
+                        'duration_ms' => 1,
+                    ],
+                ];
+            }
+        });
+
+        Artisan::call('domains:refresh-should-fix', [
+            '--domain' => 'target.example.com',
+        ]);
+
+        $this->assertSame(2, DomainCheck::query()->where('domain_id', $targetDomain->id)->where('check_type', 'security_headers')->count());
+        $this->assertSame(1, DomainCheck::query()->where('domain_id', $otherDomain->id)->where('check_type', 'security_headers')->count());
+        $this->assertSame('ok', DomainCheck::query()->where('domain_id', $targetDomain->id)->where('check_type', 'security_headers')->latest()->first()?->status);
+        $this->assertSame('warn', DomainCheck::query()->where('domain_id', $otherDomain->id)->where('check_type', 'security_headers')->latest()->first()?->status);
     }
 }


### PR DESCRIPTION
## Summary
- add a scheduled automation refresh runner for Search Console coverage and baseline sync
- refresh downstream coverage tags and should-fix state after the sync run
- cover the new command with focused feature tests

## Testing
- ./vendor/bin/phpunit tests/Feature/RefreshAutomationCoverageCommandTest.php tests/Feature/AutomationCoverageQueueTest.php tests/Feature/RefreshShouldFixQueueCommandTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RefreshAutomationCoverage.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
