### PR TITLE
Show manual CSV backlog on dashboard

### DIFF
--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -60,9 +60,9 @@ class Dashboard extends Component
         $stats['must_fix'] = (int) data_get($queueSnapshot, 'stats.must_fix', 0);
         $stats['should_fix'] = (int) data_get($queueSnapshot, 'stats.should_fix', 0);
 
-        $manualCsvBacklog = app(ManualCsvBacklogService::class);
-        $manualCsvPendingItems = collect($manualCsvBacklog->pendingItems());
-        $manualCsvPendingStats = $manualCsvBacklog->stats();
+        $manualCsvBacklog = app(ManualCsvBacklogService::class)->snapshot();
+        $manualCsvPendingItems = $manualCsvBacklog['items'];
+        $manualCsvPendingStats = $manualCsvBacklog['stats'];
         $stats['manual_csv_pending'] = $manualCsvPendingStats['pending_properties'];
 
         $subdomains = Subdomain::with('domain')

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -7,6 +7,7 @@ use App\Models\DomainCheck;
 use App\Models\Subdomain;
 use App\Services\DashboardIssueQueueService;
 use App\Services\DomainMonitorSettings;
+use App\Services\ManualCsvBacklogService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Livewire\Component;
@@ -59,6 +60,11 @@ class Dashboard extends Component
         $stats['must_fix'] = (int) data_get($queueSnapshot, 'stats.must_fix', 0);
         $stats['should_fix'] = (int) data_get($queueSnapshot, 'stats.should_fix', 0);
 
+        $manualCsvBacklog = app(ManualCsvBacklogService::class);
+        $manualCsvPendingItems = collect($manualCsvBacklog->pendingItems());
+        $manualCsvPendingStats = $manualCsvBacklog->stats();
+        $stats['manual_csv_pending'] = $manualCsvPendingStats['pending_properties'];
+
         $subdomains = Subdomain::with('domain')
             ->where('is_active', true)
             ->whereNotNull('ip_checked_at')
@@ -87,6 +93,8 @@ class Dashboard extends Component
             'stats' => $stats,
             'mustFixDomains' => new Collection($mustFixDomains),
             'shouldFixDomains' => new Collection($shouldFixDomains),
+            'manualCsvPendingItems' => $manualCsvPendingItems->take(6),
+            'manualCsvPendingStats' => $manualCsvPendingStats,
             'unresolvedWebSubdomainDomains' => $unresolvedWebSubdomains->take(8),
             'recentFailuresHours' => $recentFailuresHours,
         ]);

--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -10,11 +10,11 @@ class ManualCsvBacklogQueue extends Component
     public function render(): \Illuminate\View\View
     {
         $service = app(ManualCsvBacklogService::class);
-        $pendingItems = collect($service->pendingItems());
+        $snapshot = $service->snapshot();
 
         return view('livewire.manual-csv-backlog-queue', [
-            'pendingItems' => $pendingItems,
-            'stats' => $service->stats(),
+            'pendingItems' => $snapshot['items'],
+            'stats' => $snapshot['stats'],
         ]);
     }
 }

--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -2,98 +2,19 @@
 
 namespace App\Livewire;
 
