### PR TITLE
Sync automation state tags

### DIFF
--- a/app/Console/Commands/SyncCoverageTags.php
+++ b/app/Console/Commands/SyncCoverageTags.php
@@ -63,7 +63,7 @@ class SyncCoverageTags extends Command
             ->map(fn (string $domain) => mb_strtolower(trim($domain)))
             ->values();
 
-        $properties = WebProperty::query()
+        $propertyGroups = WebProperty::query()
             ->when(
                 $targetDomains->isNotEmpty(),
                 fn ($query) => $query->whereHas('primaryDomain', fn ($domainQuery) => $domainQuery->whereIn('domain', $targetDomains->all()))
@@ -80,11 +80,11 @@ class SyncCoverageTags extends Command
             ->orderBy('name')
             ->get()
             ->groupBy(fn (WebProperty $property): string => (string) ($property->primary_domain_id ?? $property->id))
-            ->map(fn (Collection $group): ?WebProperty => $this->authoritativePropertyForPrimaryDomain($group))
+            ->map(fn (Collection $group): ?Collection => $group->isEmpty() ? null : $group)
             ->filter()
             ->values();
 
-        if ($properties->isEmpty()) {
+        if ($propertyGroups->isEmpty()) {
             $this->warn('No matching web properties found.');
 
             return self::SUCCESS;
@@ -107,32 +107,34 @@ class SyncCoverageTags extends Command
         $manualCsvPendingCount = 0;
         $domainsChanged = 0;
 
-        foreach ($properties as $property) {
+        foreach ($propertyGroups as $group) {
+            /** @var Collection<int, WebProperty> $group */
+            $property = $this->authoritativePropertyForPrimaryDomain($group);
+            if (! $property instanceof WebProperty) {
+                continue;
+            }
+
             $domain = $property->primaryDomainModel();
             if (! $domain instanceof Domain) {
                 continue;
             }
 
             $summary = $property->fullCoverageSummary();
-            $automationSummary = $property->automationCoverageSummary();
+            $automationSummary = $this->automationSummaryForPrimaryDomainGroup($group, $property);
             $desiredTagNames = $this->desiredTagNames($summary, $managedTagDefinitions->all());
-            $desiredAutomationTagNames = $this->desiredAutomationTagNames($automationSummary, $managedAutomationDefinitions->all());
+            $desiredAutomationTagNames = $this->desiredAutomationTagNames(
+                $automationSummary,
+                $managedAutomationDefinitions->all(),
+                $automationSummary['manual_csv_pending']
+            );
             $desiredManagedTagNames = $desiredTagNames->merge($desiredAutomationTagNames)->unique()->values();
-            $currentManagedTagNames = $domain->tags
+            $currentDomainTags = $domain->tags()->get();
+            $currentManagedTagNames = $currentDomainTags
                 ->pluck('name')
                 ->intersect($managedTagNames)
                 ->values();
             $attachNames = $desiredManagedTagNames->diff($currentManagedTagNames)->values();
             $detachNames = $currentManagedTagNames->diff($desiredManagedTagNames)->values();
-            $desiredTagIds = $desiredManagedTagNames
-                ->map(fn (string $name): string => $tagIds[$name])
-                ->values();
-            $retainedTagIds = $domain->tags
-                ->reject(fn (DomainTag $tag): bool => $managedTagNames->contains($tag->name))
-                ->pluck('id')
-                ->values();
-            $finalTagIds = $retainedTagIds->merge($desiredTagIds)->unique()->values();
-            $currentTagIds = $domain->tags->pluck('id')->values();
 
             if ($summary['required']) {
                 $requiredCount++;
@@ -159,7 +161,7 @@ class SyncCoverageTags extends Command
                 $automationGapCount++;
             }
 
-            if ($currentTagIds->sort()->values()->all() !== $finalTagIds->sort()->values()->all()) {
+            if ($attachNames->isNotEmpty() || $detachNames->isNotEmpty()) {
                 $domainsChanged++;
             }
 
@@ -194,7 +196,25 @@ class SyncCoverageTags extends Command
                 continue;
             }
 
-            $domain->tags()->sync($finalTagIds->all());
+            if ($attachNames->isEmpty() && $detachNames->isEmpty()) {
+                continue;
+            }
+
+            if ($attachNames->isNotEmpty()) {
+                $domain->tags()->syncWithoutDetaching(
+                    $attachNames
+                        ->map(fn (string $name): string => $tagIds[$name])
+                        ->all()
+                );
+            }
+
+            if ($detachNames->isNotEmpty()) {
+                $domain->tags()->detach(
+                    $detachNames
+                        ->map(fn (string $name): string => $tagIds[$name])
+                        ->all()
+                );
+            }
         }
 
         $this->table(
@@ -205,7 +225,7 @@ class SyncCoverageTags extends Command
         $this->table(
             ['Metric', 'Value'],
             [
-                ['properties_considered', (string) $properties->count()],
+                ['properties_considered', (string) $propertyGroups->count()],
                 ['coverage_required', (string) $requiredCount],
                 ['coverage_complete', (string) $completeCount],
                 ['coverage_gaps', (string) $gapCount],
@@ -260,7 +280,8 @@ class SyncCoverageTags extends Command
     /**
      * @param  array{
      *   required: bool,
-     *   status: string
+     *   status: string,
+     *   manual_csv_pending?: bool
      * }  $summary
      * @param  array<int|string, array{name: string, priority: int, color: string|null, description: string|null}>  $tagDefinitions
      * @return Collection<int, string>
@@ -305,7 +326,7 @@ class SyncCoverageTags extends Command
      * @param  array<int|string, array{name: string, priority: int, color: string|null, description: string|null}>  $tagDefinitions
      * @return Collection<int, string>
      */
-    private function desiredAutomationTagNames(array $summary, array $tagDefinitions): Collection
+    private function desiredAutomationTagNames(array $summary, array $tagDefinitions, bool $manualCsvPending = false): Collection
     {
         $requiredTag = $tagDefinitions['required'] ?? null;
         $completeTag = $tagDefinitions['complete'] ?? null;
@@ -330,7 +351,7 @@ class SyncCoverageTags extends Command
             $tagNames[] = $map['gap'];
         }
 
-        if ($summary['status'] === 'manual_csv_pending') {
+        if ($manualCsvPending || $summary['status'] === 'manual_csv_pending') {
             $tagNames[] = $map['manual_csv_pending'];
         }
 
@@ -341,6 +362,91 @@ class SyncCoverageTags extends Command
         ));
 
         return collect($filteredTagNames);
+    }
+
+    /**
+     * @param  Collection<int, WebProperty>  $properties
+     * @return array{
+     *   required: bool,
+     *   status: string,
+     *   label: string,
+     *   reason: string|null,
+     *   reasons: array<int, string>,
+     *   checks: array<string, mixed>,
+     *   manual_csv_pending: bool
+     * }
+     */
+    private function automationSummaryForPrimaryDomainGroup(Collection $properties, WebProperty $authoritativeProperty): array
+    {
+        $summaries = $properties
+            ->map(fn (WebProperty $property): array => $property->automationCoverageSummary())
+            ->values();
+
+        $requiredSummaries = $summaries
+            ->filter(fn (array $summary): bool => $summary['required'])
+            ->values();
+
+        if ($requiredSummaries->isEmpty()) {
+            $summary = $authoritativeProperty->automationCoverageSummary();
+            $summary['manual_csv_pending'] = false;
+
+            return $summary;
+        }
+
+        $manualCsvPending = $requiredSummaries->contains(
+            fn (array $summary): bool => $summary['status'] === 'manual_csv_pending'
+        );
+
+        $blockingStatuses = [
+            'needs_controller',
+            'needs_matomo_binding',
+            'needs_search_console_mapping',
+            'needs_onboarding',
+            'import_stale',
+            'needs_baseline_sync',
+        ];
+
+        $blockingSummary = $requiredSummaries->first(
+            fn (array $summary): bool => in_array($summary['status'], $blockingStatuses, true)
+        );
+
+        if (is_array($blockingSummary)) {
+            return [
+                'required' => true,
+                'status' => 'gap',
+                'label' => $blockingSummary['label'],
+                'reason' => $blockingSummary['reason'] ?? null,
+                'reasons' => $requiredSummaries->pluck('reason')->filter()->values()->all(),
+                'checks' => ['group' => $requiredSummaries->all()],
+                'manual_csv_pending' => $manualCsvPending,
+            ];
+        }
+
+        if ($manualCsvPending) {
+            $pendingSummary = $requiredSummaries->first(
+                fn (array $summary): bool => $summary['status'] === 'manual_csv_pending'
+            );
+
+            return [
+                'required' => true,
+                'status' => 'manual_csv_pending',
+                'label' => $pendingSummary['label'] ?? 'Manual CSV Pending',
+                'reason' => $pendingSummary['reason'] ?? null,
+                'reasons' => $requiredSummaries->pluck('reason')->filter()->values()->all(),
+                'checks' => ['group' => $requiredSummaries->all()],
+                'manual_csv_pending' => true,
+            ];
+        }
+
+        return [
+            'required' => true,
+            'status' => 'complete',
+            'label' => 'Complete',
+            'reason' => 'All grouped properties on this primary domain are automation-complete',
+            'reasons' => [],
+            'checks' => ['group' => $requiredSummaries->all()],
+            'manual_csv_pending' => false,
+        ];
     }
 
     /**

--- a/app/Console/Commands/SyncCoverageTags.php
+++ b/app/Console/Commands/SyncCoverageTags.php
@@ -24,7 +24,7 @@ class SyncCoverageTags extends Command
      *
      * @var string
      */
-    protected $description = 'Sync fleet coverage tags onto primary domains using repository, Matomo, and Search Console coverage state';
+    protected $description = 'Sync fleet coverage and automation checklist tags onto primary domains';
 
     /**
      * Execute the console command.
@@ -35,6 +35,9 @@ class SyncCoverageTags extends Command
         $managedTagDefinitions = collect((array) ($tagConfig['tags'] ?? []))
             ->map(fn ($tag): ?array => $this->normalizeTagDefinition($tag))
             ->filter();
+        $managedAutomationDefinitions = collect((array) ($tagConfig['automation_tags'] ?? []))
+            ->map(fn ($tag): ?array => $this->normalizeTagDefinition($tag))
+            ->filter();
 
         $manualExclusionTag = (array) ($tagConfig['manual_exclusion_tag'] ?? []);
         $manualExclusionDefinition = $this->normalizeTagDefinition($manualExclusionTag) !== null
@@ -43,7 +46,10 @@ class SyncCoverageTags extends Command
             ])
             : collect();
 
-        $tagDefinitions = $managedTagDefinitions->merge($manualExclusionDefinition);
+        $tagDefinitions = $managedTagDefinitions
+            ->values()
+            ->concat($managedAutomationDefinitions->values())
+            ->concat($manualExclusionDefinition->values());
 
         if ($managedTagDefinitions->isEmpty()) {
             $this->warn('No coverage tags are configured.');
@@ -87,12 +93,18 @@ class SyncCoverageTags extends Command
         $tagDefinitionsArray = $tagDefinitions->all();
         $tagIds = $this->ensureTags($tagDefinitionsArray, $dryRun);
         $coverageTagNames = $managedTagDefinitions->pluck('name')->values();
+        $automationTagNames = $managedAutomationDefinitions->pluck('name')->values();
+        $managedTagNames = $coverageTagNames->merge($automationTagNames)->unique()->values();
 
         $rows = [];
         $requiredCount = 0;
         $completeCount = 0;
         $gapCount = 0;
         $excludedCount = 0;
+        $automationRequiredCount = 0;
+        $automationCompleteCount = 0;
+        $automationGapCount = 0;
+        $manualCsvPendingCount = 0;
         $domainsChanged = 0;
 
         foreach ($properties as $property) {
@@ -102,14 +114,25 @@ class SyncCoverageTags extends Command
             }
 
             $summary = $property->fullCoverageSummary();
+            $automationSummary = $property->automationCoverageSummary();
             $desiredTagNames = $this->desiredTagNames($summary, $managedTagDefinitions->all());
-            $currentCoverageTagNames = $domain->tags
+            $desiredAutomationTagNames = $this->desiredAutomationTagNames($automationSummary, $managedAutomationDefinitions->all());
+            $desiredManagedTagNames = $desiredTagNames->merge($desiredAutomationTagNames)->unique()->values();
+            $currentManagedTagNames = $domain->tags
                 ->pluck('name')
-                ->intersect($coverageTagNames)
+                ->intersect($managedTagNames)
                 ->values();
-
-            $attachNames = $desiredTagNames->diff($currentCoverageTagNames)->values();
-            $detachNames = $currentCoverageTagNames->diff($desiredTagNames)->values();
+            $attachNames = $desiredManagedTagNames->diff($currentManagedTagNames)->values();
+            $detachNames = $currentManagedTagNames->diff($desiredManagedTagNames)->values();
+            $desiredTagIds = $desiredManagedTagNames
+                ->map(fn (string $name): string => $tagIds[$name])
+                ->values();
+            $retainedTagIds = $domain->tags
+                ->reject(fn (DomainTag $tag): bool => $managedTagNames->contains($tag->name))
+                ->pluck('id')
+                ->values();
+            $finalTagIds = $retainedTagIds->merge($desiredTagIds)->unique()->values();
+            $currentTagIds = $domain->tags->pluck('id')->values();
 
             if ($summary['required']) {
                 $requiredCount++;
@@ -123,7 +146,20 @@ class SyncCoverageTags extends Command
                 $excludedCount++;
             }
 
-            if ($attachNames->isNotEmpty() || $detachNames->isNotEmpty()) {
+            if ($automationSummary['required']) {
+                $automationRequiredCount++;
+            }
+
+            if ($automationSummary['status'] === 'complete') {
+                $automationCompleteCount++;
+            } elseif ($automationSummary['status'] === 'manual_csv_pending') {
+                $automationGapCount++;
+                $manualCsvPendingCount++;
+            } elseif ($automationSummary['status'] !== 'excluded') {
+                $automationGapCount++;
+            }
+
+            if ($currentTagIds->sort()->values()->all() !== $finalTagIds->sort()->values()->all()) {
                 $domainsChanged++;
             }
 
@@ -131,8 +167,11 @@ class SyncCoverageTags extends Command
                 $domain->domain,
                 $property->slug,
                 $summary['label'],
+                $automationSummary['label'],
                 $desiredTagNames->implode(', '),
+                $desiredAutomationTagNames->implode(', '),
                 $summary['reason'] ?? '-',
+                $automationSummary['reason'] ?? '-',
             ];
 
             if ($dryRun) {
@@ -155,25 +194,11 @@ class SyncCoverageTags extends Command
                 continue;
             }
 
-            if ($attachNames->isNotEmpty()) {
-                $domain->tags()->syncWithoutDetaching(
-                    $attachNames
-                        ->map(fn (string $name): string => $tagIds[$name])
-                        ->all()
-                );
-            }
-
-            if ($detachNames->isNotEmpty()) {
-                $domain->tags()->detach(
-                    $detachNames
-                        ->map(fn (string $name): string => $tagIds[$name])
-                        ->all()
-                );
-            }
+            $domain->tags()->sync($finalTagIds->all());
         }
 
         $this->table(
-            ['Domain', 'Property', 'Coverage', 'Desired tags', 'Reason'],
+            ['Domain', 'Property', 'Coverage', 'Automation', 'Coverage tags', 'Automation tags', 'Coverage reason', 'Automation reason'],
             $rows
         );
 
@@ -185,6 +210,10 @@ class SyncCoverageTags extends Command
                 ['coverage_complete', (string) $completeCount],
                 ['coverage_gaps', (string) $gapCount],
                 ['coverage_excluded', (string) $excludedCount],
+                ['automation_required', (string) $automationRequiredCount],
+                ['automation_complete', (string) $automationCompleteCount],
+                ['automation_gaps', (string) $automationGapCount],
+                ['manual_csv_pending', (string) $manualCsvPendingCount],
                 ['domains_changed', (string) $domainsChanged],
                 ['dry_run', $dryRun ? 'true' : 'false'],
             ]
@@ -257,6 +286,52 @@ class SyncCoverageTags extends Command
             $tagNames[] = $map['complete'];
         } else {
             $tagNames[] = $map['gap'];
+        }
+
+        /** @var array<int, string> $filteredTagNames */
+        $filteredTagNames = array_values(array_filter(
+            $tagNames,
+            fn (string $name): bool => $name !== ''
+        ));
+
+        return collect($filteredTagNames);
+    }
+
+    /**
+     * @param  array{
+     *   required: bool,
+     *   status: string
+     * }  $summary
+     * @param  array<int|string, array{name: string, priority: int, color: string|null, description: string|null}>  $tagDefinitions
+     * @return Collection<int, string>
+     */
+    private function desiredAutomationTagNames(array $summary, array $tagDefinitions): Collection
+    {
+        $requiredTag = $tagDefinitions['required'] ?? null;
+        $completeTag = $tagDefinitions['complete'] ?? null;
+        $gapTag = $tagDefinitions['gap'] ?? null;
+        $manualCsvPendingTag = $tagDefinitions['manual_csv_pending'] ?? null;
+        $map = [
+            'required' => is_array($requiredTag) ? $requiredTag['name'] : '',
+            'complete' => is_array($completeTag) ? $completeTag['name'] : '',
+            'gap' => is_array($gapTag) ? $gapTag['name'] : '',
+            'manual_csv_pending' => is_array($manualCsvPendingTag) ? $manualCsvPendingTag['name'] : '',
+        ];
+
+        if (! $summary['required']) {
+            return collect();
+        }
+
+        $tagNames = [$map['required']];
+
+        if ($summary['status'] === 'complete') {
+            $tagNames[] = $map['complete'];
+        } else {
+            $tagNames[] = $map['gap'];
+        }
+
+        if ($summary['status'] === 'manual_csv_pending') {
+            $tagNames[] = $map['manual_csv_pending'];
         }
 
         /** @var array<int, string> $filteredTagNames */

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -600,5 +600,31 @@ return [
                 'description' => 'This managed domain should be fully covered, but one or more coverage controls still need attention.',
             ],
         ],
+        'automation_tags' => [
+            'required' => [
+                'name' => 'automation.required',
+                'priority' => 70,
+                'color' => '#7c3aed',
+                'description' => 'This managed domain should participate in the full automation checklist.',
+            ],
+            'complete' => [
+                'name' => 'automation.complete',
+                'priority' => 60,
+                'color' => '#16a34a',
+                'description' => 'This managed domain has automation coverage in place, including manual CSV evidence where required.',
+            ],
+            'gap' => [
+                'name' => 'automation.gap',
+                'priority' => 65,
+                'color' => '#dc2626',
+                'description' => 'This managed domain still has one or more automation checklist gaps.',
+            ],
+            'manual_csv_pending' => [
+                'name' => 'automation.manual_csv_pending',
+                'priority' => 68,
+                'color' => '#ca8a04',
+                'description' => 'Automation is in place, but manual Search Console CSV evidence is still pending for this domain.',
+            ],
+        ],
     ],
 ];

--- a/tests/Feature/SyncCoverageTagsCommandTest.php
+++ b/tests/Feature/SyncCoverageTagsCommandTest.php
@@ -12,6 +12,7 @@ use App\Models\SearchConsoleCoverageStatus;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 use Tests\TestCase;
 
 class SyncCoverageTagsCommandTest extends TestCase
@@ -89,7 +90,7 @@ class SyncCoverageTagsCommandTest extends TestCase
             'matomo_site_id' => '101',
             'search_console_property_uri' => 'sc-domain:complete.example.au',
             'search_type' => 'web',
-            'import_method' => 'manual',
+            'import_method' => 'matomo_plus_manual_csv',
             'clicks' => 10,
             'impressions' => 100,
             'ctr' => 0.1,
@@ -116,6 +117,28 @@ class SyncCoverageTagsCommandTest extends TestCase
             'is_canonical' => true,
         ]);
 
