### PR TITLE
Add manual CSV backlog queue

### DIFF
--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -16,7 +16,6 @@ class ManualCsvBacklogQueue extends Component
         $properties = WebProperty::query()
             ->with([
                 'primaryDomain.tags',
-                'primaryDomain.latestSeoBaseline',
                 'repositories',
                 'analyticsSources',
                 'analyticsSources.latestInstallAudit',
@@ -27,9 +26,17 @@ class ManualCsvBacklogQueue extends Component
             ->orderBy('name')
             ->get();
 
+        $baselinesByProperty = DomainSeoBaseline::query()
+            ->whereIn('web_property_id', $properties->pluck('id'))
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->unique('web_property_id')
+            ->keyBy('web_property_id');
+
         $pendingItems = $properties
-            ->map(function (WebProperty $property): ?array {
-                $baseline = $this->latestBaselineForProperty($property);
+            ->map(function (WebProperty $property) use ($baselinesByProperty): ?array {
+                $baseline = $baselinesByProperty->get($property->id);
                 if (! $baseline instanceof DomainSeoBaseline) {
                     return null;
                 }
@@ -37,6 +44,7 @@ class ManualCsvBacklogQueue extends Component
                 $repository = $property->repositoryCoverageSummary();
                 $matomo = $property->matomoCoverageSummary();
                 $searchConsole = $property->searchConsoleCoverageSummary();
+                $matomoSource = $property->primaryAnalyticsSource('matomo');
 
                 if (
                     $repository['status'] !== 'covered'
@@ -57,8 +65,8 @@ class ManualCsvBacklogQueue extends Component
                     ],
                     'primary_domain' => $property->primaryDomainName(),
                     'repository' => $property->repositories->first(),
-                    'matomo_source' => $property->primaryAnalyticsSource('matomo'),
-                    'search_console_coverage' => $property->primaryAnalyticsSource('matomo')?->latestSearchConsoleCoverage,
+                    'matomo_source' => $matomoSource,
+                    'search_console_coverage' => $matomoSource?->latestSearchConsoleCoverage,
                     'latest_baseline' => $baseline,
                 ];
             })
@@ -87,14 +95,5 @@ class ManualCsvBacklogQueue extends Component
                     ->count(),
             ],
         ]);
-    }
-
-    private function latestBaselineForProperty(WebProperty $property): ?DomainSeoBaseline
-    {
-        return DomainSeoBaseline::query()
-            ->where('web_property_id', $property->id)
-            ->latest('captured_at')
-            ->latest('created_at')
-            ->first();
     }
 }