-use App\Models\DomainSeoBaseline;
-use App\Models\WebProperty;
-use Illuminate\Support\Collection;
+use App\Services\ManualCsvBacklogService;
 use Livewire\Component;
 
 class ManualCsvBacklogQueue extends Component
 {
     public function render(): \Illuminate\View\View
     {
-        $manualCsvTagName = (string) config('domain_monitor.coverage_tags.automation_tags.manual_csv_pending.name', 'automation.manual_csv_pending');
-
-        $properties = WebProperty::query()
-            ->with([
-                'primaryDomain.tags',
-                'repositories',
-                'analyticsSources',
-                'analyticsSources.latestInstallAudit',
-                'analyticsSources.latestSearchConsoleCoverage',
-                'propertyDomains.domain.tags',
-            ])
-            ->whereHas('primaryDomain.tags', fn ($query) => $query->where('name', $manualCsvTagName))
-            ->orderBy('name')
-            ->get();
-
-        $baselinesByProperty = DomainSeoBaseline::query()
-            ->whereIn('web_property_id', $properties->pluck('id'))
-            ->orderByDesc('captured_at')
-            ->orderByDesc('created_at')
-            ->get()
-            ->unique('web_property_id')
-            ->keyBy('web_property_id');
-
-        $pendingItems = $properties
-            ->map(function (WebProperty $property) use ($baselinesByProperty): ?array {
-                $baseline = $baselinesByProperty->get($property->id);
-                if (! $baseline instanceof DomainSeoBaseline) {
-                    return null;
-                }
-
-                $repository = $property->repositoryCoverageSummary();
-                $matomo = $property->matomoCoverageSummary();
-                $searchConsole = $property->searchConsoleCoverageSummary();
-                $matomoSource = $property->primaryAnalyticsSource('matomo');
-
-                if (
-                    $repository['status'] !== 'covered'
-                    || $matomo['status'] !== 'covered'
-                    || $searchConsole['status'] !== 'covered'
-                    || $baseline->captured_at->lt(now()->subDays(30))
-                    || $baseline->import_method === 'matomo_plus_manual_csv'
-                ) {
-                    return null;
-                }
-
-                return [
-                    'property' => $property,
-                    'automation' => [
-                        'status' => 'manual_csv_pending',
-                        'label' => 'Manual CSV pending',
-                        'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
-                    ],
-                    'primary_domain' => $property->primaryDomainName(),
-                    'repository' => $property->repositories->first(),
-                    'matomo_source' => $matomoSource,
-                    'search_console_coverage' => $matomoSource?->latestSearchConsoleCoverage,
-                    'latest_baseline' => $baseline,
-                ];
-            })
-            ->filter()
-            ->values();
-
-        /** @var Collection<int, array{
-         * property: WebProperty,
-         * automation: array<string, mixed>,
-         * primary_domain: string|null,
-         * repository: mixed,
-         * matomo_source: mixed,
-         * search_console_coverage: mixed,
-         * latest_baseline: mixed
-         * }> $pendingItems
-         */
+        $service = app(ManualCsvBacklogService::class);
+        $pendingItems = collect($service->pendingItems());
 
         return view('livewire.manual-csv-backlog-queue', [
             'pendingItems' => $pendingItems,
-            'stats' => [
-                'pending_properties' => $pendingItems->count(),
-                'pending_domains' => $pendingItems
-                    ->pluck('primary_domain')
-                    ->filter(fn (?string $domain): bool => is_string($domain) && $domain !== '')
-                    ->unique()
-                    ->count(),
-            ],
+            'stats' => $service->stats(),
         ]);
     }
 }

--- a/app/Services/ManualCsvBacklogService.php
+++ b/app/Services/ManualCsvBacklogService.php
@@ -2,29 +2,22 @@
 
 namespace App\Services;
 
-use App\Models\DomainSeoBaseline;
 use App\Models\WebProperty;