+        $csvPendingDomain = Domain::factory()->create([
+            'domain' => 'csv-pending.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'Astro',
+        ]);
+        $csvPendingProperty = WebProperty::factory()->create([
+            'slug' => 'csv-pending-site',
+            'name' => 'CSV Pending Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $csvPendingDomain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $csvPendingProperty->id,
+            'domain_id' => $csvPendingDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+        $csvPendingSource = $this->attachRepositoryAndCoverage($csvPendingProperty, '102');
+        $this->attachBaselineForSource($csvPendingProperty, $csvPendingSource, 'matomo_api');
+
         $excludedDomain = Domain::factory()->create([
             'domain' => 'parked.example.au',
             'is_active' => true,
@@ -141,6 +164,11 @@ class SyncCoverageTagsCommandTest extends TestCase
             'priority' => 85,
             'color' => '#dc2626',
         ]);
+        $wrongAutomationTag = DomainTag::create([
+            'name' => 'automation.gap',
+            'priority' => 65,
+            'color' => '#dc2626',
+        ]);
         $requiredTag = DomainTag::create([
             'name' => 'coverage.required',
             'priority' => 90,
@@ -151,20 +179,28 @@ class SyncCoverageTagsCommandTest extends TestCase
             'priority' => 95,
             'color' => '#6b7280',
         ]);
-        $excludedDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id, $manualExclusionTag->id]);
-        $completeDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id]);
+        $excludedDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id, $wrongAutomationTag->id, $manualExclusionTag->id]);
+        $completeDomain->tags()->sync([$requiredTag->id, $wrongGapTag->id, $wrongAutomationTag->id]);
 
