### PR TITLE
Automate Matomo install audit refreshes

### DIFF
--- a/app/Console/Commands/ImportMatomoInstallAudit.php
+++ b/app/Console/Commands/ImportMatomoInstallAudit.php
@@ -118,6 +118,23 @@ class ImportMatomoInstallAudit extends Command
                 ])
             );
 
+            $existingAudit = AnalyticsInstallAudit::query()
+                ->where('property_analytics_source_id', $source->id)
+                ->first();
+
+            if (
+                ($audit['verdict'] ?? null) === 'fetch_failed'
+                && $existingAudit instanceof AnalyticsInstallAudit
+                && $existingAudit->install_verdict === 'installed_match'
+            ) {
+                $this->warn(sprintf(
+                    'Preserved the last successful Matomo install audit for site [%s] after a fetch failure.',
+                    $externalId
+                ));
+
+                continue;
+            }
+
             AnalyticsInstallAudit::query()->updateOrCreate(
                 ['property_analytics_source_id' => $source->id],
                 [

--- a/app/Console/Commands/RefreshMatomoInstallAudits.php
+++ b/app/Console/Commands/RefreshMatomoInstallAudits.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PropertyAnalyticsSource;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+
+class RefreshMatomoInstallAudits extends Command
+{
+    protected $signature = 'analytics:refresh-matomo-install-audits
+                            {--domain= : Optional domain to verify only one linked property}
+                            {--timeout=10 : HTTP timeout in seconds for site verification requests}';
+
+    protected $description = 'Verify live Matomo tracker installs for linked properties and import the latest audit state.';
+
+    public function handle(): int
+    {
+        $domainFilter = $this->normalizeDomain((string) $this->option('domain'));
+        $timeout = max(1, (int) $this->option('timeout'));
+        $expectedTrackerHost = $this->expectedTrackerHost();
+
+        $sources = PropertyAnalyticsSource::query()
+            ->where('provider', 'matomo')
+            ->where('status', 'active')
+            ->with([
+                'webProperty.primaryDomain',
+                'webProperty.propertyDomains.domain',
+            ])
+            ->when(
+                $domainFilter,
+                fn ($query) => $query->whereHas(
+                    'webProperty.propertyDomains.domain',
+                    fn ($domainQuery) => $domainQuery->where('domain', $domainFilter)
+                )
+            )
+            ->orderBy('external_name')
+            ->get()
+            ->filter(function (PropertyAnalyticsSource $source): bool {
+                $property = $source->webProperty;
+
+                return $property !== null && $property->matomoEligibility()['eligible'];
+            })
+            ->values();
+
+        if ($sources->isEmpty()) {
+            $this->warn('No eligible Matomo-linked properties found to verify.');
+
+            return self::SUCCESS;
+        }
+
+        $payload = [
+            'source_system' => 'matamo',
+            'contract_version' => 1,
+            'report_type' => 'install_verification',
+            'generated_at' => now()->toIso8601String(),
+            'install_audits' => $sources
+                ->map(fn (PropertyAnalyticsSource $source): array => $this->verifySource($source, $expectedTrackerHost, $timeout))
+                ->all(),
+        ];
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'matomo-install-audit-');
+        if (! is_string($tempPath)) {
+            $this->error('Could not create a temporary file for the Matomo audit import.');
+
+            return self::FAILURE;
+        }
+
+        file_put_contents($tempPath, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        try {
+            $exitCode = Artisan::call('analytics:import-matomo-audit', ['path' => $tempPath]);
+            $output = trim(Artisan::output());
+        } finally {
+            @unlink($tempPath);
+        }
+
+        if ($exitCode !== 0) {
+            $this->error($output !== '' ? $output : 'Matomo install audit import failed.');
+
+            return self::FAILURE;
+        }
+
+        $this->info(sprintf('Verified %d Matomo-linked property/site combination(s).', $sources->count()));
+
+        if ($output !== '') {
+            $this->line($output);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{
+     *   id_site: string,
+     *   site_name: string|null,
+     *   expected_tracker_host: string|null,
+     *   verdict: string,
+     *   best_url: string|null,
+     *   detected_site_ids: array<int, string>,
+     *   detected_tracker_hosts: array<int, string>,
+     *   summary: string,
+     *   urls: array<int, string>
+     * }
+     */
+    private function verifySource(PropertyAnalyticsSource $source, ?string $expectedTrackerHost, int $timeout): array
+    {
+        $property = $source->webProperty;
+        $urls = $property ? $this->candidateUrlsFor($property) : collect();
+        $bestUrl = $urls->first();
+        $html = null;
+
+        foreach ($urls as $url) {
+            try {
+                /** @var \Illuminate\Http\Client\Response $response */
+                $response = Http::timeout($timeout)
+                    ->withHeaders([
+                        'User-Agent' => 'domain-monitor-matomo-audit/1.0',
+                    ])
+                    ->get($url);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (! $response->successful()) {
+                continue;
+            }
+
+            $body = (string) $response->body();
+            if ($body === '') {
+                continue;
+            }
+
+            $bestUrl = $url;
+            $html = $body;
+
+            break;
+        }
+
+        if (! is_string($html)) {
+            return [
+                'id_site' => $source->external_id,
+                'site_name' => $source->external_name,
+                'expected_tracker_host' => $expectedTrackerHost,
+                'verdict' => 'fetch_failed',
+                'best_url' => $bestUrl,
+                'detected_site_ids' => [],
+                'detected_tracker_hosts' => [],
+                'summary' => 'Could not fetch any candidate URL to verify the Matomo install.',
+                'urls' => $urls->all(),
+            ];
+        }
+
+        $detectedSiteIds = $this->detectedSiteIds($html);
+        $detectedTrackerHosts = $this->detectedTrackerHosts($html);
+        $hasMatomoSignals = $this->hasMatomoSignals($html);
+
+        [$verdict, $summary] = $this->verdictForDetection(
+            expectedSiteId: $source->external_id,
+            expectedTrackerHost: $expectedTrackerHost,
+            detectedSiteIds: $detectedSiteIds,
+            detectedTrackerHosts: $detectedTrackerHosts,
+            hasMatomoSignals: $hasMatomoSignals,
+        );
+
+        return [
+            'id_site' => $source->external_id,
+            'site_name' => $source->external_name,
+            'expected_tracker_host' => $expectedTrackerHost,
+            'verdict' => $verdict,
+            'best_url' => $bestUrl,
+            'detected_site_ids' => $detectedSiteIds,
+            'detected_tracker_hosts' => $detectedTrackerHosts,
+            'summary' => $summary,
+            'urls' => $urls->all(),
+        ];
+    }
+
+    /**
+     * @return Collection<int, non-empty-string>
+     */
+    private function candidateUrlsFor(\App\Models\WebProperty $property): Collection
+    {
+        $urls = [];
+
+        if (is_string($property->production_url) && trim($property->production_url) !== '') {
+            $urls[] = trim($property->production_url);
+        }
+
+        $primaryDomain = $property->primaryDomainName();
+        if (is_string($primaryDomain) && $primaryDomain !== '') {
+            $urls[] = 'https://'.$primaryDomain.'/';
+            $urls[] = 'http://'.$primaryDomain.'/';
+        }
+
+        return collect($urls)
+            ->map(fn (string $url): string => trim($url))
+            ->filter(fn (string $url): bool => $url !== '')
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * @param  array<int, string>  $detectedSiteIds
+     * @param  array<int, string>  $detectedTrackerHosts
+     * @return array{0: string, 1: string}
+     */
+    private function verdictForDetection(
+        string $expectedSiteId,
+        ?string $expectedTrackerHost,
+        array $detectedSiteIds,
+        array $detectedTrackerHosts,
+        bool $hasMatomoSignals
+    ): array {
+        $siteIdMatch = in_array($expectedSiteId, $detectedSiteIds, true);
+        $trackerHostMatch = $expectedTrackerHost !== null && in_array($expectedTrackerHost, $detectedTrackerHosts, true);
+
+        if ($siteIdMatch && ($expectedTrackerHost === null || $trackerHostMatch)) {
+            return [
+                'installed_match',
+                'Matomo snippet detected with the expected tracker host and site ID.',
+            ];
+        }
+
+        if ($expectedTrackerHost !== null && $detectedTrackerHosts !== [] && ! $trackerHostMatch) {
+            return [
+                'installed_other_tracker_host',
+                'Tracking code was found, but it points at a different Matomo tracker host.',
+            ];
+        }
+
+        if ($detectedSiteIds !== [] && ! $siteIdMatch) {
+            return [
+                'installed_wrong_site_id',
+                'Tracking code was found, but the detected Matomo site ID does not match the linked property.',
+            ];
+        }
+
+        if ($hasMatomoSignals) {
+            return [
+                'partial_detection',
+                'Some Matomo signals were found, but the expected tracker host and site ID could not be fully confirmed.',
+            ];
+        }
+
+        return [
+            'not_detected',
+            'No Matomo snippet signals were detected in the fetched source.',
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function detectedSiteIds(string $html): array
+    {
+        $matches = [];
+        $siteIds = [];
+
+        preg_match_all(
+            "/_paq\.push\(\s*\[\s*['\"]setSiteId['\"]\s*,\s*['\"]?(\d+)['\"]?\s*\]\s*\)/i",
+            $html,
+            $matches
+        );
+
+        $siteIds = array_merge($siteIds, $matches[1]);
+
+        preg_match_all(
+            "/\b(?:setSiteId|idSite)\b\s*[:(=,]\s*['\"]?(\d+)['\"]?/i",
+            $html,
+            $matches
+        );
+
+        $siteIds = array_merge($siteIds, $matches[1]);
+
+        return collect($siteIds)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function detectedTrackerHosts(string $html): array
+    {
+        $matches = [];
+
+        preg_match_all(
+            '~https?://([a-z0-9.-]+)/(?:(?:matomo|piwik)\.php|(?:matomo|piwik)\.js)~i',
+            $html,
+            $matches
+        );
+
+        return collect($matches[1])
+            ->map(fn ($value): string => mb_strtolower((string) $value))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function hasMatomoSignals(string $html): bool
+    {
+        return str_contains($html, '_paq')
+            || str_contains(mb_strtolower($html), 'matomo.js')
+            || str_contains(mb_strtolower($html), 'piwik.js');
+    }
+
+    private function expectedTrackerHost(): ?string
+    {
+        $host = parse_url((string) config('services.matomo.base_url', ''), PHP_URL_HOST);
+
+        return is_string($host) && trim($host) !== '' ? mb_strtolower(trim($host)) : null;
+    }
+
+    private function normalizeDomain(string $value): ?string
+    {
+        $normalized = trim(mb_strtolower($value));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/app/Console/Commands/RefreshMatomoInstallAudits.php
+++ b/app/Console/Commands/RefreshMatomoInstallAudits.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\Http;
 
 class RefreshMatomoInstallAudits extends Command
 {
+    private const MAX_SCRIPT_ASSETS = 3;
+
     protected $signature = 'analytics:refresh-matomo-install-audits
                             {--domain= : Optional domain to verify only one linked property}
                             {--timeout=10 : HTTP timeout in seconds for site verification requests}';
@@ -21,6 +23,12 @@ class RefreshMatomoInstallAudits extends Command
         $domainFilter = $this->normalizeDomain((string) $this->option('domain'));
         $timeout = max(1, (int) $this->option('timeout'));
         $expectedTrackerHost = $this->expectedTrackerHost();
+
+        if (! is_string($expectedTrackerHost) || $expectedTrackerHost === '') {
+            $this->error('Matomo base URL is not configured or does not include a valid tracker host.');
+
+            return self::FAILURE;
+        }
 
         $sources = PropertyAnalyticsSource::query()
             ->where('provider', 'matomo')
@@ -105,7 +113,7 @@ class RefreshMatomoInstallAudits extends Command
      *   urls: array<int, string>
      * }
      */
-    private function verifySource(PropertyAnalyticsSource $source, ?string $expectedTrackerHost, int $timeout): array
+    private function verifySource(PropertyAnalyticsSource $source, string $expectedTrackerHost, int $timeout): array
     {
         $property = $source->webProperty;
         $urls = $property ? $this->candidateUrlsFor($property) : collect();
@@ -153,9 +161,15 @@ class RefreshMatomoInstallAudits extends Command
             ];
         }
 
+        $analysis = $this->analyzeSignals($html, $bestUrl, $timeout);
+
         $detectedSiteIds = $this->detectedSiteIds($html);
-        $detectedTrackerHosts = $this->detectedTrackerHosts($html);
-        $hasMatomoSignals = $this->hasMatomoSignals($html);
+        $detectedSiteIds = array_values(array_unique(array_merge(
+            $detectedSiteIds,
+            $analysis['site_ids']
+        )));
+        $detectedTrackerHosts = $analysis['tracker_hosts'];
+        $hasMatomoSignals = $analysis['has_signals'];
 
         [$verdict, $summary] = $this->verdictForDetection(
             expectedSiteId: $source->external_id,
@@ -179,11 +193,12 @@ class RefreshMatomoInstallAudits extends Command
     }
 
     /**
-     * @return Collection<int, non-empty-string>
+     * @return Collection<int, string>
      */
     private function candidateUrlsFor(\App\Models\WebProperty $property): Collection
     {
         $urls = [];
+        $allowedHosts = $this->allowedHostsFor($property);
 
         if (is_string($property->production_url) && trim($property->production_url) !== '') {
             $urls[] = trim($property->production_url);
@@ -192,12 +207,28 @@ class RefreshMatomoInstallAudits extends Command
         $primaryDomain = $property->primaryDomainName();
         if (is_string($primaryDomain) && $primaryDomain !== '') {
             $urls[] = 'https://'.$primaryDomain.'/';
-            $urls[] = 'http://'.$primaryDomain.'/';
         }
 
         return collect($urls)
             ->map(fn (string $url): string => trim($url))
-            ->filter(fn (string $url): bool => $url !== '')
+            ->filter(function (string $url) use ($allowedHosts): bool {
+                if ($url === '') {
+                    return false;
+                }
+
+                if (! str_starts_with(mb_strtolower($url), 'https://')) {
+                    return false;
+                }
+
+                $host = parse_url($url, PHP_URL_HOST);
+                if (! is_string($host) || $host === '') {
+                    return false;
+                }
+
+                $host = mb_strtolower($host);
+
+                return $allowedHosts->contains(fn (string $allowedHost): bool => $host === $allowedHost || str_ends_with($host, '.'.$allowedHost));
+            })
             ->unique()
             ->values();
     }
@@ -275,6 +306,14 @@ class RefreshMatomoInstallAudits extends Command
 
         $siteIds = array_merge($siteIds, $matches[1]);
 
+        preg_match_all(
+            '/[?&]idsite=(\d+)/i',
+            $html,
+            $matches
+        );
+
+        $siteIds = array_merge($siteIds, $matches[1]);
+
         return collect($siteIds)
             ->unique()
             ->values()
@@ -289,7 +328,7 @@ class RefreshMatomoInstallAudits extends Command
         $matches = [];
 
         preg_match_all(
-            '~https?://([a-z0-9.-]+)/(?:(?:matomo|piwik)\.php|(?:matomo|piwik)\.js)~i',
+            '~(?:https?:)?//([a-z0-9.-]+)/(?:(?:matomo|piwik)\.php|(?:matomo|piwik)\.js)~i',
             $html,
             $matches
         );
@@ -304,8 +343,231 @@ class RefreshMatomoInstallAudits extends Command
     private function hasMatomoSignals(string $html): bool
     {
         return str_contains($html, '_paq')
+            || str_contains($html, 'trackPageView')
+            || str_contains($html, 'enableLinkTracking')
             || str_contains(mb_strtolower($html), 'matomo.js')
             || str_contains(mb_strtolower($html), 'piwik.js');
+    }
+
+    /**
+     * @return array{site_ids: array<int, string>, tracker_hosts: array<int, string>, has_signals: bool}
+     */
+    private function analyzeSignals(string $html, string $sourceUrl, int $timeout): array
+    {
+        $siteIds = $this->detectedSiteIds($html);
+        $trackerHosts = $this->detectedTrackerHosts($html);
+        $hasSignals = $this->hasMatomoSignals($html);
+
+        $trackerBaseVariables = $this->trackerBaseVariables($html, $sourceUrl);
+        $trackerHosts = array_values(array_unique(array_merge(
+            $trackerHosts,
+            $this->detectedVariableTrackerHosts($html, $trackerBaseVariables, $sourceUrl)
+        )));
+
+        foreach ($this->scriptAssetUrls($html, $sourceUrl) as $assetUrl) {
+            try {
+                /** @var \Illuminate\Http\Client\Response $response */
+                $response = Http::timeout($timeout)
+                    ->withHeaders([
+                        'User-Agent' => 'domain-monitor-matomo-audit/1.0',
+                    ])
+                    ->get($assetUrl);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (! $response->successful()) {
+                continue;
+            }
+
+            $assetBody = (string) $response->body();
+            if ($assetBody === '') {
+                continue;
+            }
+
+            $hasSignals = $hasSignals || $this->hasMatomoSignals($assetBody);
+            $siteIds = array_values(array_unique(array_merge(
+                $siteIds,
+                $this->detectedSiteIds($assetBody)
+            )));
+
+            $assetTrackerHosts = array_merge(
+                $this->detectedTrackerHosts($assetBody),
+                $this->detectedVariableTrackerHosts($assetBody, $this->trackerBaseVariables($assetBody, $assetUrl), $assetUrl)
+            );
+
+            $trackerHosts = array_values(array_unique(array_merge(
+                $trackerHosts,
+                $assetTrackerHosts
+            )));
+        }
+
+        return [
+            'site_ids' => $siteIds,
+            'tracker_hosts' => $trackerHosts,
+            'has_signals' => $hasSignals,
+        ];
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function allowedHostsFor(\App\Models\WebProperty $property): Collection
+    {
+        $hosts = [];
+
+        foreach ($property->orderedDomainLinks() as $link) {
+            $domain = $link->domain?->domain;
+            if (! is_string($domain) || $domain === '') {
+                continue;
+            }
+
+            $hosts[] = mb_strtolower($domain);
+        }
+
+        /** @var Collection<int, string> $result */
+        $result = collect(array_values(array_map(
+            static fn (string $host): string => (string) $host,
+            array_unique($hosts)
+        )));
+
+        return $result;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function scriptAssetUrls(string $html, string $sourceUrl): array
+    {
+        $matches = [];
+
+        preg_match_all('/<script[^>]+src=["\']([^"\']+)["\']/i', $html, $matches);
+
+        $sourceHost = parse_url($sourceUrl, PHP_URL_HOST);
+
+        return collect($matches[1])
+            ->map(fn ($value): ?string => $this->resolveUrl((string) $value, $sourceUrl))
+            ->filter(function (?string $value) use ($sourceHost): bool {
+                if (! is_string($value) || $value === '') {
+                    return false;
+                }
+
+                $host = parse_url($value, PHP_URL_HOST);
+
+                return is_string($host) && is_string($sourceHost) && mb_strtolower($host) === mb_strtolower($sourceHost);
+            })
+            ->take(self::MAX_SCRIPT_ASSETS)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function trackerBaseVariables(string $html, string $sourceUrl): array
+    {
+        $matches = [];
+        $variables = [];
+
+        preg_match_all(
+            '/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*["\']((?:https?:)?\/\/[^"\']+)["\']/i',
+            $html,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $variableName = $match[1];
+            $rawValue = $match[2];
+
+            $resolved = $this->resolveUrl($rawValue, $sourceUrl);
+            if (! is_string($resolved)) {
+                continue;
+            }
+
+            $variables[$variableName] = $resolved;
+        }
+
+        return $variables;
+    }
+
+    /**
+     * @param  array<string, string>  $trackerBaseVariables
+     * @return array<int, string>
+     */
+    private function detectedVariableTrackerHosts(string $html, array $trackerBaseVariables, string $sourceUrl): array
+    {
+        $matches = [];
+        $hosts = [];
+
+        preg_match_all(
+            '/setTrackerUrl[\'"]?\s*,\s*([A-Za-z_$][\w$]*)\s*\+\s*[\'"]((?:matomo|piwik)\.php[^\'"]*)[\'"]/i',
+            $html,
+            $matches,
+            PREG_SET_ORDER
+        );
+
+        foreach ($matches as $match) {
+            $variableName = $match[1];
+            $suffix = $match[2];
+
+            $baseUrl = $trackerBaseVariables[$variableName] ?? null;
+            if (! is_string($baseUrl)) {
+                continue;
+            }
+
+            $resolved = $this->resolveUrl($suffix, $this->ensureTrailingSlash($baseUrl) ?? $sourceUrl);
+            $host = is_string($resolved) ? parse_url($resolved, PHP_URL_HOST) : null;
+
+            if (is_string($host) && $host !== '') {
+                $hosts[] = mb_strtolower($host);
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+
+    private function resolveUrl(string $value, string $baseUrl): ?string
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        if (preg_match('~^https?://~i', $value)) {
+            return $value;
+        }
+
+        $baseParts = parse_url($baseUrl);
+        $scheme = $baseParts['scheme'] ?? null;
+        $host = $baseParts['host'] ?? null;
+
+        if (! is_string($scheme) || ! is_string($host)) {
+            return null;
+        }
+
+        $port = isset($baseParts['port']) ? ':'.$baseParts['port'] : '';
+        $origin = $scheme.'://'.$host.$port;
+
+        if (str_starts_with($value, '//')) {
+            return $scheme.':'.$value;
+        }
+
+        if (str_starts_with($value, '/')) {
+            return $origin.$value;
+        }
+
+        $basePath = $baseParts['path'] ?? '/';
+        $directory = rtrim(str_replace('\\', '/', dirname($basePath)), '/');
+
+        return $origin.($directory === '' ? '' : $directory).'/'.$value;
+    }
+
+    private function ensureTrailingSlash(string $url): ?string
+    {
+        $trimmed = rtrim($url, '/');
+
+        return $trimmed === '' ? null : $trimmed.'/';
     }
 
     private function expectedTrackerHost(): ?string

--- a/routes/console.php
+++ b/routes/console.php
@@ -177,6 +177,12 @@ Schedule::command('domains:prune-monitoring-data')
     ->at('09:00')
     ->timezone('UTC');
 
+// Verify live Matomo tracker installs before automation coverage is refreshed.
+Schedule::command('analytics:refresh-matomo-install-audits')
+    ->daily()
+    ->at('08:50')
+    ->timezone('UTC');
+
 // Refresh fleet automation coverage after upstream analytics imports have had time to settle.
 Schedule::command('analytics:refresh-automation-coverage')
     ->daily()

--- a/tests/Feature/ImportMatomoInstallAuditCommandTest.php
+++ b/tests/Feature/ImportMatomoInstallAuditCommandTest.php
@@ -77,4 +77,83 @@ class ImportMatomoInstallAuditCommandTest extends TestCase
 
         @unlink($path);
     }
+
+    public function test_it_preserves_last_successful_audit_when_new_payload_only_reports_fetch_failed(): void
+    {
+        $property = WebProperty::factory()->create([
+            'slug' => 'steady-site',
+            'name' => 'Steady Site',
+        ]);
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '18',
+            'external_name' => 'Steady Site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '18',
+            'external_name' => 'Steady Site',
+            'expected_tracker_host' => 'stats.redirection.com.au',
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://steady.example.au/',
+            'detected_site_ids' => ['18'],
+            'detected_tracker_hosts' => ['stats.redirection.com.au'],
+            'summary' => 'Previous good audit.',
+            'checked_at' => now()->subDay(),
+            'raw_payload' => ['id_site' => '18', 'verdict' => 'installed_match'],
+        ]);
+
+        $path = $this->writeAuditPayload([
+            [
+                'id_site' => '18',
+                'site_name' => 'Steady Site',
+                'expected_tracker_host' => 'stats.redirection.com.au',
+                'verdict' => 'fetch_failed',
+                'best_url' => 'https://steady.example.au/',
+                'detected_site_ids' => [],
+                'detected_tracker_hosts' => [],
+                'summary' => 'Could not fetch any candidate URL to verify the Matomo install.',
+            ],
+        ]);
+
+        $this->assertSame(0, Artisan::call('analytics:import-matomo-audit', ['path' => $path]));
+
+        $audit = AnalyticsInstallAudit::query()->where('property_analytics_source_id', $source->id)->firstOrFail();
+        $this->assertSame('installed_match', $audit->install_verdict);
+        $this->assertSame('Previous good audit.', $audit->summary);
+
+        $observation = AnalyticsSourceObservation::query()
+            ->where('provider', 'matomo')
+            ->where('external_id', '18')
+            ->firstOrFail();
+
+        $this->assertSame('fetch_failed', $observation->install_verdict);
+
+        @unlink($path);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $audits
+     */
+    private function writeAuditPayload(array $audits): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'matomo-audit-');
+
+        file_put_contents($path, json_encode([
+            'source_system' => 'matamo',
+            'contract_version' => 1,
+            'report_type' => 'install_verification',
+            'generated_at' => now()->toIso8601String(),
+            'install_audits' => $audits,
+        ], JSON_PRETTY_PRINT));
+
+        return $path;
+    }
 }

--- a/tests/Feature/RefreshMatomoInstallAuditsCommandTest.php
+++ b/tests/Feature/RefreshMatomoInstallAuditsCommandTest.php
@@ -115,6 +115,74 @@ class RefreshMatomoInstallAuditsCommandTest extends TestCase
         ]);
     }
 
+    public function test_it_fails_when_expected_tracker_host_is_not_configured(): void
+    {
+        config()->set('services.matomo.base_url', null);
+
+        $property = $this->makeProperty('missing-config.example.au', 'Missing Config');
+
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '48',
+            'external_name' => 'Missing Config',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $this->assertSame(1, Artisan::call('analytics:refresh-matomo-install-audits'));
+        $this->assertDatabaseCount('analytics_install_audits', 0);
+    }
+
+    public function test_it_detects_same_origin_script_assets_with_variable_tracker_urls(): void
+    {
+        config()->set('services.matomo.base_url', 'https://stats.redirection.com.au');
+
+        $property = $this->makeProperty('bundled.example.au', 'Bundled Site');
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '58',
+            'external_name' => 'Bundled Site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        Http::fake([
+            'https://bundled.example.au/' => Http::response(
+                <<<'HTML'
+                <html>
+                    <head>
+                        <script src="/assets/app.js"></script>
+                    </head>
+                    <body>Bundled</body>
+                </html>
+                HTML,
+                200
+            ),
+            'https://bundled.example.au/assets/app.js' => Http::response(
+                <<<'JS'
+                const trackerBase = '//stats.redirection.com.au/';
+                var _paq = window._paq = window._paq || [];
+                _paq.push(['setSiteId', '58']);
+                _paq.push(['setTrackerUrl', trackerBase + 'matomo.php']);
+                JS,
+                200
+            ),
+        ]);
+
+        $this->assertSame(0, Artisan::call('analytics:refresh-matomo-install-audits'));
+
+        $audit = AnalyticsInstallAudit::query()
+            ->where('property_analytics_source_id', $source->id)
+            ->firstOrFail();
+
+        $this->assertSame('installed_match', $audit->install_verdict);
+        $this->assertSame(['58'], $audit->detected_site_ids);
+        $this->assertSame(['stats.redirection.com.au'], $audit->detected_tracker_hosts);
+    }
+
     private function makeProperty(string $domainName, string $name): WebProperty
     {
         $domain = Domain::factory()->create([

--- a/tests/Feature/RefreshMatomoInstallAuditsCommandTest.php
+++ b/tests/Feature/RefreshMatomoInstallAuditsCommandTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AnalyticsInstallAudit;
+use App\Models\Domain;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class RefreshMatomoInstallAuditsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_verifies_and_imports_live_matomo_install_audits(): void
+    {
+        config()->set('services.matomo.base_url', 'https://stats.redirection.com.au');
+
+        $property = $this->makeProperty('tracked.example.au', 'Tracked Site');
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '8',
+            'external_name' => 'Tracked Site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        Http::fake([
+            'https://tracked.example.au/' => Http::response(
+                <<<'HTML'
+                <html>
+                    <head>
+                        <script>
+                            var _paq = window._paq = window._paq || [];
+                            _paq.push(['setSiteId', '8']);
+                            _paq.push(['setTrackerUrl', 'https://stats.redirection.com.au/matomo.php']);
+                        </script>
+                        <script src="https://stats.redirection.com.au/matomo.js"></script>
+                    </head>
+                    <body>Tracked</body>
+                </html>
+                HTML,
+                200
+            ),
+        ]);
+
+        $exitCode = Artisan::call('analytics:refresh-matomo-install-audits');
+
+        $this->assertSame(0, $exitCode);
+
+        $audit = AnalyticsInstallAudit::query()
+            ->where('property_analytics_source_id', $source->id)
+            ->firstOrFail();
+
+        $this->assertSame('installed_match', $audit->install_verdict);
+        $this->assertSame('https://tracked.example.au/', $audit->best_url);
+        $this->assertSame(['8'], $audit->detected_site_ids);
+        $this->assertSame(['stats.redirection.com.au'], $audit->detected_tracker_hosts);
+    }
+
+    public function test_it_can_scope_verification_to_one_domain(): void
+    {
+        config()->set('services.matomo.base_url', 'https://stats.redirection.com.au');
+
+        $target = $this->makeProperty('target.example.au', 'Target');
+        $other = $this->makeProperty('other.example.au', 'Other');
+
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $target->id,
+            'provider' => 'matomo',
+            'external_id' => '18',
+            'external_name' => 'Target',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $other->id,
+            'provider' => 'matomo',
+            'external_id' => '28',
+            'external_name' => 'Other',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        Http::fake([
+            'https://target.example.au/' => Http::response(
+                "<script>var _paq=[];_paq.push(['setSiteId','18']);</script><script src=\"https://stats.redirection.com.au/matomo.js\"></script>",
+                200
+            ),
+            'https://other.example.au/' => Http::response(
+                "<script>var _paq=[];_paq.push(['setSiteId','28']);</script><script src=\"https://stats.redirection.com.au/matomo.js\"></script>",
+                200
+            ),
+        ]);
+
+        $exitCode = Artisan::call('analytics:refresh-matomo-install-audits', [
+            '--domain' => 'target.example.au',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('analytics_install_audits', 1);
+        $this->assertDatabaseHas('analytics_install_audits', [
+            'web_property_id' => $target->id,
+            'install_verdict' => 'installed_match',
+        ]);
+        $this->assertDatabaseMissing('analytics_install_audits', [
+            'web_property_id' => $other->id,
+        ]);
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://'.$domainName.'/',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+}


### PR DESCRIPTION
## Summary
- add a native Domain Monitor command that verifies linked sites for Matomo snippet signals and imports the resulting audit payload
- schedule the verifier before the automation coverage refresh so Matomo coverage stays current automatically
- cover the new verifier with focused feature tests, including domain scoping

## Testing
- ./vendor/bin/phpunit tests/Feature/RefreshMatomoInstallAuditsCommandTest.php tests/Feature/ImportMatomoInstallAuditCommandTest.php tests/Feature/MatomoCoverageQueueTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RefreshMatomoInstallAudits.php tests/Feature/RefreshMatomoInstallAuditsCommandTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