--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\DomainSeoBaseline;
+use App\Models\WebProperty;
+use Illuminate\Support\Collection;
+use Livewire\Component;
+
+class ManualCsvBacklogQueue extends Component
+{
+    public function render(): \Illuminate\View\View
+    {
+        $manualCsvTagName = (string) config('domain_monitor.coverage_tags.automation_tags.manual_csv_pending.name', 'automation.manual_csv_pending');
+
+        $properties = WebProperty::query()
+            ->with([
+                'primaryDomain.tags',
+                'primaryDomain.latestSeoBaseline',
+                'repositories',
+                'analyticsSources',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain.tags',
+            ])
+            ->whereHas('primaryDomain.tags', fn ($query) => $query->where('name', $manualCsvTagName))
+            ->orderBy('name')
+            ->get();
+
+        $pendingItems = $properties
+            ->map(function (WebProperty $property): ?array {
+                $baseline = $this->latestBaselineForProperty($property);
+                if (! $baseline instanceof DomainSeoBaseline) {
+                    return null;
+                }
+
+                $repository = $property->repositoryCoverageSummary();
+                $matomo = $property->matomoCoverageSummary();
+                $searchConsole = $property->searchConsoleCoverageSummary();
+
+                if (
+                    $repository['status'] !== 'covered'
+                    || $matomo['status'] !== 'covered'
+                    || $searchConsole['status'] !== 'covered'
+                    || $baseline->captured_at->lt(now()->subDays(30))
+                    || $baseline->import_method === 'matomo_plus_manual_csv'
+                ) {
+                    return null;
+                }
+
+                return [
+                    'property' => $property,
+                    'automation' => [
+                        'status' => 'manual_csv_pending',
+                        'label' => 'Manual CSV pending',
+                        'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
+                    ],
+                    'primary_domain' => $property->primaryDomainName(),
+                    'repository' => $property->repositories->first(),
+                    'matomo_source' => $property->primaryAnalyticsSource('matomo'),
+                    'search_console_coverage' => $property->primaryAnalyticsSource('matomo')?->latestSearchConsoleCoverage,
+                    'latest_baseline' => $baseline,
+                ];
+            })
+            ->filter()
+            ->values();
+
+        /** @var Collection<int, array{
+         * property: WebProperty,
+         * automation: array<string, mixed>,
+         * primary_domain: string|null,
+         * repository: mixed,
+         * matomo_source: mixed,
+         * search_console_coverage: mixed,
+         * latest_baseline: mixed
+         * }> $pendingItems
+         */
+
+        return view('livewire.manual-csv-backlog-queue', [
+            'pendingItems' => $pendingItems,
+            'stats' => [
+                'pending_properties' => $pendingItems->count(),
+                'pending_domains' => $pendingItems
+                    ->pluck('primary_domain')
+                    ->filter(fn (?string $domain): bool => is_string($domain) && $domain !== '')
+                    ->unique()
+                    ->count(),
+            ],
+        ]);
+    }
+
+    private function latestBaselineForProperty(WebProperty $property): ?DomainSeoBaseline
+    {
+        return DomainSeoBaseline::query()
+            ->where('web_property_id', $property->id)
+            ->latest('captured_at')
+            ->latest('created_at')
+            ->first();
+    }
+}