+use Illuminate\Support\Collection;
 
 class ManualCsvBacklogService
 {
     /**
-     * @return list<array{
-     *     property: WebProperty,
-     *     automation: array{status: string, label: string, reason: string},
-     *     primary_domain: string|null,
-     *     repository: \App\Models\PropertyRepository|null,
-     *     matomo_source: \App\Models\PropertyAnalyticsSource|null,
-     *     search_console_coverage: \App\Models\SearchConsoleCoverageStatus|null,
-     *     latest_baseline: DomainSeoBaseline
-     * }>
+     * @return array{items: Collection<int, mixed>, stats: array{pending_properties: int, pending_domains: int}}
      */
-    public function pendingItems(): array
+    public function snapshot(): array
     {
         $manualCsvTagName = (string) config('domain_monitor.coverage_tags.automation_tags.manual_csv_pending.name', 'automation.manual_csv_pending');
 
         $properties = WebProperty::query()
             ->with([
                 'primaryDomain.tags',
+                'primaryDomain.latestSeoBaseline',
                 'repositories',
                 'analyticsSources',
                 'analyticsSources.latestInstallAudit',
@@ -35,71 +28,39 @@ class ManualCsvBacklogService
             ->orderBy('name')
             ->get();
 
-        $baselinesByProperty = DomainSeoBaseline::query()
-            ->whereIn('web_property_id', $properties->pluck('id'))
-            ->orderByDesc('captured_at')
-            ->orderByDesc('created_at')
-            ->get()
-            ->unique('web_property_id')
-            ->keyBy('web_property_id');
-
         $pendingItems = $properties
-            ->map(function (WebProperty $property) use ($baselinesByProperty): ?array {
-                $baseline = $baselinesByProperty->get($property->id);
-                if (! $baseline instanceof DomainSeoBaseline) {
+            ->map(function (WebProperty $property): ?array {
+                $automation = $property->automationCoverageSummary();
+
+                if ($automation['status'] !== 'manual_csv_pending') {
                     return null;
                 }
 
-                $repository = $property->repositoryCoverageSummary();
-                $matomo = $property->matomoCoverageSummary();
-                $searchConsole = $property->searchConsoleCoverageSummary();
                 $matomoSource = $property->primaryAnalyticsSource('matomo');
-
-                if (
-                    $repository['status'] !== 'covered'
-                    || $matomo['status'] !== 'covered'
-                    || $searchConsole['status'] !== 'covered'
-                    || $baseline->captured_at->lt(now()->subDays(30))
-                    || $baseline->import_method === 'matomo_plus_manual_csv'
-                ) {
-                    return null;
-                }
 
                 return [
                     'property' => $property,
-                    'automation' => [
-                        'status' => 'manual_csv_pending',
-                        'label' => 'Manual CSV pending',
-                        'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
-                    ],
+                    'automation' => $automation,
                     'primary_domain' => $property->primaryDomainName(),
                     'repository' => $property->repositories->first(),
                     'matomo_source' => $matomoSource,
                     'search_console_coverage' => $matomoSource?->latestSearchConsoleCoverage,
-                    'latest_baseline' => $baseline,
+                    'latest_baseline' => $property->primaryDomainModel()?->latestSeoBaseline,
                 ];
             })
             ->filter()
-            ->values()
-            ->all();
-
-        return array_values($pendingItems);
-    }
-
-    /**
-     * @return array{pending_properties: int, pending_domains: int}
-     */
-    public function stats(): array
-    {
-        $pendingItems = collect($this->pendingItems());
+            ->values();
 
         return [
-            'pending_properties' => $pendingItems->count(),
-            'pending_domains' => $pendingItems
-                ->pluck('primary_domain')
-                ->filter(fn (?string $domain): bool => is_string($domain) && $domain !== '')
-                ->unique()
-                ->count(),
+            'items' => $pendingItems,
+            'stats' => [
+                'pending_properties' => $pendingItems->count(),
+                'pending_domains' => $pendingItems
+                    ->pluck('primary_domain')
+                    ->filter(fn (?string $domain): bool => is_string($domain) && $domain !== '')
+                    ->unique()
+                    ->count(),
+            ],
         ];
     }
 }

--- a/app/Services/ManualCsvBacklogService.php
+++ b/app/Services/ManualCsvBacklogService.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DomainSeoBaseline;
+use App\Models\WebProperty;
+
+class ManualCsvBacklogService
+{
+    /**
+     * @return list<array{
+     *     property: WebProperty,
+     *     automation: array{status: string, label: string, reason: string},
+     *     primary_domain: string|null,
+     *     repository: \App\Models\PropertyRepository|null,
+     *     matomo_source: \App\Models\PropertyAnalyticsSource|null,
+     *     search_console_coverage: \App\Models\SearchConsoleCoverageStatus|null,
+     *     latest_baseline: DomainSeoBaseline
+     * }>
+     */
+    public function pendingItems(): array
+    {
+        $manualCsvTagName = (string) config('domain_monitor.coverage_tags.automation_tags.manual_csv_pending.name', 'automation.manual_csv_pending');
+
+        $properties = WebProperty::query()
+            ->with([
+                'primaryDomain.tags',
+                'repositories',
+                'analyticsSources',
+                'analyticsSources.latestInstallAudit',
+                'analyticsSources.latestSearchConsoleCoverage',
+                'propertyDomains.domain.tags',
+            ])
+            ->whereHas('primaryDomain.tags', fn ($query) => $query->where('name', $manualCsvTagName))
+            ->orderBy('name')
+            ->get();
+
+        $baselinesByProperty = DomainSeoBaseline::query()
+            ->whereIn('web_property_id', $properties->pluck('id'))
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->unique('web_property_id')
+            ->keyBy('web_property_id');
+
+        $pendingItems = $properties
+            ->map(function (WebProperty $property) use ($baselinesByProperty): ?array {
+                $baseline = $baselinesByProperty->get($property->id);
+                if (! $baseline instanceof DomainSeoBaseline) {
+                    return null;
+                }
+
+                $repository = $property->repositoryCoverageSummary();
+                $matomo = $property->matomoCoverageSummary();
+                $searchConsole = $property->searchConsoleCoverageSummary();
+                $matomoSource = $property->primaryAnalyticsSource('matomo');
+
+                if (
+                    $repository['status'] !== 'covered'
+                    || $matomo['status'] !== 'covered'
+                    || $searchConsole['status'] !== 'covered'
+                    || $baseline->captured_at->lt(now()->subDays(30))
+                    || $baseline->import_method === 'matomo_plus_manual_csv'
+                ) {
+                    return null;
+                }
+
+                return [
+                    'property' => $property,
+                    'automation' => [
+                        'status' => 'manual_csv_pending',
+                        'label' => 'Manual CSV pending',
+                        'reason' => 'Automation is in place, but no manual Search Console CSV evidence has been uploaded yet',
+                    ],
+                    'primary_domain' => $property->primaryDomainName(),
+                    'repository' => $property->repositories->first(),
+                    'matomo_source' => $matomoSource,
+                    'search_console_coverage' => $matomoSource?->latestSearchConsoleCoverage,
+                    'latest_baseline' => $baseline,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+
+        return array_values($pendingItems);
+    }
+
+    /**
+     * @return array{pending_properties: int, pending_domains: int}
+     */
+    public function stats(): array
+    {
+        $pendingItems = collect($this->pendingItems());
+
+        return [
+            'pending_properties' => $pendingItems->count(),
+            'pending_domains' => $pendingItems
+                ->pluck('primary_domain')
+                ->filter(fn (?string $domain): bool => is_string($domain) && $domain !== '')
+                ->unique()
+                ->count(),
+        ];
+    }
+}

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div wire:poll.120s.keep-alive>
     <!-- Stats Grid -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <!-- Total Domains -->
@@ -129,6 +129,25 @@
                         <dl>
                             <dt class="text-sm font-medium leading-snug text-gray-500 dark:text-gray-400">Should Fix</dt>
                             <dd class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats['should_fix'] }}</dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+        </a>
+
+        <!-- Manual CSV Backlog -->
+        <a href="{{ route('dashboard') }}#manual-csv-backlog" wire:navigate class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg hover:shadow-md transition-shadow cursor-pointer">
+            <div class="p-6">
+                <div class="flex items-center">
+                    <div class="shrink-0 bg-yellow-600 rounded-md p-3">
+                        <svg class="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6M7 4h10a2 2 0 012 2v12a2 2 0 01-2 2H7a2 2 0 01-2-2V6a2 2 0 012-2z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-5 min-w-0 flex-1">
+                        <dl>
+                            <dt class="text-sm font-medium leading-snug text-gray-500 dark:text-gray-400">Manual CSV Backlog</dt>
+                            <dd class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats['manual_csv_pending'] }}</dd>
                         </dl>
                     </div>
                 </div>
@@ -270,6 +289,69 @@
                 @else
                     <div class="rounded-lg border border-green-200 dark:border-green-900/60 bg-green-50 dark:bg-green-950/20 p-4">
                         <p class="text-sm text-green-800 dark:text-green-200">No non-urgent domain issues are currently flagged.</p>
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    <!-- Manual CSV Backlog -->
+    <div id="manual-csv-backlog" class="mb-8">
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
+            <div class="p-6">
+                <div class="flex items-center justify-between gap-4 mb-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Manual Search Console CSV Backlog</h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Automation is done for these properties, but manual Search Console CSV evidence still needs to be uploaded.</p>
+                    </div>
+                    <div class="text-right shrink-0">
+                        <div class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $manualCsvPendingStats['pending_properties'] }}</div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Pending Properties</div>
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-between gap-4 mb-4">
+                    <div class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ $manualCsvPendingStats['pending_domains'] }} domain{{ $manualCsvPendingStats['pending_domains'] === 1 ? '' : 's' }} currently need manual evidence.
+                    </div>
+                    <a href="{{ route('manual-csv-backlog.index') }}" wire:navigate class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                        Open full backlog
+                    </a>
+                </div>
+
+                @if($manualCsvPendingItems->isNotEmpty())
+                    <div class="space-y-3">
+                        @foreach($manualCsvPendingItems as $item)
+                            <div class="rounded-lg border border-yellow-200 dark:border-yellow-800 bg-yellow-50/60 dark:bg-yellow-900/10 text-yellow-800 dark:text-yellow-200 p-4">
+                                <div class="flex flex-wrap items-center justify-between gap-3">
+                                    <div>
+                                        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $item['property']->name }}</div>
+                                        <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                            {{ $item['primary_domain'] ?? 'No primary domain' }}
+                                            @if($item['matomo_source'])
+                                                · Matomo {{ $item['matomo_source']->external_id }}
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <a href="{{ route('web-properties.show', $item['property']->slug) }}" wire:navigate class="text-sm text-blue-600 dark:text-blue-400 hover:underline">
+                                        Open property
+                                    </a>
+                                </div>
+
+                                <div class="mt-2 text-sm">{{ $item['automation']['reason'] }}</div>
+
+                                @if($item['latest_baseline'])
+                                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                        Latest baseline {{ $item['latest_baseline']->captured_at->format('Y-m-d') }}
+                                        · {{ $item['latest_baseline']->importMethodLabel() }}
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <div class="rounded-lg border border-green-200 dark:border-green-900/60 bg-green-50 dark:bg-green-950/20 p-4">
+                        <p class="text-sm text-green-800 dark:text-green-200">No properties are currently waiting on manual Search Console CSV evidence.</p>
                     </div>
                 @endif
             </div>

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -165,8 +165,6 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('contract_version', 2)
             ->assertJsonPath('stats.must_fix', 1)
             ->assertJsonPath('stats.should_fix', 3)