-        $this->artisan('coverage:sync-tags')
-            ->assertSuccessful();
+        $this->assertSame('complete', $completeProperty->fresh()->fullCoverageSummary()['status']);
+        $this->assertSame('complete', $completeProperty->fresh()->automationCoverageSummary()['status']);
+        $this->assertSame('manual_csv_pending', $csvPendingProperty->fresh()->automationCoverageSummary()['status']);
+
+        $this->assertSame(0, Artisan::call('coverage:sync-tags'));
 
         $this->assertSame(
-            ['coverage.complete', 'coverage.required'],
+            ['automation.complete', 'automation.required', 'coverage.complete', 'coverage.required'],
             $completeDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
         );
 
         $this->assertSame(
-            ['coverage.gap', 'coverage.required'],
+            ['automation.gap', 'automation.required', 'coverage.gap', 'coverage.required'],
             $gapDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+
+        $this->assertSame(
+            ['automation.gap', 'automation.manual_csv_pending', 'automation.required', 'coverage.complete', 'coverage.required'],
+            $csvPendingDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
         );
 
         $this->assertSame(['coverage.excluded'], $excludedDomain->fresh()->tags()->pluck('name')->all());
@@ -193,8 +229,7 @@ class SyncCoverageTagsCommandTest extends TestCase
             'is_canonical' => true,
         ]);
 
