### PR TITLE
Import manual Search Console evidence zips

### DIFF
--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -5,6 +5,7 @@ namespace App\Livewire;
 use App\Models\WebProperty;
 use App\Services\ManualCsvBacklogService;
 use App\Services\ManualSearchConsoleEvidenceImporter;
+use Illuminate\Support\Facades\Artisan;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 
@@ -22,7 +23,7 @@ class ManualCsvBacklogQueue extends Component
         $key = 'evidenceArchives.'.$propertyId;
 
         $this->validate([
-            $key => ['required', 'file', 'mimes:zip'],
+            $key => ['required', 'file', 'mimes:zip', 'max:5120'],
         ]);
 
         $property = WebProperty::query()->find($propertyId);
@@ -40,16 +41,38 @@ class ManualCsvBacklogQueue extends Component
                 auth()->user()->email ?: 'domain_monitor_ui'
             );
 
+            $tagRefreshError = $this->refreshCoverageTags($property);
+
             unset($this->evidenceArchives[$propertyId]);
 
             session()->flash('message', sprintf(
-                'Imported Search Console evidence for %s. Baseline %s recorded.',
+                'Imported Search Console evidence for %s. Baseline %s recorded.%s',
                 $property->name,
-                $result['baseline']->captured_at->format('Y-m-d H:i')
+                $result['baseline']->captured_at->format('Y-m-d H:i'),
+                $tagRefreshError ? ' Coverage tags will refresh on the next scheduled sync.' : ' Coverage tags refreshed.'
             ));
         } catch (\Throwable $exception) {
             session()->flash('error', 'Manual CSV import failed: '.$exception->getMessage());
         }
+    }
+
+    private function refreshCoverageTags(WebProperty $property): ?string
+    {
+        $domain = $property->primaryDomainName();
+
+        if (! is_string($domain) || $domain === '') {
+            return 'Missing primary domain.';
+        }
+
+        try {
+            $exitCode = Artisan::call('coverage:sync-tags', [
+                '--domain' => [$domain],
+            ]);
+        } catch (\Throwable $exception) {
+            return $exception->getMessage();
+        }
+
+        return $exitCode === 0 ? null : trim(Artisan::output());
     }
 
     public function render(): \Illuminate\View\View

--- a/app/Livewire/ManualCsvBacklogQueue.php
+++ b/app/Livewire/ManualCsvBacklogQueue.php
@@ -2,11 +2,56 @@
 
 namespace App\Livewire;
 
+use App\Models\WebProperty;
 use App\Services\ManualCsvBacklogService;
+use App\Services\ManualSearchConsoleEvidenceImporter;
 use Livewire\Component;