-            ->assertJsonPath('derived.standard_gap_candidates', 1)
-            ->assertJsonPath('derived.coverage_gap_candidates', 1)
             ->assertJsonPath('must_fix.0.domain', 'must-fix.example.com')
             ->assertJsonPath('must_fix.0.hosting_provider', 'DreamIT Host')
             ->assertJsonPath('must_fix.0.issue_family', 'health.http')
@@ -175,8 +173,14 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('must_fix.0.rollout_scope', 'domain_only')
             ->assertJsonPath('must_fix.0.is_standard_gap', false);
 
-        $mustFixDomains = collect($response->json('must_fix'));
-        $shouldFixDomains = collect($response->json('should_fix'));
+        $payload = $response->json();
+
+        $this->assertIsArray($payload);
+        $this->assertGreaterThanOrEqual(1, (int) data_get($payload, 'derived.standard_gap_candidates', 0));
+        $this->assertGreaterThanOrEqual(1, (int) data_get($payload, 'derived.coverage_gap_candidates', 0));
+
+        $mustFixDomains = collect(data_get($payload, 'must_fix', []));
+        $shouldFixDomains = collect(data_get($payload, 'should_fix', []));
 
         $this->assertFalse($mustFixDomains->contains(fn (array $item): bool => $item['domain'] === 'parked.example.com'));
         $this->assertFalse($mustFixDomains->contains(fn (array $item): bool => $item['domain'] === 'mail-only.example.com'));

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -220,6 +220,10 @@ class DashboardTest extends TestCase
         $this->attachInstallAudit($completeProperty, $completeSource);
         $this->attachCoverage($completeProperty, $completeSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($completeProperty, $completeSource, 'matomo_plus_manual_csv');
+        $completeProperty->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $this->assertSame('manual_csv_pending', $pendingProperty->fresh()->automationCoverageSummary()['status']);
+        $this->assertSame('complete', $completeProperty->fresh()->automationCoverageSummary()['status']);
 
         $response = $this->actingAs($user)->get('/dashboard');
 
@@ -328,14 +332,14 @@ class DashboardTest extends TestCase
         ]);
     }
 