-        $this->artisan('coverage:sync-tags', ['--dry-run' => true])
-            ->assertSuccessful();
+        $this->assertSame(0, Artisan::call('coverage:sync-tags', ['--dry-run' => true]));
 
         $this->assertDatabaseCount('domain_tags', 0);
         $this->assertSame([], $domain->fresh()->tags()->pluck('name')->all());
@@ -225,12 +260,12 @@ class SyncCoverageTagsCommandTest extends TestCase
             'is_canonical' => true,
         ]);
 
-        $this->artisan('coverage:sync-tags', [
+        $this->assertSame(0, Artisan::call('coverage:sync-tags', [
             '--domain' => ['target.example.au'],
-        ])->assertSuccessful();
+        ]));
 
         $this->assertSame(
-            ['coverage.complete', 'coverage.required'],
+            ['automation.complete', 'automation.required', 'coverage.complete', 'coverage.required'],
             $targetDomain->fresh()->tags()->orderBy('name')->pluck('name')->all()
         );
         $this->assertSame([], $untouchedDomain->fresh()->tags()->pluck('name')->all());
@@ -260,9 +295,9 @@ class SyncCoverageTagsCommandTest extends TestCase
             'is_canonical' => true,
         ]);
 
-        $this->artisan('coverage:sync-tags', [
+        $this->assertSame(0, Artisan::call('coverage:sync-tags', [
             '--domain' => ['missing.example.au'],
-        ])->assertSuccessful();
+        ]));
 
         $this->assertDatabaseCount('domain_tags', 0);
         $this->assertSame([], $domain->fresh()->tags()->pluck('name')->all());
