### PR TITLE
Add beauy Matomo bootstrap source

### DIFF
--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -317,6 +317,14 @@ return [
                     'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
                     'framework' => 'WordPress',
                 ],
+                'analytics_sources' => [
+                    [
+                        'provider' => 'matomo',
+                        'external_id' => '30',
+                        'external_name' => 'beauy.com.au',
+                        'workspace_path' => '/Users/jasonhill/Projects/2026 Projects/Matamo',
+                    ],
+                ],
             ],
             'removalsinterstate.com.au' => [
                 'slug' => 'removalsinterstate-com-au',


### PR DESCRIPTION
## Summary\n- persist the beauy.com.au Matomo analytics source in domain monitor bootstrap config\n- keep the workspace path tidy without the accidental trailing space\n\n## Verification\n- php -l config/domain_monitor.php\n
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