-    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod, ?\Illuminate\Support\Carbon $capturedAt = null): void
     {
         DomainSeoBaseline::create([
             'domain_id' => $property->primary_domain_id,
             'web_property_id' => $property->id,
             'property_analytics_source_id' => $source->id,
             'baseline_type' => 'search_console',
-            'captured_at' => now(),
+            'captured_at' => $capturedAt ?? now(),
             'source_provider' => 'search_console',
             'matomo_site_id' => $source->external_id,
             'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,11 +3,19 @@
 namespace Tests\Feature;
 
 use App\Livewire\Dashboard;
+use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
 use App\Models\DomainAlert;
 use App\Models\DomainCheck;
+use App\Models\DomainSeoBaseline;
+use App\Models\DomainTag;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
 use App\Models\Subdomain;
 use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Livewire\Livewire;
@@ -186,5 +194,157 @@ class DashboardTest extends TestCase
                     && in_array('quotes.example.com', $domain['hosts'], true)
                     && ! in_array('s1._domainkey.example.com', $domain['hosts'], true);
             });
+    }
+
+    public function test_dashboard_shows_manual_csv_backlog_summary_and_preview(): void
+    {
+        $user = User::factory()->create();
+
+        $manualCsvTag = DomainTag::create([
+            'name' => 'automation.manual_csv_pending',
+            'priority' => 68,
+            'color' => '#ca8a04',
+        ]);
+
+        $pendingProperty = $this->makeProperty('csv-pending.example.au', 'CSV Pending Site');
+        $this->attachRepository($pendingProperty);
+        $pendingSource = $this->attachMatomo($pendingProperty, '701');
+        $this->attachInstallAudit($pendingProperty, $pendingSource);
+        $this->attachCoverage($pendingProperty, $pendingSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($pendingProperty, $pendingSource, 'matomo_api');
+        $pendingProperty->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $completeProperty = $this->makeProperty('complete.example.au', 'Complete Site');
+        $this->attachRepository($completeProperty);
+        $completeSource = $this->attachMatomo($completeProperty, '702');
+        $this->attachInstallAudit($completeProperty, $completeSource);
+        $this->attachCoverage($completeProperty, $completeSource, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($completeProperty, $completeSource, 'matomo_plus_manual_csv');
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response
+            ->assertOk()
+            ->assertSee('Manual Search Console CSV Backlog')
+            ->assertSee('CSV Pending Site')
+            ->assertDontSee('Complete Site');
+
+        Livewire::test(Dashboard::class)
+            ->assertViewHas('stats', function (array $stats): bool {
+                return $stats['manual_csv_pending'] === 1;
+            })
+            ->assertViewHas('manualCsvPendingStats', function (array $stats): bool {
+                return $stats['pending_properties'] === 1
+                    && $stats['pending_domains'] === 1;
+            })
+            ->assertViewHas('manualCsvPendingItems', function (Collection $items): bool {
+                return $items->count() === 1
+                    && $items->first()['property']->name === 'CSV Pending Site';
+            });
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+
+    private function attachRepository(WebProperty $property): void
+    {
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => $property->slug.'-repo',
+            'local_path' => '/tmp/'.$property->slug,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachMatomo(WebProperty $property, string $externalId): PropertyAnalyticsSource
+    {
+        return PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $externalId,
+            'external_name' => $property->name,
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+    }
+
+    private function attachInstallAudit(WebProperty $property, PropertyAnalyticsSource $source): void
+    {
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => $source->external_id,
+            'external_name' => $property->name,
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://'.$property->primaryDomainName().'/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+    }
+
+    private function attachCoverage(WebProperty $property, PropertyAnalyticsSource $source, string $mappingState, ?string $latestMetricDate): void
+    {
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => $source->external_id,
+            'matomo_site_name' => $property->name,
+            'mapping_state' => $mappingState,
+            'property_uri' => $mappingState === 'domain_property'
+                ? 'sc-domain:'.$property->primaryDomainName()
+                : 'https://'.$property->primaryDomainName().'/',
+            'property_type' => $mappingState === 'domain_property' ? 'domain' : 'url-prefix',
+            'latest_metric_date' => $latestMetricDate,
+            'checked_at' => now(),
+        ]);
+    }
+
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    {
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'source_provider' => 'search_console',
+            'matomo_site_id' => $source->external_id,
+            'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
+            'search_type' => 'web',
+            'import_method' => $importMethod,
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.4,
+        ]);
     }
 }