@@ -307,12 +342,12 @@ class SyncCoverageTagsCommandTest extends TestCase
             'is_canonical' => true,
         ]);
         $canonicalSource = $this->attachRepositoryAndCoverage($canonicalCompleteProperty, '301');
-        $this->attachBaselineForSource($canonicalCompleteProperty, $canonicalSource, 'manual');
+        $this->attachBaselineForSource($canonicalCompleteProperty, $canonicalSource, 'matomo_plus_manual_csv');
 
-        $this->artisan('coverage:sync-tags')->assertSuccessful();
+        $this->assertSame(0, Artisan::call('coverage:sync-tags'));
 
         $this->assertSame(
-            ['coverage.complete', 'coverage.required'],
+            ['automation.complete', 'automation.required', 'coverage.complete', 'coverage.required'],
             $domain->fresh()->tags()->orderBy('name')->pluck('name')->all()
         );
     }
@@ -346,6 +381,32 @@ class SyncCoverageTagsCommandTest extends TestCase
                     'description' => 'Gap',
                 ],
             ],
+            'automation_tags' => [
+                'required' => [
+                    'name' => 'automation.required',
+                    'priority' => 70,
+                    'color' => '#7c3aed',
+                    'description' => 'Automation required',
+                ],
+                'complete' => [
+                    'name' => 'automation.complete',
+                    'priority' => 60,
+                    'color' => '#16a34a',
+                    'description' => 'Automation complete',
+                ],
+                'gap' => [
+                    'name' => 'automation.gap',
+                    'priority' => 65,
+                    'color' => '#dc2626',
+                    'description' => 'Automation gap',
+                ],
+                'manual_csv_pending' => [
+                    'name' => 'automation.manual_csv_pending',
+                    'priority' => 68,
+                    'color' => '#ca8a04',
+                    'description' => 'Manual CSV pending',
+                ],
+            ],
         ]);
     }
 