+use Livewire\WithFileUploads;
 
 class ManualCsvBacklogQueue extends Component
 {
+    use WithFileUploads;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $evidenceArchives = [];
+
+    public function importEvidence(string $propertyId, ManualSearchConsoleEvidenceImporter $importer): void
+    {
+        $key = 'evidenceArchives.'.$propertyId;
+
+        $this->validate([
+            $key => ['required', 'file', 'mimes:zip'],
+        ]);
+
+        $property = WebProperty::query()->find($propertyId);
+
+        if (! $property instanceof WebProperty) {
+            session()->flash('error', 'Property not found.');
+
+            return;
+        }
+
+        try {
+            $result = $importer->importForProperty(
+                $property,
+                (string) $this->evidenceArchives[$propertyId]->getRealPath(),
+                auth()->user()->email ?: 'domain_monitor_ui'
+            );
+
+            unset($this->evidenceArchives[$propertyId]);
+
+            session()->flash('message', sprintf(
+                'Imported Search Console evidence for %s. Baseline %s recorded.',
+                $property->name,
+                $result['baseline']->captured_at->format('Y-m-d H:i')
+            ));
+        } catch (\Throwable $exception) {
+            session()->flash('error', 'Manual CSV import failed: '.$exception->getMessage());
+        }
+    }
+
     public function render(): \Illuminate\View\View
     {
         $service = app(ManualCsvBacklogService::class);

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -109,6 +110,35 @@ class WebProperty extends Model
     public function analyticsSources(): HasMany
     {
         return $this->hasMany(PropertyAnalyticsSource::class)->orderByDesc('is_primary');
+    }
+
+    /**
+     * @return HasMany<DomainSeoBaseline, $this>
+     */
+    public function seoBaselines(): HasMany
+    {
+        return $this->hasMany(DomainSeoBaseline::class)
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at');
+    }
+
+    /**
+     * @return HasOne<DomainSeoBaseline, $this>
+     */
+    public function latestSeoBaselineForProperty(): HasOne
+    {
+        return $this->hasOne(DomainSeoBaseline::class)
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at');
+    }
+
+    public function latestPropertySeoBaselineRecord(): ?DomainSeoBaseline
+    {
+        $latestBaseline = $this->relationLoaded('latestSeoBaselineForProperty')
+            ? $this->latestSeoBaselineForProperty
+            : $this->latestSeoBaselineForProperty()->first();
+
+        return $latestBaseline instanceof DomainSeoBaseline ? $latestBaseline : null;
     }
 
     /**
@@ -741,10 +771,7 @@ class WebProperty extends Model
             ];
         }
 
-        $primaryDomain = $this->primaryDomainModel();
-        $latestBaseline = $primaryDomain && $primaryDomain->relationLoaded('latestSeoBaseline')
-            ? $primaryDomain->latestSeoBaseline
-            : $primaryDomain?->latestSeoBaseline()->first();
+        $latestBaseline = $this->latestPropertySeoBaselineRecord();
 
         if (! $latestBaseline instanceof DomainSeoBaseline) {
             return [

--- a/app/Services/ManualCsvBacklogService.php
+++ b/app/Services/ManualCsvBacklogService.php
@@ -18,6 +18,7 @@ class ManualCsvBacklogService
             ->with([
                 'primaryDomain.tags',
                 'primaryDomain.latestSeoBaseline',
+                'latestSeoBaselineForProperty',
                 'repositories',
                 'analyticsSources',
                 'analyticsSources.latestInstallAudit',
@@ -45,7 +46,7 @@ class ManualCsvBacklogService
                     'repository' => $property->repositories->first(),
                     'matomo_source' => $matomoSource,
                     'search_console_coverage' => $matomoSource?->latestSearchConsoleCoverage,
-                    'latest_baseline' => $property->primaryDomainModel()?->latestSeoBaseline,
+                    'latest_baseline' => $property->latestPropertySeoBaselineRecord(),
                 ];
             })
             ->filter()

--- a/app/Services/ManualSearchConsoleEvidenceImporter.php
+++ b/app/Services/ManualSearchConsoleEvidenceImporter.php
@@ -8,6 +8,7 @@ use App\Models\PropertyAnalyticsSource;
 use App\Models\SearchConsoleCoverageStatus;
 use App\Models\WebProperty;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -16,6 +17,10 @@ use ZipArchive;
 
 class ManualSearchConsoleEvidenceImporter
 {
+    private const MAX_ARCHIVE_BYTES = 5_242_880;
+
+    private const MAX_ENTRY_BYTES = 1_048_576;
+
     /**
      * @return array{baseline: DomainSeoBaseline, artifact_path: string, parsed: array<string, mixed>}
      */
@@ -23,6 +28,13 @@ class ManualSearchConsoleEvidenceImporter
     {
         if (! is_file($archivePath)) {
             throw new InvalidArgumentException(sprintf('Evidence archive not found at [%s].', $archivePath));
+        }
+
+        $this->assertArchiveWithinLimits($archivePath);
+
+        $automation = $property->automationCoverageSummary();
+        if ($automation['status'] !== 'manual_csv_pending') {
+            throw new InvalidArgumentException('This property is not currently waiting on manual Search Console CSV evidence.');
         }
 
         $domain = $property->primaryDomainModel();
@@ -35,62 +47,87 @@ class ManualSearchConsoleEvidenceImporter
             throw new InvalidArgumentException('The property does not have a primary Matomo source.');
         }
 
-        $latestBaseline = $domain->latestSeoBaseline()->first();
+        $latestBaseline = $property->latestPropertySeoBaselineRecord();
         if (! $latestBaseline instanceof DomainSeoBaseline) {
             throw new InvalidArgumentException('The property does not have an existing SEO baseline to enrich.');
         }
 
         $parsed = $this->parseArchive($archivePath);
-        $artifactPath = $this->storeArtifact($property, $archivePath);
         $coverage = $matomoSource->latestSearchConsoleCoverage()->first();
+        $artifactPath = $this->storeArtifact($property, $archivePath);
 
-        $baseline = DomainSeoBaseline::query()->create([
-            'domain_id' => $domain->id,
-            'web_property_id' => $property->id,
-            'property_analytics_source_id' => $matomoSource->id,
-            'baseline_type' => $latestBaseline->baseline_type ?: 'search_console',
-            'captured_at' => now(),
-            'captured_by' => $capturedBy ?: 'manual_csv_import',
-            'source_provider' => $latestBaseline->source_provider ?: 'matomo',
-            'matomo_site_id' => $matomoSource->external_id,
-            'search_console_property_uri' => $coverage instanceof SearchConsoleCoverageStatus
-                ? $coverage->property_uri
-                : $latestBaseline->search_console_property_uri,
-            'search_type' => $latestBaseline->search_type ?: 'web',
-            'date_range_start' => $parsed['date_range_start'] ?? $latestBaseline->date_range_start,
-            'date_range_end' => $parsed['date_range_end'] ?? $latestBaseline->date_range_end,
-            'import_method' => 'matomo_plus_manual_csv',
-            'artifact_path' => $artifactPath,
-            'clicks' => $latestBaseline->clicks,
-            'impressions' => $latestBaseline->impressions,
-            'ctr' => $latestBaseline->ctr,
-            'average_position' => $latestBaseline->average_position,
-            'indexed_pages' => $parsed['indexed_pages'],
-            'not_indexed_pages' => $parsed['not_indexed_pages'],
-            'pages_with_redirect' => $parsed['pages_with_redirect'],
-            'not_found_404' => $parsed['not_found_404'],
-            'blocked_by_robots' => $parsed['blocked_by_robots'],
-            'alternate_with_canonical' => $parsed['alternate_with_canonical'],
-            'crawled_currently_not_indexed' => $parsed['crawled_currently_not_indexed'],
-            'discovered_currently_not_indexed' => $parsed['discovered_currently_not_indexed'],
-            'duplicate_without_user_selected_canonical' => $parsed['duplicate_without_user_selected_canonical'],
-            'top_pages_count' => $latestBaseline->top_pages_count,
-            'top_queries_count' => $latestBaseline->top_queries_count,
-            'inspected_url_count' => $latestBaseline->inspected_url_count,
-            'inspection_indexed_url_count' => $latestBaseline->inspection_indexed_url_count,
-            'inspection_non_indexed_url_count' => $latestBaseline->inspection_non_indexed_url_count,
-            'amp_urls' => $latestBaseline->amp_urls,
-            'mobile_issue_urls' => $latestBaseline->mobile_issue_urls,
-            'rich_result_urls' => $latestBaseline->rich_result_urls,
-            'rich_result_issue_urls' => $latestBaseline->rich_result_issue_urls,
-            'notes' => $this->buildNotes($latestBaseline->notes, $archivePath, $parsed),
-            'raw_payload' => [
-                'source_system' => 'google_search_console_page_indexing_export',
-                'imported_from' => basename($archivePath),
-                'parsed_export' => $parsed['raw_payload'],
-                'previous_baseline_id' => $latestBaseline->id,
-            ],
-        ]);
+        try {
+            $baseline = DB::transaction(function () use (
+                $capturedBy,
+                $coverage,
+                $domain,
+                $latestBaseline,
+                $matomoSource,
+                $parsed,
+                $property,
+                $archivePath,
+                $artifactPath
+            ): DomainSeoBaseline {
+                return DomainSeoBaseline::query()->create([
+                    'domain_id' => $domain->id,
+                    'web_property_id' => $property->id,
+                    'property_analytics_source_id' => $matomoSource->id,
+                    'baseline_type' => $latestBaseline->baseline_type ?: 'search_console',
+                    'captured_at' => now(),
+                    'captured_by' => $capturedBy ?: 'manual_csv_import',
+                    'source_provider' => $latestBaseline->source_provider ?: 'matomo',
+                    'matomo_site_id' => $matomoSource->external_id,
+                    'search_console_property_uri' => $coverage instanceof SearchConsoleCoverageStatus
+                        ? $coverage->property_uri
+                        : $latestBaseline->search_console_property_uri,
+                    'search_type' => $latestBaseline->search_type ?: 'web',
+                    // Keep the original Matomo/API window on the enriched baseline.
+                    'date_range_start' => $latestBaseline->date_range_start,
+                    'date_range_end' => $latestBaseline->date_range_end,
+                    'import_method' => 'matomo_plus_manual_csv',
+                    'artifact_path' => $artifactPath,
+                    'clicks' => $latestBaseline->clicks,
+                    'impressions' => $latestBaseline->impressions,
+                    'ctr' => $latestBaseline->ctr,
+                    'average_position' => $latestBaseline->average_position,
+                    'indexed_pages' => $parsed['indexed_pages'],
+                    'not_indexed_pages' => $parsed['not_indexed_pages'],
+                    'pages_with_redirect' => $parsed['pages_with_redirect'],
+                    'not_found_404' => $parsed['not_found_404'],
+                    'blocked_by_robots' => $parsed['blocked_by_robots'],
+                    'alternate_with_canonical' => $parsed['alternate_with_canonical'],
+                    'crawled_currently_not_indexed' => $parsed['crawled_currently_not_indexed'],
+                    'discovered_currently_not_indexed' => $parsed['discovered_currently_not_indexed'],
+                    'duplicate_without_user_selected_canonical' => $parsed['duplicate_without_user_selected_canonical'],
+                    'top_pages_count' => $latestBaseline->top_pages_count,
+                    'top_queries_count' => $latestBaseline->top_queries_count,
+                    'inspected_url_count' => $latestBaseline->inspected_url_count,
+                    'inspection_indexed_url_count' => $latestBaseline->inspection_indexed_url_count,
+                    'inspection_non_indexed_url_count' => $latestBaseline->inspection_non_indexed_url_count,
+                    'amp_urls' => $latestBaseline->amp_urls,
+                    'mobile_issue_urls' => $latestBaseline->mobile_issue_urls,
+                    'rich_result_urls' => $latestBaseline->rich_result_urls,
+                    'rich_result_issue_urls' => $latestBaseline->rich_result_issue_urls,
+                    'notes' => $this->buildNotes($latestBaseline->notes, $archivePath, $parsed),
+                    'raw_payload' => [
+                        'source_system' => 'google_search_console_page_indexing_export',
+                        'imported_from' => basename($archivePath),
+                        'parsed_export' => $parsed['raw_payload'],
+                        'page_indexing_window' => [
+                            'date_range_start' => $parsed['date_range_start']?->toDateString(),
+                            'date_range_end' => $parsed['date_range_end']?->toDateString(),
+                        ],
+                        'previous_baseline_id' => $latestBaseline->id,
+                    ],
+                ]);
+            });
+        } catch (\Throwable $exception) {
+            if ($artifactPath !== '') {
+                Storage::disk('local')->delete($artifactPath);
+            }
+
+            throw $exception;
+        }
 
         return [
             'baseline' => $baseline,
@@ -164,20 +201,32 @@ class ManualSearchConsoleEvidenceImporter
         $safeExtension = $extension !== '' ? '.'.Str::lower($extension) : '';
         $filename = now()->format('Ymd-His').'-'.Str::slug(pathinfo($archivePath, PATHINFO_FILENAME)).$safeExtension;
         $relativePath = 'search-console-manual-evidence/'.$property->slug.'/'.$filename;
+        $stream = fopen($archivePath, 'rb');
 
-        $contents = file_get_contents($archivePath);
-
-        if (! is_string($contents)) {
+        if (! is_resource($stream)) {
             throw new RuntimeException('Unable to read Search Console evidence archive.');
         }
 
-        Storage::disk('local')->put($relativePath, $contents);
+        try {
+            $written = Storage::disk('local')->writeStream($relativePath, $stream);
+        } finally {
+            fclose($stream);
+        }
+
+        if ($written === false) {
+            throw new RuntimeException('Unable to store Search Console evidence archive.');
+        }
 
         return $relativePath;
     }
 
     private function zipEntryContents(ZipArchive $zip, string $entryName, bool $required = true): ?string
     {
+        $stats = $zip->statName($entryName);
+        if (is_array($stats) && (int) $stats['size'] > self::MAX_ENTRY_BYTES) {
+            throw new RuntimeException(sprintf('The Search Console export entry [%s] exceeds the supported size limit.', $entryName));
+        }
+
         $contents = $zip->getFromName($entryName);
 
         if (is_string($contents)) {
@@ -287,5 +336,18 @@ class ManualSearchConsoleEvidenceImporter
         ]);
 
         return implode(' ', $segments);
+    }
+
+    private function assertArchiveWithinLimits(string $archivePath): void
+    {
+        $size = filesize($archivePath);
+
+        if ($size === false) {
+            throw new InvalidArgumentException('Unable to determine Search Console evidence archive size.');
+        }
+
+        if ($size > self::MAX_ARCHIVE_BYTES) {
+            throw new InvalidArgumentException('The Search Console evidence archive exceeds the 5 MB upload limit.');
+        }
     }
 }

--- a/app/Services/ManualSearchConsoleEvidenceImporter.php
+++ b/app/Services/ManualSearchConsoleEvidenceImporter.php
@@ -1,0 +1,291 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\WebProperty;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use RuntimeException;
+use ZipArchive;
+
+class ManualSearchConsoleEvidenceImporter
+{
+    /**
+     * @return array{baseline: DomainSeoBaseline, artifact_path: string, parsed: array<string, mixed>}
+     */
+    public function importForProperty(WebProperty $property, string $archivePath, ?string $capturedBy = null): array
+    {
+        if (! is_file($archivePath)) {
+            throw new InvalidArgumentException(sprintf('Evidence archive not found at [%s].', $archivePath));
+        }
+
+        $domain = $property->primaryDomainModel();
+        if (! $domain instanceof Domain) {
+            throw new InvalidArgumentException('The property does not have a primary domain.');
+        }
+
+        $matomoSource = $property->primaryAnalyticsSource('matomo');
+        if (! $matomoSource instanceof PropertyAnalyticsSource) {
+            throw new InvalidArgumentException('The property does not have a primary Matomo source.');
+        }
+
+        $latestBaseline = $domain->latestSeoBaseline()->first();
+        if (! $latestBaseline instanceof DomainSeoBaseline) {
+            throw new InvalidArgumentException('The property does not have an existing SEO baseline to enrich.');
+        }
+
+        $parsed = $this->parseArchive($archivePath);
+        $artifactPath = $this->storeArtifact($property, $archivePath);
+        $coverage = $matomoSource->latestSearchConsoleCoverage()->first();
+
+        $baseline = DomainSeoBaseline::query()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $matomoSource->id,
+            'baseline_type' => $latestBaseline->baseline_type ?: 'search_console',
+            'captured_at' => now(),
+            'captured_by' => $capturedBy ?: 'manual_csv_import',
+            'source_provider' => $latestBaseline->source_provider ?: 'matomo',
+            'matomo_site_id' => $matomoSource->external_id,
+            'search_console_property_uri' => $coverage instanceof SearchConsoleCoverageStatus
+                ? $coverage->property_uri
+                : $latestBaseline->search_console_property_uri,
+            'search_type' => $latestBaseline->search_type ?: 'web',
+            'date_range_start' => $parsed['date_range_start'] ?? $latestBaseline->date_range_start,
+            'date_range_end' => $parsed['date_range_end'] ?? $latestBaseline->date_range_end,
+            'import_method' => 'matomo_plus_manual_csv',
+            'artifact_path' => $artifactPath,
+            'clicks' => $latestBaseline->clicks,
+            'impressions' => $latestBaseline->impressions,
+            'ctr' => $latestBaseline->ctr,
+            'average_position' => $latestBaseline->average_position,
+            'indexed_pages' => $parsed['indexed_pages'],
+            'not_indexed_pages' => $parsed['not_indexed_pages'],
+            'pages_with_redirect' => $parsed['pages_with_redirect'],
+            'not_found_404' => $parsed['not_found_404'],
+            'blocked_by_robots' => $parsed['blocked_by_robots'],
+            'alternate_with_canonical' => $parsed['alternate_with_canonical'],
+            'crawled_currently_not_indexed' => $parsed['crawled_currently_not_indexed'],
+            'discovered_currently_not_indexed' => $parsed['discovered_currently_not_indexed'],
+            'duplicate_without_user_selected_canonical' => $parsed['duplicate_without_user_selected_canonical'],
+            'top_pages_count' => $latestBaseline->top_pages_count,
+            'top_queries_count' => $latestBaseline->top_queries_count,
+            'inspected_url_count' => $latestBaseline->inspected_url_count,
+            'inspection_indexed_url_count' => $latestBaseline->inspection_indexed_url_count,
+            'inspection_non_indexed_url_count' => $latestBaseline->inspection_non_indexed_url_count,
+            'amp_urls' => $latestBaseline->amp_urls,
+            'mobile_issue_urls' => $latestBaseline->mobile_issue_urls,
+            'rich_result_urls' => $latestBaseline->rich_result_urls,
+            'rich_result_issue_urls' => $latestBaseline->rich_result_issue_urls,
+            'notes' => $this->buildNotes($latestBaseline->notes, $archivePath, $parsed),
+            'raw_payload' => [
+                'source_system' => 'google_search_console_page_indexing_export',
+                'imported_from' => basename($archivePath),
+                'parsed_export' => $parsed['raw_payload'],
+                'previous_baseline_id' => $latestBaseline->id,
+            ],
+        ]);
+
+        return [
+            'baseline' => $baseline,
+            'artifact_path' => $artifactPath,
+            'parsed' => $parsed,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   date_range_start: Carbon|null,
+     *   date_range_end: Carbon|null,
+     *   indexed_pages: int|null,
+     *   not_indexed_pages: int|null,
+     *   pages_with_redirect: int|null,
+     *   not_found_404: int|null,
+     *   blocked_by_robots: int|null,
+     *   alternate_with_canonical: int|null,
+     *   crawled_currently_not_indexed: int|null,
+     *   discovered_currently_not_indexed: int|null,
+     *   duplicate_without_user_selected_canonical: int|null,
+     *   raw_payload: array<string, mixed>
+     * }
+     */
+    public function parseArchive(string $archivePath): array
+    {
+        $zip = new ZipArchive;
+        if ($zip->open($archivePath) !== true) {
+            throw new RuntimeException('Unable to open Search Console evidence archive.');
+        }
+
+        $chartRows = $this->parseCsvString($this->zipEntryContents($zip, 'Chart.csv'));
+        $criticalRows = $this->parseCsvString($this->zipEntryContents($zip, 'Critical issues.csv'));
+        $nonCriticalRows = $this->parseCsvString($this->zipEntryContents($zip, 'Non-critical issues.csv', false) ?? '');
+        $metadataRows = $this->parseCsvString($this->zipEntryContents($zip, 'Metadata.csv', false) ?? '');
+
+        $zip->close();
+
+        $chartRows = array_values(array_filter($chartRows, fn (array $row): bool => $row['Date'] !== ''));
+        if ($chartRows === []) {
+            throw new RuntimeException('The Search Console export does not contain chart data.');
+        }
+
+        $latestChartRow = end($chartRows);
+        $issueRows = [...$criticalRows, ...$nonCriticalRows];
+
+        return [
+            'date_range_start' => $this->parseDate($chartRows[0]['Date']),
+            'date_range_end' => $this->parseDate($latestChartRow['Date']),
+            'indexed_pages' => $this->nullableInt($latestChartRow['Indexed'] ?? null),
+            'not_indexed_pages' => $this->nullableInt($latestChartRow['Not indexed'] ?? null),
+            'pages_with_redirect' => $this->issueCount($issueRows, ['Page with redirect']),
+            'not_found_404' => $this->issueCount($issueRows, ['Not found (404)']),
+            'blocked_by_robots' => $this->issueCount($issueRows, ['Blocked by robots.txt']),
+            'alternate_with_canonical' => $this->issueCount($issueRows, ['Alternative page with proper canonical tag']),
+            'crawled_currently_not_indexed' => $this->issueCount($issueRows, ['Crawled - currently not indexed']),
+            'discovered_currently_not_indexed' => $this->issueCount($issueRows, ['Discovered - currently not indexed']),
+            'duplicate_without_user_selected_canonical' => $this->issueCount($issueRows, ['Duplicate without user-selected canonical']),
+            'raw_payload' => [
+                'chart' => $chartRows,
+                'critical_issues' => $criticalRows,
+                'non_critical_issues' => $nonCriticalRows,
+                'metadata' => $metadataRows,
+            ],
+        ];
+    }
+
+    private function storeArtifact(WebProperty $property, string $archivePath): string
+    {
+        $extension = pathinfo($archivePath, PATHINFO_EXTENSION);
+        $safeExtension = $extension !== '' ? '.'.Str::lower($extension) : '';
+        $filename = now()->format('Ymd-His').'-'.Str::slug(pathinfo($archivePath, PATHINFO_FILENAME)).$safeExtension;
+        $relativePath = 'search-console-manual-evidence/'.$property->slug.'/'.$filename;
+
+        $contents = file_get_contents($archivePath);
+
+        if (! is_string($contents)) {
+            throw new RuntimeException('Unable to read Search Console evidence archive.');
+        }
+
+        Storage::disk('local')->put($relativePath, $contents);
+
+        return $relativePath;
+    }
+
+    private function zipEntryContents(ZipArchive $zip, string $entryName, bool $required = true): ?string
+    {
+        $contents = $zip->getFromName($entryName);
+
+        if (is_string($contents)) {
+            return $contents;
+        }
+
+        if ($required) {
+            throw new RuntimeException(sprintf('The Search Console export is missing [%s].', $entryName));
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function parseCsvString(string $contents): array
+    {
+        $contents = preg_replace('/^\xEF\xBB\xBF/u', '', $contents) ?? $contents;
+        $lines = preg_split('/\\r\\n|\\n|\\r/', trim($contents));
+
+        if (! is_array($lines) || $lines === [] || trim((string) $lines[0]) === '') {
+            return [];
+        }
+
+        $headers = array_map(
+            static fn ($header): string => trim((string) $header),
+            str_getcsv((string) array_shift($lines))
+        );
+        $rows = [];
+
+        foreach ($lines as $line) {
+            if (trim($line) === '') {
+                continue;
+            }
+
+            $values = str_getcsv($line);
+            $row = [];
+
+            foreach ($headers as $index => $header) {
+                $row[$header] = isset($values[$index]) ? trim((string) $values[$index]) : '';
+            }
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<int, array<string, string>>  $rows
+     * @param  array<int, string>  $reasons
+     */
+    private function issueCount(array $rows, array $reasons): ?int
+    {
+        $reasonMap = array_flip(array_map([$this, 'normalizeReason'], $reasons));
+
+        foreach ($rows as $row) {
+            $reason = $this->normalizeReason($row['Reason'] ?? null);
+
+            if (isset($reasonMap[$reason])) {
+                return $this->nullableInt($row['Pages'] ?? null) ?? 0;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizeReason(?string $reason): string
+    {
+        return Str::of((string) $reason)
+            ->lower()
+            ->replace(['‘', '’', '“', '”'], ["'", "'", '"', '"'])
+            ->squish()
+            ->toString();
+    }
+
+    private function parseDate(?string $date): ?Carbon
+    {
+        if (! is_string($date) || trim($date) === '') {
+            return null;
+        }
+
+        return Carbon::parse($date);
+    }
+
+    private function nullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $parsed
+     */
+    private function buildNotes(?string $existingNotes, string $archivePath, array $parsed): string
+    {
+        $segments = array_filter([
+            $existingNotes,
+            sprintf('Manual Search Console evidence imported from %s.', basename($archivePath)),
+            isset($parsed['date_range_end']) && $parsed['date_range_end'] instanceof Carbon
+                ? sprintf('Page indexing snapshot current to %s.', $parsed['date_range_end']->toDateString())
+                : null,
+        ]);
+
+        return implode(' ', $segments);
+    }
+}

--- a/resources/views/livewire/manual-csv-backlog-queue.blade.php
+++ b/resources/views/livewire/manual-csv-backlog-queue.blade.php
@@ -1,9 +1,21 @@
 <div class="space-y-6">
+    @if (session('message'))
+        <div class="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 px-4 py-3 text-sm text-green-800 dark:text-green-200">
+            {{ session('message') }}
+        </div>
+    @endif
+
+    @if (session('error'))
+        <div class="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-800 dark:text-red-200">
+            {{ session('error') }}
+        </div>
+    @endif
+
     <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
         <div class="p-6">
             <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Manual Search Console CSV Backlog</h3>
             <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                These properties are fully automated up to the final Search Console CSV evidence step. Use this queue to clear the remaining manual backlog.
+                These properties are fully automated up to the final Search Console CSV evidence step. Upload the Google Search Console Page indexing export ZIP here to clear the remaining manual backlog.
             </p>
         </div>
     </div>
@@ -72,6 +84,32 @@
                                     · {{ $item['latest_baseline']->importMethodLabel() }}
                                 </div>
                             @endif
+
+                            <div class="mt-4 rounded-md border border-yellow-200 dark:border-yellow-800/60 bg-white/70 dark:bg-gray-900/40 p-3">
+                                <div class="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                                    Import Search Console export
+                                </div>
+                                <div class="mt-2 flex flex-col gap-3 md:flex-row md:items-center">
+                                    <input
+                                        type="file"
+                                        accept=".zip,application/zip"
+                                        wire:model="evidenceArchives.{{ $item['property']->id }}"
+                                        class="block w-full text-sm text-gray-700 dark:text-gray-200 file:mr-4 file:rounded-md file:border-0 file:bg-yellow-600 file:px-3 file:py-2 file:text-sm file:font-medium file:text-white hover:file:bg-yellow-700"
+                                    />
+                                    <button
+                                        type="button"
+                                        wire:click="importEvidence('{{ $item['property']->id }}')"
+                                        wire:loading.attr="disabled"
+                                        wire:target="importEvidence('{{ $item['property']->id }}'), evidenceArchives.{{ $item['property']->id }}"
+                                        class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                                    >
+                                        Import ZIP
+                                    </button>
+                                </div>
+                                @error('evidenceArchives.'.$item['property']->id)
+                                    <div class="mt-2 text-xs text-red-600 dark:text-red-400">{{ $message }}</div>
+                                @enderror
+                            </div>
                         </div>
                     @endforeach
                 @endif

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\WebProperty;
+use App\Services\ManualSearchConsoleEvidenceImporter;
+use Illuminate\Console\Command;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
@@ -7,6 +10,47 @@ use Illuminate\Support\Facades\Schedule;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('analytics:import-search-console-evidence {property : Web property slug} {path : Path to the Google Search Console page indexing export ZIP} {--captured-by= : Optional captured_by value}', function (ManualSearchConsoleEvidenceImporter $importer) {
+    $propertyArgument = $this->argument('property');
+    $pathArgument = $this->argument('path');
+    $capturedByOption = $this->option('captured-by');
+
+    $property = WebProperty::query()
+        ->where('slug', is_string($propertyArgument) ? $propertyArgument : '')
+        ->first();
+
+    if (! $property instanceof WebProperty) {
+        $this->error('Could not find the requested web property.');
+
+        return Command::FAILURE;
+    }
+
+    try {
+        $result = $importer->importForProperty(
+            $property,
+            is_string($pathArgument) ? $pathArgument : '',
+            is_string($capturedByOption) && $capturedByOption !== ''
+                ? $capturedByOption
+                : 'artisan_manual_csv_import'
+        );
+    } catch (\Throwable $exception) {
+        $this->error($exception->getMessage());
+
+        return Command::FAILURE;
+    }
+
+    $baseline = $result['baseline'];
+
+    $this->info(sprintf(
+        'Imported manual Search Console evidence for [%s] and stored baseline [%s].',
+        $property->slug,
+        $baseline->id
+    ));
+    $this->line(sprintf('Artifact path: %s', $result['artifact_path']));
+
+    return Command::SUCCESS;
+})->purpose('Import a Google Search Console page indexing export ZIP and clear a manual CSV backlog item.');
 
 $brainConfigured = filled(config('services.brain.base_url')) && filled(config('services.brain.api_key'));
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -41,6 +41,22 @@ Artisan::command('analytics:import-search-console-evidence {property : Web prope
     }
 
     $baseline = $result['baseline'];
+    $tagRefreshMessage = null;
+    $primaryDomain = $property->primaryDomainName();
+
+    if (is_string($primaryDomain) && $primaryDomain !== '') {
+        try {
+            $tagRefreshExitCode = Artisan::call('coverage:sync-tags', [
+                '--domain' => [$primaryDomain],
+            ]);
+
+            if ($tagRefreshExitCode !== 0) {
+                $tagRefreshMessage = trim(Artisan::output()) ?: 'Coverage tags will refresh on the next scheduled sync.';
+            }
+        } catch (\Throwable $exception) {
+            $tagRefreshMessage = $exception->getMessage();
+        }
+    }
 
     $this->info(sprintf(
         'Imported manual Search Console evidence for [%s] and stored baseline [%s].',
@@ -48,6 +64,11 @@ Artisan::command('analytics:import-search-console-evidence {property : Web prope
         $baseline->id
     ));
     $this->line(sprintf('Artifact path: %s', $result['artifact_path']));
+    if (is_string($tagRefreshMessage) && $tagRefreshMessage !== '') {
+        $this->warn(sprintf('Coverage tags were not refreshed automatically: %s', $tagRefreshMessage));
+    } else {
+        $this->line('Coverage tags refreshed for the affected domain.');
+    }
 
     return Command::SUCCESS;
 })->purpose('Import a Google Search Console page indexing export ZIP and clear a manual CSV backlog item.');

--- a/tests/Feature/ImportSearchConsoleEvidenceCommandTest.php
+++ b/tests/Feature/ImportSearchConsoleEvidenceCommandTest.php
@@ -98,6 +98,8 @@ class ImportSearchConsoleEvidenceCommandTest extends TestCase
             'matomo_site_id' => '6',
             'search_console_property_uri' => 'sc-domain:moveroo.com.au',
             'search_type' => 'web',
+            'date_range_start' => '2025-12-31',
+            'date_range_end' => '2026-03-30',
             'import_method' => 'matomo_api',
             'clicks' => 287,
             'impressions' => 8200,
@@ -122,6 +124,8 @@ class ImportSearchConsoleEvidenceCommandTest extends TestCase
         $this->assertSame('test-suite', $latestBaseline->captured_by);
         $this->assertSame(287.0, $latestBaseline->clicks);
         $this->assertSame(8200.0, $latestBaseline->impressions);
+        $this->assertSame('2025-12-31', $latestBaseline->date_range_start?->toDateString());
+        $this->assertSame('2026-03-30', $latestBaseline->date_range_end?->toDateString());
         $this->assertSame(18, $latestBaseline->indexed_pages);
         $this->assertSame(186, $latestBaseline->not_indexed_pages);
         $this->assertSame(35, $latestBaseline->pages_with_redirect);
@@ -129,6 +133,106 @@ class ImportSearchConsoleEvidenceCommandTest extends TestCase
         $this->assertSame(23, $latestBaseline->duplicate_without_user_selected_canonical);
         Storage::disk('local')->assertExists($latestBaseline->artifact_path);
         $this->assertSame('complete', $property->fresh()->automationCoverageSummary()['status']);
+    }
+
+    public function test_it_rejects_import_when_property_is_not_waiting_on_manual_csv(): void
+    {
+        Storage::fake('local');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'already-complete.example.au',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'already-complete-site',
+            'name' => 'Already Complete Site',
+            'primary_domain_id' => $domain->id,
+            'status' => 'active',
+            'property_type' => 'website',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'production',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => 'already-complete-site-repo',
+            'local_path' => '/tmp/already-complete-site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '9',
+            'external_name' => 'Already Complete Site',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '9',
+            'external_name' => 'Already Complete Site',
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://already-complete.example.au/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '9',
+            'matomo_site_name' => 'Already Complete Site',
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:already-complete.example.au',
+            'property_type' => 'domain',
+            'latest_metric_date' => now()->subDay()->toDateString(),
+            'checked_at' => now(),
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now()->subDay(),
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '9',
+            'search_console_property_uri' => 'sc-domain:already-complete.example.au',
+            'search_type' => 'web',
+            'import_method' => 'matomo_plus_manual_csv',
+            'clicks' => 30,
+            'impressions' => 400,
+            'ctr' => 0.075,
+            'average_position' => 8.5,
+        ]);
+
+        $zipPath = $this->makeSearchConsoleExportZip();
+
+        $exitCode = Artisan::call('analytics:import-search-console-evidence', [
+            'property' => 'already-complete-site',
+            'path' => $zipPath,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(
+            'This property is not currently waiting on manual Search Console CSV evidence.',
+            trim(Artisan::output())
+        );
+        $this->assertCount(1, DomainSeoBaseline::query()->where('web_property_id', $property->id)->get());
     }
 
     private function makeSearchConsoleExportZip(): string

--- a/tests/Feature/ImportSearchConsoleEvidenceCommandTest.php
+++ b/tests/Feature/ImportSearchConsoleEvidenceCommandTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AnalyticsInstallAudit;
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use ZipArchive;
+
+class ImportSearchConsoleEvidenceCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_imports_manual_search_console_evidence_for_a_property(): void
+    {
+        Storage::fake('local');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo website',
+            'primary_domain_id' => $domain->id,
+            'status' => 'active',
+            'property_type' => 'website',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'production',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_provider' => 'local',
+            'repo_name' => 'moveroo-website-repo',
+            'local_path' => '/tmp/moveroo-website',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '6',
+            'external_name' => 'Moveroo website',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        AnalyticsInstallAudit::create([
+            'property_analytics_source_id' => $source->id,
+            'web_property_id' => $property->id,
+            'provider' => 'matomo',
+            'external_id' => '6',
+            'external_name' => 'Moveroo website',
+            'install_verdict' => 'installed_match',
+            'best_url' => 'https://moveroo.com.au/',
+            'summary' => 'Tracker matches the linked Matomo site.',
+            'checked_at' => now(),
+            'raw_payload' => ['verdict' => 'installed_match'],
+        ]);
+
+        SearchConsoleCoverageStatus::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '6',
+            'matomo_site_name' => 'Moveroo website',
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:moveroo.com.au',
+            'property_type' => 'domain',
+            'latest_metric_date' => now()->subDay()->toDateString(),
+            'checked_at' => now(),
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now()->subDay(),
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '6',
+            'search_console_property_uri' => 'sc-domain:moveroo.com.au',
+            'search_type' => 'web',
+            'import_method' => 'matomo_api',
+            'clicks' => 287,
+            'impressions' => 8200,
+            'ctr' => 0.034,
+            'average_position' => 12.8,
+        ]);
+
+        $zipPath = $this->makeSearchConsoleExportZip();
+
+        $exitCode = Artisan::call('analytics:import-search-console-evidence', [
+            'property' => 'moveroo-website',
+            'path' => $zipPath,
+            '--captured-by' => 'test-suite',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $latestBaseline = $domain->latestSeoBaseline()->first();
+
+        $this->assertNotNull($latestBaseline);
+        $this->assertSame('matomo_plus_manual_csv', $latestBaseline->import_method);
+        $this->assertSame('test-suite', $latestBaseline->captured_by);
+        $this->assertSame(287.0, $latestBaseline->clicks);
+        $this->assertSame(8200.0, $latestBaseline->impressions);
+        $this->assertSame(18, $latestBaseline->indexed_pages);
+        $this->assertSame(186, $latestBaseline->not_indexed_pages);
+        $this->assertSame(35, $latestBaseline->pages_with_redirect);
+        $this->assertSame(12, $latestBaseline->not_found_404);
+        $this->assertSame(23, $latestBaseline->duplicate_without_user_selected_canonical);
+        Storage::disk('local')->assertExists($latestBaseline->artifact_path);
+        $this->assertSame('complete', $property->fresh()->automationCoverageSummary()['status']);
+    }
+
+    private function makeSearchConsoleExportZip(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'sc-evidence-');
+        $zipPath = $path.'.zip';
+
+        @unlink($path);
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('Chart.csv', implode("\n", [
+            'Date,Not indexed,Indexed,Impressions',
+            '2026-03-29,188,18,140',
+            '2026-03-30,186,18,160',
+        ]));
+        $zip->addFromString('Critical issues.csv', implode("\n", [
+            'Reason,Source,Validation,Pages',
+            'Page with redirect,Website,Not Started,35',
+            'Duplicate without user-selected canonical,Website,Not Started,23',
+            'Not found (404),Website,Not Started,12',
+            'Alternative page with proper canonical tag,Website,Not Started,4',
+            'Crawled - currently not indexed,Google systems,Not Started,90',
+        ]));
+        $zip->addFromString('Non-critical issues.csv', "Reason,Source,Validation,Pages\n");
+        $zip->addFromString('Metadata.csv', implode("\n", [
+            'Property,Value',
+            'Sitemap,All known pages',
+        ]));
+        $zip->close();
+
+        return $zipPath;
+    }
+}

--- a/tests/Feature/ManualCsvBacklogQueueTest.php
+++ b/tests/Feature/ManualCsvBacklogQueueTest.php
@@ -143,7 +143,7 @@ class ManualCsvBacklogQueueTest extends TestCase
         $source = $this->attachMatomo($property, '701');
         $this->attachInstallAudit($property, $source);
         $this->attachCoverage($property, $source, 'domain_property', now()->subDay()->toDateString());
-        $this->attachBaseline($property, $source, 'matomo_api');
+        $this->attachBaseline($property, $source, 'matomo_api', now()->subMinute());
         $property->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
 
         $zipPath = $this->makeSearchConsoleExportZip();
@@ -155,7 +155,10 @@ class ManualCsvBacklogQueueTest extends TestCase
             ->test(ManualCsvBacklogQueue::class)
             ->set('evidenceArchives.'.$property->id, UploadedFile::fake()->createWithContent('page-indexing.zip', $zipContents))
             ->call('importEvidence', $property->id)
-            ->assertHasNoErrors()
+            ->assertHasNoErrors();
+
+        Livewire::actingAs($user)
+            ->test(ManualCsvBacklogQueue::class)
             ->assertViewHas('stats', fn (array $stats): bool => $stats['pending_properties'] === 0);
 
         $latestBaseline = $property->primaryDomainModel()?->latestSeoBaseline()->first();
@@ -167,6 +170,80 @@ class ManualCsvBacklogQueueTest extends TestCase
         $this->assertSame(35, $latestBaseline->pages_with_redirect);
         $this->assertSame('complete', $property->fresh()->automationCoverageSummary()['status']);
         Storage::disk('local')->assertExists($latestBaseline->artifact_path);
+    }
+
+    public function test_upload_uses_the_target_property_baseline_on_shared_domains(): void
+    {
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+        $manualCsvTag = DomainTag::create([
+            'name' => 'automation.manual_csv_pending',
+            'priority' => 68,
+            'color' => '#ca8a04',
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'shared-csv.example.au',
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $propertyA = WebProperty::factory()->create([
+            'slug' => 'shared-property-a',
+            'name' => 'Shared Property A',
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        $propertyB = WebProperty::factory()->create([
+            'slug' => 'shared-property-b',
+            'name' => 'Shared Property B',
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        foreach ([$propertyA, $propertyB] as $property) {
+            WebPropertyDomain::create([
+                'web_property_id' => $property->id,
+                'domain_id' => $domain->id,
+                'usage_type' => 'primary',
+                'is_canonical' => $property->id === $propertyA->id,
+            ]);
+            $this->attachRepository($property);
+            $property->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+        }
+
+        $sourceA = $this->attachMatomo($propertyA, '810');
+        $sourceB = $this->attachMatomo($propertyB, '811');
+        $this->attachInstallAudit($propertyA, $sourceA);
+        $this->attachInstallAudit($propertyB, $sourceB);
+        $this->attachCoverage($propertyA, $sourceA, 'domain_property', now()->subDay()->toDateString());
+        $this->attachCoverage($propertyB, $sourceB, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($propertyA, $sourceA, 'matomo_api', now()->subMinutes(2), 10, 100);
+        $this->attachBaseline($propertyB, $sourceB, 'matomo_api', now()->subMinute(), 999, 5000);
+
+        $zipPath = $this->makeSearchConsoleExportZip();
+        $zipContents = file_get_contents($zipPath);
+
+        $this->assertIsString($zipContents);
+
+        Livewire::actingAs($user)
+            ->test(ManualCsvBacklogQueue::class)
+            ->set('evidenceArchives.'.$propertyB->id, UploadedFile::fake()->createWithContent('page-indexing.zip', $zipContents))
+            ->call('importEvidence', $propertyB->id)
+            ->assertHasNoErrors();
+
+        $propertyBLatestBaseline = $propertyB->fresh()->latestPropertySeoBaselineRecord();
+
+        $this->assertNotNull($propertyBLatestBaseline);
+        $this->assertSame('matomo_plus_manual_csv', $propertyBLatestBaseline->import_method);
+        $this->assertSame(999.0, $propertyBLatestBaseline->clicks);
+        $this->assertSame(5000.0, $propertyBLatestBaseline->impressions);
+        $this->assertSame('complete', $propertyB->fresh()->automationCoverageSummary()['status']);
+        $this->assertSame('manual_csv_pending', $propertyA->fresh()->automationCoverageSummary()['status']);
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty
@@ -254,8 +331,14 @@ class ManualCsvBacklogQueueTest extends TestCase
         ]);
     }
 
-    private function attachBaseline(WebProperty $property, PropertyAnalyticsSource $source, string $importMethod, ?\Illuminate\Support\Carbon $capturedAt = null): void
-    {
+    private function attachBaseline(
+        WebProperty $property,
+        PropertyAnalyticsSource $source,
+        string $importMethod,
+        ?\Illuminate\Support\Carbon $capturedAt = null,
+        int $clicks = 10,
+        int $impressions = 100
+    ): void {
         DomainSeoBaseline::create([
             'domain_id' => $property->primary_domain_id,
             'web_property_id' => $property->id,
@@ -267,9 +350,9 @@ class ManualCsvBacklogQueueTest extends TestCase
             'search_console_property_uri' => 'sc-domain:'.$property->primaryDomainName(),
             'search_type' => 'web',
             'import_method' => $importMethod,
-            'clicks' => 10,
-            'impressions' => 100,
-            'ctr' => 0.1,
+            'clicks' => $clicks,
+            'impressions' => $impressions,
+            'ctr' => $impressions > 0 ? round($clicks / $impressions, 4) : 0.0,
             'average_position' => 12.4,
         ]);
     }

--- a/tests/Feature/ManualCsvBacklogQueueTest.php
+++ b/tests/Feature/ManualCsvBacklogQueueTest.php
@@ -14,9 +14,12 @@ use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 use Tests\TestCase;
+use ZipArchive;
 
 class ManualCsvBacklogQueueTest extends TestCase
 {
@@ -124,6 +127,48 @@ class ManualCsvBacklogQueueTest extends TestCase
             });
     }
 
+    public function test_operator_can_upload_search_console_zip_and_clear_manual_csv_backlog(): void
+    {
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+        $manualCsvTag = DomainTag::create([
+            'name' => 'automation.manual_csv_pending',
+            'priority' => 68,
+            'color' => '#ca8a04',
+        ]);
+
+        $property = $this->makeProperty('csv-pending.example.au', 'CSV Pending Site');
+        $this->attachRepository($property);
+        $source = $this->attachMatomo($property, '701');
+        $this->attachInstallAudit($property, $source);
+        $this->attachCoverage($property, $source, 'domain_property', now()->subDay()->toDateString());
+        $this->attachBaseline($property, $source, 'matomo_api');
+        $property->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualCsvTag->id]);
+
+        $zipPath = $this->makeSearchConsoleExportZip();
+        $zipContents = file_get_contents($zipPath);
+
+        $this->assertIsString($zipContents);
+
+        Livewire::actingAs($user)
+            ->test(ManualCsvBacklogQueue::class)
+            ->set('evidenceArchives.'.$property->id, UploadedFile::fake()->createWithContent('page-indexing.zip', $zipContents))
+            ->call('importEvidence', $property->id)
+            ->assertHasNoErrors()
+            ->assertViewHas('stats', fn (array $stats): bool => $stats['pending_properties'] === 0);
+
+        $latestBaseline = $property->primaryDomainModel()?->latestSeoBaseline()->first();
+
+        $this->assertNotNull($latestBaseline);
+        $this->assertSame('matomo_plus_manual_csv', $latestBaseline->import_method);
+        $this->assertSame(18, $latestBaseline->indexed_pages);
+        $this->assertSame(186, $latestBaseline->not_indexed_pages);
+        $this->assertSame(35, $latestBaseline->pages_with_redirect);
+        $this->assertSame('complete', $property->fresh()->automationCoverageSummary()['status']);
+        Storage::disk('local')->assertExists($latestBaseline->artifact_path);
+    }
+
     private function makeProperty(string $domainName, string $name): WebProperty
     {
         $domain = Domain::factory()->create([
@@ -227,5 +272,37 @@ class ManualCsvBacklogQueueTest extends TestCase
             'ctr' => 0.1,
             'average_position' => 12.4,
         ]);
+    }
+
+    private function makeSearchConsoleExportZip(): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'sc-export-');
+        $zipPath = $path.'.zip';
+
+        @unlink($path);
+
+        $zip = new ZipArchive;
+        $zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('Chart.csv', implode("\n", [
+            'Date,Not indexed,Indexed,Impressions',
+            '2026-03-29,188,18,140',
+            '2026-03-30,186,18,160',
+        ]));
+        $zip->addFromString('Critical issues.csv', implode("\n", [
+            'Reason,Source,Validation,Pages',
+            'Page with redirect,Website,Not Started,35',
+            'Duplicate without user-selected canonical,Website,Not Started,23',
+            'Not found (404),Website,Not Started,12',
+            'Alternative page with proper canonical tag,Website,Not Started,4',
+            'Crawled - currently not indexed,Google systems,Not Started,90',
+        ]));
+        $zip->addFromString('Non-critical issues.csv', "Reason,Source,Validation,Pages\n");
+        $zip->addFromString('Metadata.csv', implode("\n", [
+            'Property,Value',
+            'Sitemap,All known pages',
+        ]));
+        $zip->close();
+
+        return $zipPath;
     }
 }


### PR DESCRIPTION
## Summary
- add a manual Search Console page-indexing ZIP importer that creates a new SEO baseline with `matomo_plus_manual_csv`
- add an artisan command and backlog UI upload flow so operators can clear `manual_csv_pending` items directly in Domain Monitor
- cover the importer and Livewire upload flow with focused tests

## Testing
- ./vendor/bin/phpunit tests/Feature/ImportSearchConsoleEvidenceCommandTest.php tests/Feature/ManualCsvBacklogQueueTest.php tests/Feature/ImportMatomoSearchConsoleBaselineCommandTest.php
- ./vendor/bin/phpstan analyse app/Services/ManualSearchConsoleEvidenceImporter.php app/Livewire/ManualCsvBacklogQueue.php tests/Feature/ImportSearchConsoleEvidenceCommandTest.php tests/Feature/ManualCsvBacklogQueueTest.php routes/console.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