--- a/resources/views/automation-coverage/index.blade.php
+++ b/resources/views/automation-coverage/index.blade.php
@@ -1,8 +1,13 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            Automation Coverage
-        </h2>
+        <div class="flex items-center justify-between gap-4">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                Automation Coverage
+            </h2>
+            <a href="{{ route('manual-csv-backlog.index') }}" wire:navigate class="inline-flex items-center rounded-md border border-yellow-300 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20 px-3 py-2 text-sm font-medium text-yellow-900 dark:text-yellow-200 hover:bg-yellow-100 dark:hover:bg-yellow-900/30">
+                Open Manual CSV Backlog
+            </a>
+        </div>
     </x-slot>
 
     <div class="py-12">

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -45,6 +45,9 @@ new class extends Component
                     <x-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
                         {{ __('Automation') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('manual-csv-backlog.index')" :active="request()->routeIs('manual-csv-backlog.*')" wire:navigate>
+                        {{ __('CSV Backlog') }}
+                    </x-nav-link>
                     <x-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                         {{ __('Search Console') }}
                     </x-nav-link>
@@ -123,6 +126,9 @@ new class extends Component
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('automation-coverage.index')" :active="request()->routeIs('automation-coverage.*')" wire:navigate>
                 {{ __('Automation') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('manual-csv-backlog.index')" :active="request()->routeIs('manual-csv-backlog.*')" wire:navigate>
+                {{ __('CSV Backlog') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('search-console-coverage.index')" :active="request()->routeIs('search-console-coverage.*')" wire:navigate>
                 {{ __('Search Console') }}

--- a/resources/views/livewire/manual-csv-backlog-queue.blade.php
+++ b/resources/views/livewire/manual-csv-backlog-queue.blade.php
@@ -1,0 +1,81 @@
+<div class="space-y-6">
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
+        <div class="p-6">
+            <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Manual Search Console CSV Backlog</h3>
+            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                These properties are fully automated up to the final Search Console CSV evidence step. Use this queue to clear the remaining manual backlog.
+            </p>
+        </div>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        @foreach([
+            ['id' => 'pending_properties', 'label' => 'Pending Properties'],
+            ['id' => 'pending_domains', 'label' => 'Pending Domains'],
+        ] as $stat)
+            <div class="rounded-lg bg-white dark:bg-gray-800 shadow-xs p-4">
+                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $stat['label'] }}</div>
+                <div class="mt-2 text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats[$stat['id']] }}</div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
+        <div class="p-6">
+            <div class="flex items-center justify-between">
+                <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">Pending Evidence</h4>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ $pendingItems->count() }} properties</span>
+            </div>
+
+            <div class="mt-4 space-y-3">
+                @if($pendingItems->isEmpty())
+                    <p class="text-sm text-gray-500 dark:text-gray-400">No properties are waiting on manual Search Console CSV evidence right now.</p>
+                @else
+                    @foreach($pendingItems as $item)
+                        <div class="rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50/60 dark:bg-yellow-900/10 text-yellow-800 dark:text-yellow-200 p-4">
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <div>
+                                    <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $item['property']->name }}</div>
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        {{ $item['primary_domain'] ?? 'No primary domain' }}
+                                        @if($item['matomo_source'])
+                                            · Matomo {{ $item['matomo_source']->external_id }}
+                                        @endif
+                                    </div>
+                                </div>
+                                <a href="{{ route('web-properties.show', $item['property']->slug) }}" wire:navigate class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                    Open property
+                                </a>
+                            </div>
+
+                            <div class="mt-2 text-sm">{{ $item['automation']['reason'] }}</div>
+
+                            @if($item['repository'])
+                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    Controller: {{ $item['repository']->repo_name }}
+                                </div>
+                            @endif
+
+                            @if($item['search_console_coverage'])
+                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    {{ $item['search_console_coverage']->mappingStateLabel() }}
+                                    @if($item['search_console_coverage']->property_uri)
+                                        · {{ $item['search_console_coverage']->property_uri }}
+                                    @endif
+                                    · {{ $item['search_console_coverage']->freshnessLabel() }}
+                                </div>
+                            @endif
+
+                            @if($item['latest_baseline'])
+                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    Latest baseline {{ $item['latest_baseline']->captured_at->format('Y-m-d') }}
+                                    · {{ $item['latest_baseline']->importMethodLabel() }}
+                                </div>
+                            @endif
+                        </div>
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/manual-csv-backlog/index.blade.php
+++ b/resources/views/manual-csv-backlog/index.blade.php
@@ -1,0 +1,13 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Manual CSV Backlog
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <livewire:manual-csv-backlog-queue />
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return view('automation-coverage.index');
     })->name('automation-coverage.index');
 
+    Route::get('/manual-csv-backlog', function () {
+        return view('manual-csv-backlog.index');
+    })->name('manual-csv-backlog.index');
+
     Route::get('/search-console-coverage', function () {
         return view('search-console-coverage.index');
     })->name('search-console-coverage.index');