@@ -372,7 +433,7 @@ class SyncCoverageTagsCommandTest extends TestCase
         ]);
 
         $source = $this->attachRepositoryAndCoverage($property, $matomoId);
-        $this->attachBaselineForSource($property, $source, 'manual');
+        $this->attachBaselineForSource($property, $source, 'matomo_plus_manual_csv');
 
         return $domain;
     }

--- a/tests/Feature/SyncCoverageTagsCommandTest.php
+++ b/tests/Feature/SyncCoverageTagsCommandTest.php
@@ -347,7 +347,78 @@ class SyncCoverageTagsCommandTest extends TestCase
         $this->assertSame(0, Artisan::call('coverage:sync-tags'));
 
         $this->assertSame(
-            ['automation.complete', 'automation.required', 'coverage.complete', 'coverage.required'],
+            ['automation.gap', 'automation.required', 'coverage.complete', 'coverage.required'],
+            $domain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+    }
+
+    public function test_shared_primary_domain_surfaces_non_authoritative_manual_csv_backlog_in_automation_tags(): void
+    {
+        $this->setCoverageTagConfig();
+
+        $domain = Domain::factory()->create([
+            'domain' => 'shared-automation.example.au',
+            'is_active' => true,
+            'dns_config_name' => 'DNS Hosting',
+            'platform' => 'WordPress',
+        ]);
+
+        $canonicalCompleteProperty = WebProperty::factory()->create([
+            'slug' => 'canonical-complete-site',
+            'name' => 'Canonical Complete Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $canonicalCompleteProperty->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+        $canonicalSource = $this->attachRepositoryAndCoverage($canonicalCompleteProperty, '401');
+        $this->attachBaselineForSource($canonicalCompleteProperty, $canonicalSource, 'matomo_plus_manual_csv');
+
+        $nonCanonicalCsvPendingProperty = WebProperty::factory()->create([
+            'slug' => 'noncanonical-csv-site',
+            'name' => 'Noncanonical CSV Site',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $nonCanonicalCsvPendingProperty->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => false,
+        ]);
+        $nonCanonicalSource = $this->attachRepositoryAndCoverage($nonCanonicalCsvPendingProperty, '402');
+        $this->attachBaselineForSource($nonCanonicalCsvPendingProperty, $nonCanonicalSource, 'matomo_api');
+
+        $this->assertSame(0, Artisan::call('coverage:sync-tags'));
+
+        $this->assertSame(
+            ['automation.gap', 'automation.manual_csv_pending', 'automation.required', 'coverage.complete', 'coverage.required'],
+            $domain->fresh()->tags()->orderBy('name')->pluck('name')->all()
+        );
+    }
+
+    public function test_it_preserves_unrelated_non_managed_domain_tags(): void
+    {
+        $this->setCoverageTagConfig();
+
+        $domain = $this->createCompleteCoverageProperty('preserve-tags.example.au', 'Preserve Tags Site', '501');
+        $customTag = DomainTag::create([
+            'name' => 'ops.watchlist',
+            'priority' => 40,
+            'color' => '#0f766e',
+        ]);
+        $domain->tags()->sync([$customTag->id]);
+
+        $this->assertSame(0, Artisan::call('coverage:sync-tags'));
+
+        $this->assertSame(
+            ['automation.complete', 'automation.required', 'coverage.complete', 'coverage.required', 'ops.watchlist'],
             $domain->fresh()->tags()->orderBy('name')->pluck('name')->all()
         );
     }


### PR DESCRIPTION
## Summary
- extend coverage tag sync to also project automation checklist state onto primary domains
- add explicit automation tags for complete, gap, required, and manual CSV pending domains
- cover the new tag behavior with focused sync-tag tests

## Testing
- ./vendor/bin/phpunit tests/Feature/SyncCoverageTagsCommandTest.php tests/Feature/AutomationCoverageQueueTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/SyncCoverageTags.php tests/Feature/SyncCoverageTagsCommandTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