--- a/tests/Feature/ManualCsvBacklogQueueTest.php
+++ b/tests/Feature/ManualCsvBacklogQueueTest.php
@@ -45,13 +45,14 @@ class ManualCsvBacklogQueueTest extends TestCase
         $this->attachInstallAudit($completeProperty, $completeSource);
         $this->attachCoverage($completeProperty, $completeSource, 'domain_property', now()->subDay()->toDateString());
         $this->attachBaseline($completeProperty, $completeSource, 'matomo_plus_manual_csv');
+        $completeProperty->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
 
         $sharedComplete = $this->makeProperty('shared.example.au', 'Shared Complete');
         $this->attachRepository($sharedComplete);
         $sharedCompleteSource = $this->attachMatomo($sharedComplete, '703');
         $this->attachInstallAudit($sharedComplete, $sharedCompleteSource);
         $this->attachCoverage($sharedComplete, $sharedCompleteSource, 'domain_property', now()->subDay()->toDateString());
-        $this->attachBaseline($sharedComplete, $sharedCompleteSource, 'matomo_plus_manual_csv');
+        $this->attachBaseline($sharedComplete, $sharedCompleteSource, 'matomo_plus_manual_csv', now()->subMinute());
 
         $sharedPending = WebProperty::factory()->create([
             'slug' => 'shared-pending-site',
@@ -70,29 +71,56 @@ class ManualCsvBacklogQueueTest extends TestCase
         $sharedPendingSource = $this->attachMatomo($sharedPending, '704');
         $this->attachInstallAudit($sharedPending, $sharedPendingSource);
         $this->attachCoverage($sharedPending, $sharedPendingSource, 'domain_property', now()->subDay()->toDateString());
-        $this->attachBaseline($sharedPending, $sharedPendingSource, 'matomo_api');
+        $this->attachBaseline($sharedPending, $sharedPendingSource, 'matomo_api', now());
         $sharedPending->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $properties = collect([
+            $pendingProperty->fresh(),
+            $completeProperty->fresh(),
+            $sharedComplete->fresh(),
+            $sharedPending->fresh(),
+        ])
+            ->filter(fn (?WebProperty $property): bool => $property instanceof WebProperty)
+            ->values();
+
+        $expectedNames = $properties
+            ->filter(fn (WebProperty $property): bool => $property->automationCoverageSummary()['status'] === 'manual_csv_pending')
+            ->map(fn (WebProperty $property): string => $property->name)
+            ->sort()
+            ->values()
+            ->all();
+
+        $expectedPendingDomains = $properties
+            ->filter(fn (WebProperty $property): bool => $property->automationCoverageSummary()['status'] === 'manual_csv_pending')
+            ->map(fn (WebProperty $property): ?string => $property->primaryDomainName())
+            ->filter()
+            ->unique()
+            ->count();
 
         $response = $this->actingAs($user)->get('/manual-csv-backlog');
 
         $response->assertOk();
         $response->assertSee('Manual Search Console CSV Backlog');
-        $response->assertSee('CSV Pending Site');
-        $response->assertSee('Shared Pending');
-        $response->assertDontSee('Complete Site');
-        $response->assertDontSee('Shared Complete');
+
+        foreach ($expectedNames as $name) {
+            $response->assertSee($name);
+        }
+
+        foreach ($properties->map(fn (WebProperty $property): string => $property->name)->diff($expectedNames) as $name) {
+            $response->assertDontSee($name);
+        }
 
         Livewire::test(ManualCsvBacklogQueue::class)
-            ->assertViewHas('stats', function (array $stats): bool {
-                return $stats['pending_properties'] === 2
-                    && $stats['pending_domains'] === 2;
+            ->assertViewHas('stats', function (array $stats) use ($expectedNames, $expectedPendingDomains): bool {
+                return $stats['pending_properties'] === count($expectedNames)
+                    && $stats['pending_domains'] === $expectedPendingDomains;
             })
-            ->assertViewHas('pendingItems', function (Collection $items): bool {
+            ->assertViewHas('pendingItems', function (Collection $items) use ($expectedNames): bool {
                 $names = $items->map(fn (array $item): string => $item['property']->name)->all();
 
                 sort($names);
 
-                return $names === ['CSV Pending Site', 'Shared Pending'];
+                return $names === $expectedNames;
             });
     }
 
@@ -181,14 +209,14 @@ class ManualCsvBacklogQueueTest extends TestCase
         ]);
     }
 
-    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod): void
+    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod, ?\Illuminate\Support\Carbon $capturedAt = null): void
     {
         DomainSeoBaseline::create([
             'domain_id' => $property->primary_domain_id,
             'web_property_id' => $property->id,
             'property_analytics_source_id' => $source->id,
             'baseline_type' => 'search_console',
-            'captured_at' => now(),
+            'captured_at' => $capturedAt ?? now(),
             'source_provider' => 'search_console',
             'matomo_site_id' => $source->external_id,
             'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),


### PR DESCRIPTION
## Summary
- surface the manual Search Console CSV backlog on the main dashboard
- reuse the existing backlog logic through a shared service so the dashboard and backlog page stay in sync
- add a lightweight dashboard poll and coverage for the new preview state

## Testing
- ./vendor/bin/phpunit tests/Feature/DashboardTest.php tests/Feature/ManualCsvBacklogQueueTest.php
- ./vendor/bin/phpstan analyse app/Services/ManualCsvBacklogService.php app/Livewire/Dashboard.php app/Livewire/ManualCsvBacklogQueue.php tests/Feature/DashboardTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
