### PR TITLE
Add web property automation checklist

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -21,7 +21,6 @@ class WebPropertyDetail extends Component
         $this->property = WebProperty::query()
             ->with([
                 'primaryDomain',
-                'latestSeoBaseline',
                 'repositories',
                 'analyticsSources',
                 'analyticsSources.latestInstallAudit',

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -21,9 +21,11 @@ class WebPropertyDetail extends Component
         $this->property = WebProperty::query()
             ->with([
                 'primaryDomain',
+                'latestSeoBaseline',
                 'repositories',
                 'analyticsSources',
                 'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
                 'propertyDomains.domain' => function ($query): void {
                     $query->withLatestCheckStatuses()
                         ->with([

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -110,14 +109,6 @@ class WebProperty extends Model
     public function analyticsSources(): HasMany
     {
         return $this->hasMany(PropertyAnalyticsSource::class)->orderByDesc('is_primary');
-    }
-
-    /**
-     * @return HasOne<DomainSeoBaseline, $this>
-     */
-    public function latestSeoBaseline(): HasOne
-    {
-        return $this->hasOne(DomainSeoBaseline::class)->orderByDesc('captured_at')->orderByDesc('created_at');
     }
 
     /**

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -109,6 +110,14 @@ class WebProperty extends Model
     public function analyticsSources(): HasMany
     {
         return $this->hasMany(PropertyAnalyticsSource::class)->orderByDesc('is_primary');
+    }
+
+    /**
+     * @return HasOne<DomainSeoBaseline, $this>
+     */
+    public function latestSeoBaseline(): HasOne
+    {
+        return $this->hasOne(DomainSeoBaseline::class)->orderByDesc('captured_at')->orderByDesc('created_at');
     }
 
     /**

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -189,8 +189,8 @@
                                     'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
                                     'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' => $summary['status'] === 'covered',
                                     'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' => in_array($summary['status'], ['pending', 'needs_sync', 'stale', 'needs_import', 'stale_import', 'bound_unverified', 'blocked'], true),
-                                    'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300' => in_array($summary['status'], ['needs_controller', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
-                                    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' => ! in_array($summary['status'], ['covered', 'pending', 'needs_sync', 'stale', 'needs_import', 'stale_import', 'bound_unverified', 'blocked', 'needs_controller', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
+                                    'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300' => in_array($summary['status'], ['needs_repository', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
+                                    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' => ! in_array($summary['status'], ['covered', 'pending', 'needs_sync', 'stale', 'needs_import', 'stale_import', 'bound_unverified', 'blocked', 'needs_repository', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
                                 ])>
                                     {{ $summary['label'] }}
                                 </span>

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -6,6 +6,86 @@
             $repositories = $property->repositories;
             $analyticsSources = $property->analyticsSources;
             $tags = collect($property->tagSummaries());
+            $repositoryCoverage = $property->repositoryCoverageSummary();
+            $matomoCoverage = $property->matomoCoverageSummary();
+            $searchConsoleCoverage = $property->searchConsoleCoverageSummary();
+            $automationCoverage = $property->automationCoverageSummary();
+            $latestPropertyBaseline = $property->relationLoaded('latestSeoBaseline')
+                ? $property->latestSeoBaseline
+                : $property->latestSeoBaseline()->first();
+            $baselineCoverage = match (true) {
+                $searchConsoleCoverage['status'] !== 'covered' => [
+                    'status' => 'blocked',
+                    'label' => 'Blocked',
+                    'reason' => $searchConsoleCoverage['reason'],
+                    'queue' => route('automation-coverage.index'),
+                ],
+                ! $latestPropertyBaseline instanceof \App\Models\DomainSeoBaseline => [
+                    'status' => 'needs_sync',
+                    'label' => 'Needs baseline sync',
+                    'reason' => 'Search Console data is ready, but no property baseline has been synced yet',
+                    'queue' => route('automation-coverage.index'),
+                ],
+                $latestPropertyBaseline->captured_at->lt(now()->subDays(30)) => [
+                    'status' => 'stale',
+                    'label' => 'Baseline stale',
+                    'reason' => 'The latest property baseline is older than 30 days',
+                    'queue' => route('automation-coverage.index'),
+                ],
+                default => [
+                    'status' => 'covered',
+                    'label' => 'Covered',
+                    'reason' => sprintf('Latest property baseline captured %s', $latestPropertyBaseline->captured_at->toDateString()),
+                    'queue' => route('automation-coverage.index'),
+                ],
+            };
+            $manualCsvCoverage = match (true) {
+                $baselineCoverage['status'] !== 'covered' => [
+                    'status' => 'blocked',
+                    'label' => 'Blocked',
+                    'reason' => $baselineCoverage['reason'],
+                    'queue' => route('manual-csv-backlog.index'),
+                ],
+                $latestPropertyBaseline instanceof \App\Models\DomainSeoBaseline && $latestPropertyBaseline->import_method === 'matomo_plus_manual_csv' => [
+                    'status' => 'covered',
+                    'label' => 'Covered',
+                    'reason' => 'Manual Search Console CSV evidence has been imported for this property',
+                    'queue' => route('manual-csv-backlog.index'),
+                ],
+                default => [
+                    'status' => 'pending',
+                    'label' => 'Manual CSV pending',
+                    'reason' => 'Automation is in place, but this property still needs manual Search Console CSV evidence',
+                    'queue' => route('manual-csv-backlog.index'),
+                ],
+            };
+            $automationChecks = [
+                [
+                    'title' => 'Controller',
+                    'summary' => $repositoryCoverage,
+                    'queue' => route('automation-coverage.index'),
+                ],
+                [
+                    'title' => 'Matomo',
+                    'summary' => $matomoCoverage,
+                    'queue' => route('matomo-coverage.index'),
+                ],
+                [
+                    'title' => 'Search Console',
+                    'summary' => $searchConsoleCoverage,
+                    'queue' => route('search-console-coverage.index'),
+                ],
+                [
+                    'title' => 'Baseline Sync',
+                    'summary' => $baselineCoverage,
+                    'queue' => route('automation-coverage.index'),
+                ],
+                [
+                    'title' => 'Manual CSV',
+                    'summary' => $manualCsvCoverage,
+                    'queue' => route('manual-csv-backlog.index'),
+                ],
+            ];
         @endphp
 
         <div class="mb-6">
@@ -125,6 +205,56 @@
                             @endforeach
                         @endif
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+            <div class="p-6">
+                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                    <div>
+                        <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">Automation Checklist</h4>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            This shows what is automated for this property already and what still needs operator attention.
+                        </p>
+                    </div>
+                    <span @class([
+                        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+                        'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' => $automationCoverage['status'] === 'complete',
+                        'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' => in_array($automationCoverage['status'], ['manual_csv_pending', 'needs_baseline_sync', 'import_stale', 'needs_onboarding'], true),
+                        'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300' => in_array($automationCoverage['status'], ['needs_controller', 'needs_matomo_binding', 'needs_search_console_mapping'], true),
+                        'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' => ! in_array($automationCoverage['status'], ['complete', 'manual_csv_pending', 'needs_baseline_sync', 'import_stale', 'needs_onboarding', 'needs_controller', 'needs_matomo_binding', 'needs_search_console_mapping'], true),
+                    ])>
+                        {{ $automationCoverage['label'] }}
+                    </span>
+                </div>
+
+                <div class="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-4">
+                    @foreach($automationChecks as $check)
+                        @php
+                            $summary = $check['summary'];
+                        @endphp
+                        <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                            <div class="flex items-center justify-between gap-3">
+                                <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $check['title'] }}</div>
+                                <span @class([
+                                    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                                    'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' => $summary['status'] === 'covered',
+                                    'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' => in_array($summary['status'], ['pending', 'needs_sync', 'stale', 'needs_import', 'stale_import', 'bound_unverified', 'blocked'], true),
+                                    'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300' => in_array($summary['status'], ['needs_controller', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
+                                    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' => ! in_array($summary['status'], ['covered', 'pending', 'needs_sync', 'stale', 'needs_import', 'stale_import', 'bound_unverified', 'blocked', 'needs_controller', 'needs_binding', 'bound_attention', 'needs_matomo', 'needs_property', 'url_prefix_only'], true),
+                                ])>
+                                    {{ $summary['label'] }}
+                                </span>
+                            </div>
+                            @if(! empty($summary['reason']))
+                                <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">{{ $summary['reason'] }}</p>
+                            @endif
+                            <a href="{{ $check['queue'] }}" wire:navigate class="mt-3 inline-flex items-center text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                Open related queue
+                            </a>
+                        </div>
+                    @endforeach
                 </div>
             </div>
         </div>

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -6,83 +6,31 @@
             $repositories = $property->repositories;
             $analyticsSources = $property->analyticsSources;
             $tags = collect($property->tagSummaries());
-            $repositoryCoverage = $property->repositoryCoverageSummary();
-            $matomoCoverage = $property->matomoCoverageSummary();
-            $searchConsoleCoverage = $property->searchConsoleCoverageSummary();
             $automationCoverage = $property->automationCoverageSummary();
-            $latestPropertyBaseline = $property->relationLoaded('latestSeoBaseline')
-                ? $property->latestSeoBaseline
-                : $property->latestSeoBaseline()->first();
-            $baselineCoverage = match (true) {
-                $searchConsoleCoverage['status'] !== 'covered' => [
-                    'status' => 'blocked',
-                    'label' => 'Blocked',
-                    'reason' => $searchConsoleCoverage['reason'],
-                    'queue' => route('automation-coverage.index'),
-                ],
-                ! $latestPropertyBaseline instanceof \App\Models\DomainSeoBaseline => [
-                    'status' => 'needs_sync',
-                    'label' => 'Needs baseline sync',
-                    'reason' => 'Search Console data is ready, but no property baseline has been synced yet',
-                    'queue' => route('automation-coverage.index'),
-                ],
-                $latestPropertyBaseline->captured_at->lt(now()->subDays(30)) => [
-                    'status' => 'stale',
-                    'label' => 'Baseline stale',
-                    'reason' => 'The latest property baseline is older than 30 days',
-                    'queue' => route('automation-coverage.index'),
-                ],
-                default => [
-                    'status' => 'covered',
-                    'label' => 'Covered',
-                    'reason' => sprintf('Latest property baseline captured %s', $latestPropertyBaseline->captured_at->toDateString()),
-                    'queue' => route('automation-coverage.index'),
-                ],
-            };
-            $manualCsvCoverage = match (true) {
-                $baselineCoverage['status'] !== 'covered' => [
-                    'status' => 'blocked',
-                    'label' => 'Blocked',
-                    'reason' => $baselineCoverage['reason'],
-                    'queue' => route('manual-csv-backlog.index'),
-                ],
-                $latestPropertyBaseline instanceof \App\Models\DomainSeoBaseline && $latestPropertyBaseline->import_method === 'matomo_plus_manual_csv' => [
-                    'status' => 'covered',
-                    'label' => 'Covered',
-                    'reason' => 'Manual Search Console CSV evidence has been imported for this property',
-                    'queue' => route('manual-csv-backlog.index'),
-                ],
-                default => [
-                    'status' => 'pending',
-                    'label' => 'Manual CSV pending',
-                    'reason' => 'Automation is in place, but this property still needs manual Search Console CSV evidence',
-                    'queue' => route('manual-csv-backlog.index'),
-                ],
-            };
             $automationChecks = [
                 [
                     'title' => 'Controller',
-                    'summary' => $repositoryCoverage,
+                    'summary' => $automationCoverage['checks']['repository'],
                     'queue' => route('automation-coverage.index'),
                 ],
                 [
                     'title' => 'Matomo',
-                    'summary' => $matomoCoverage,
+                    'summary' => $automationCoverage['checks']['matomo'],
                     'queue' => route('matomo-coverage.index'),
                 ],
                 [
                     'title' => 'Search Console',
-                    'summary' => $searchConsoleCoverage,
+                    'summary' => $automationCoverage['checks']['search_console'],
                     'queue' => route('search-console-coverage.index'),
                 ],
                 [
                     'title' => 'Baseline Sync',
-                    'summary' => $baselineCoverage,
+                    'summary' => $automationCoverage['checks']['baseline_sync'],
                     'queue' => route('automation-coverage.index'),
                 ],
                 [
                     'title' => 'Manual CSV',
-                    'summary' => $manualCsvCoverage,
+                    'summary' => $automationCoverage['checks']['manual_csv'],
                     'queue' => route('manual-csv-backlog.index'),
                 ],
             ];

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature;
 
 use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
 use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
@@ -132,5 +134,107 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('Car transport by Moving Again');
         $response->assertSee('not detected');
         $response->assertSee('No Matomo snippet detected.');
+        $response->assertSee('Automation Checklist');
+        $response->assertSee('Needs Matomo');
+    }
+
+    public function test_web_property_detail_shows_manual_csv_pending_checklist_state(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'checklist.example.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'checklist-site',
+            'name' => 'Checklist Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://checklist.example.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'checklist-site-repo',
+            'repo_provider' => 'local',
+            'local_path' => '/tmp/checklist-site',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '88',
+            'external_name' => 'Checklist Site',
+            'workspace_path' => '/tmp/matomo',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '88',
+            'external_name' => 'Checklist Site',
+            'expected_tracker_host' => 'stats.example.au',
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://checklist.example.au/',
+            'detected_site_ids' => ['88'],
+            'detected_tracker_hosts' => ['stats.example.au'],
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '88',
+            'matomo_site_name' => 'Checklist Site',
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:checklist.example.au',
+            'property_type' => 'domain',
+            'latest_metric_date' => now()->subDay()->toDateString(),
+            'checked_at' => now(),
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'source_provider' => 'search_console',
+            'matomo_site_id' => '88',
+            'search_console_property_uri' => 'sc-domain:checklist.example.au',
+            'search_type' => 'web',
+            'import_method' => 'matomo_api',
+            'clicks' => 20,
+            'impressions' => 120,
+            'ctr' => 0.16,
+            'average_position' => 9.8,
+        ]);
+
+        $response = $this->actingAs($user)->get('/web-properties/checklist-site');
+
+        $response->assertOk();
+        $response->assertSee('Automation Checklist');
+        $response->assertSee('Checklist Site');
+        $response->assertSee('Manual CSV pending');
+        $response->assertSee('Open related queue');
     }
 }


### PR DESCRIPTION
## Summary
- add an automation checklist card to the web property detail page
- show controller, Matomo, Search Console, baseline sync, and manual CSV status in one place
- cover the manual CSV pending detail-state with a focused UI test

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Livewire/WebPropertyDetail.php app/Models/WebProperty.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