--- a/tests/Feature/ManualCsvBacklogQueueTest.php
+++ b/tests/Feature/ManualCsvBacklogQueueTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\ManualCsvBacklogQueue;
+use App\Models\AnalyticsInstallAudit;
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\DomainTag;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ManualCsvBacklogQueueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_manual_csv_backlog_queue(): void
+    {
+        $user = User::factory()->create();
+        $manualCsvTag = DomainTag::create([
+            'name' => 'automation.manual_csv_pending',
+            'priority' => 68,
+            'color' => '#ca8a04',
+        ]);
+
+        $pendingProperty = $this->makeProperty('csv-pending.example.au', 'CSV Pending Site');
+        $this->attachRepository($pendingProperty);
+        $pendingSource = $this->attachMatomo($pendingProperty, '701');
+        $this->attachInstallAudit($pendingProperty, $pendingSource);
+        $this->attachCoverage($pendingProperty, $pendingSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($pendingProperty, $pendingSource, 'matomo_api');
+        $pendingProperty->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $completeProperty = $this->makeProperty('complete.example.au', 'Complete Site');
+        $this->attachRepository($completeProperty);
+        $completeSource = $this->attachMatomo($completeProperty, '702');
+        $this->attachInstallAudit($completeProperty, $completeSource);
+        $this->attachCoverage($completeProperty, $completeSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($completeProperty, $completeSource, 'matomo_plus_manual_csv');
+
+        $sharedComplete = $this->makeProperty('shared.example.au', 'Shared Complete');
+        $this->attachRepository($sharedComplete);
+        $sharedCompleteSource = $this->attachMatomo($sharedComplete, '703');
+        $this->attachInstallAudit($sharedComplete, $sharedCompleteSource);
+        $this->attachCoverage($sharedComplete, $sharedCompleteSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($sharedComplete, $sharedCompleteSource, 'matomo_plus_manual_csv');
+
+        $sharedPending = WebProperty::factory()->create([
+            'slug' => 'shared-pending-site',
+            'name' => 'Shared Pending',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $sharedComplete->primary_domain_id,
+        ]);
+        WebPropertyDomain::create([
+            'web_property_id' => $sharedPending->id,
+            'domain_id' => $sharedComplete->primary_domain_id,
+            'usage_type' => 'primary',
+            'is_canonical' => false,
+        ]);
+        $this->attachRepository($sharedPending);
+        $sharedPendingSource = $this->attachMatomo($sharedPending, '704');
+        $this->attachInstallAudit($sharedPending, $sharedPendingSource);
+        $this->attachCoverage($sharedPending, $sharedPendingSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($sharedPending, $sharedPendingSource, 'matomo_api');
+        $sharedPending->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $response = $this->actingAs($user)->get('/manual-csv-backlog');
+
+        $response->assertOk();
+        $response->assertSee('Manual Search Console CSV Backlog');
+        $response->assertSee('CSV Pending Site');
+        $response->assertSee('Shared Pending');
+        $response->assertDontSee('Complete Site');
+        $response->assertDontSee('Shared Complete');
+
+        Livewire::test(ManualCsvBacklogQueue::class)
+            ->assertViewHas('stats', function (array $stats): bool {
+                return $stats['pending_properties'] === 2
+                    && $stats['pending_domains'] === 2;
+            })
+            ->assertViewHas('pendingItems', function (Collection $items): bool {
+                $names = $items->map(fn (array $item): string => $item['property']->name)->all();
+
+                sort($names);
+
+                return $names === ['CSV Pending Site', 'Shared Pending'];
+            });
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+
+    private function attachRepository(WebProperty $property): void
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachMatomo(WebProperty $property, string $externalId): PropertyAnalyticsSource
+    {
+        return PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $externalId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachInstallAudit(WebProperty $property, PropertyAnalyticsSource $source): void
+    {
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $source->external_id,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://'.$property->primaryDomainName().'/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+    }
+
+    private function attachCoverage(WebProperty $property, PropertyAnalyticsSource $source, string $mappingState, ?string $latestMetricDate): void
+    {
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => $mappingState,
+            'property_uri' => $mappingState === 'domain_property'
+                ? 'sc-domain:'.$property->primaryDomainName()
+                : 'https://'.$property->primaryDomainName().'/',
+            'property_type' => $mappingState === 'domain_property' ? 'domain' : 'url-prefix',
+            'latest_metric_date' => $latestMetricDate,
+            'checked_at' => now(),
+        ]);
+    }
+
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'source_provider' => 'search_console',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.4,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Manual CSV Backlog page for properties still waiting on Search Console CSV evidence
- surface the backlog from automation coverage with a direct CTA and navigation entry
- cover the shared-domain backlog case with a focused feature test

## Testing
- ./vendor/bin/phpunit tests/Feature/ManualCsvBacklogQueueTest.php tests/Feature/AutomationCoverageQueueTest.php
- ./vendor/bin/phpstan analyse app/Livewire/ManualCsvBacklogQueue.php tests/Feature/ManualCsvBacklogQueueTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
