### PR TITLE
Promote page-with-redirect issues into fleet queue

### DIFF
--- a/app/Console/Commands/RefreshShouldFixQueue.php
+++ b/app/Console/Commands/RefreshShouldFixQueue.php
@@ -42,6 +42,7 @@ class RefreshShouldFixQueue extends Command
                 'platform',
                 'webProperties:id,slug,name,property_type,status',
                 'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+                'webProperties.latestSeoBaselineForProperty',
             ])
             ->withLatestCheckStatuses()
             ->withCount([

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -36,7 +36,7 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties',
+                'webProperties:id,slug,name,property_type,status',
                 'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
                 'webProperties.latestSeoBaselineForProperty',
             ])
@@ -159,9 +159,11 @@ class DashboardIssueQueueService
             $shouldFix[] = $coverageReason;
         }
 
-        [$baselineMustFixReasons, $baselineShouldFixReasons] = $this->seoBaselineReasonSet($property);
-        $mustFix = array_merge($mustFix, $baselineMustFixReasons);
-        $shouldFix = array_merge($shouldFix, $baselineShouldFixReasons);
+        if ($this->requiresControlCoverage($domain, $property) && ! $domain->shouldSkipMonitoringCheck('seo')) {
+            [$baselineMustFixReasons, $baselineShouldFixReasons] = $this->seoBaselineReasonSet($property);
+            $mustFix = array_merge($mustFix, $baselineMustFixReasons);
+            $shouldFix = array_merge($shouldFix, $baselineShouldFixReasons);
+        }
 
         return [
             array_values(array_unique($mustFix)),
@@ -191,13 +193,6 @@ class DashboardIssueQueueService
             $mustFix[] = sprintf(
                 'Search Console reports page with redirect (%d URLs)',
                 (int) $baseline->pages_with_redirect
-            );
-        }
-
-        if ((int) ($baseline->blocked_by_robots ?? 0) > 0) {
-            $mustFix[] = sprintf(
-                'Search Console reports indexable pages blocked by robots (%d URLs)',
-                (int) $baseline->blocked_by_robots
             );
         }
 
@@ -449,7 +444,11 @@ class DashboardIssueQueueService
      */
     private function deriveIssueFamilies(Domain $domain, array $item): array
     {
-        $families = $this->reasonDerivedIssueFamilies($item);
+        $families = [];
+
+        if (in_array('page_with_redirect_in_sitemap', $this->reasonDerivedIssueFamilies($item), true)) {
+            $families[] = 'page_with_redirect_in_sitemap';
+        }
 
         if ((int) ($domain->open_critical_alerts_count ?? 0) > 0 || (int) ($domain->open_warning_alerts_count ?? 0) > 0) {
             $families[] = 'alerts.open';
@@ -519,45 +518,8 @@ class DashboardIssueQueueService
 
         $families = [];
 
-        if (preg_match('/http[^|]*200|http url returns 200|http page accessible|http accessible/', $reasonText)) {
-            $families[] = 'health.http';
-            $families[] = 'http_url_returns_200';
-        }
-
-        if (preg_match('/https[^|]*redirect|redirect[^|]*https|force https|https not enforced|missing https redirect|http\\/https duplicate/', $reasonText)) {
-            $families[] = 'duplicate_http_https';
-        }
-
-        if (preg_match('/google chose different canonical/', $reasonText)) {
-            $families[] = 'google_chose_different_canonical';
-        }
-
-        if (preg_match('/canonical/', $reasonText) && preg_match('/(host|www|non-www|domain)/', $reasonText)) {
-            $families[] = 'canonical_host_mismatch';
-        }
-
-        if (preg_match('/canonical/', $reasonText) && preg_match('/(https|http|protocol)/', $reasonText)) {
-            $families[] = 'canonical_protocol_mismatch';
-        }
-
-        if (preg_match('/sitemap/', $reasonText) && preg_match('/noindex/', $reasonText)) {
-            $families[] = 'sitemap_includes_noindex';
-        }
-
         if (preg_match('/page with redirect/', $reasonText) || (preg_match('/sitemap/', $reasonText) && preg_match('/redirect/', $reasonText))) {
             $families[] = 'page_with_redirect_in_sitemap';
-        }
-
-        if (preg_match('/robots|blocked by robots|crawl blocked|indexable page blocked/', $reasonText)) {
-            $families[] = 'indexable_page_blocked';
-        }
-
-        if (preg_match('/missing hsts|hsts/', $reasonText)) {
-            $families[] = 'missing_hsts';
-        }
-
-        if (preg_match('/security headers|missing headers|content-security-policy|csp|x-frame-options|permissions-policy/', $reasonText)) {
-            $families[] = 'missing_security_headers';
         }
 
         return $families;

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -436,9 +436,6 @@ class DashboardIssueQueueService
     }
 
     /**
-     * @return array<int, string>
-     */
-    /**
      * @param  array<string, mixed>  $item
      * @return array<int, string>
      */
@@ -507,19 +504,28 @@ class DashboardIssueQueueService
      */
     private function reasonDerivedIssueFamilies(array $item): array
     {
-        $reasonText = strtolower(trim(implode(' | ', array_merge(
-            array_map('strval', is_array($item['primary_reasons'] ?? null) ? $item['primary_reasons'] : []),
-            array_map('strval', is_array($item['secondary_reasons'] ?? null) ? $item['secondary_reasons'] : []),
-        ))));
+        $reasonSegments = array_values(array_filter(array_map(
+            static fn (mixed $reason): string => strtolower(trim((string) $reason)),
+            array_merge(
+                is_array($item['primary_reasons'] ?? null) ? $item['primary_reasons'] : [],
+                is_array($item['secondary_reasons'] ?? null) ? $item['secondary_reasons'] : [],
+            )
+        )));
 
-        if ($reasonText === '') {
+        if ($reasonSegments === []) {
             return [];
         }
 
         $families = [];
 
-        if (preg_match('/page with redirect/', $reasonText) || (preg_match('/sitemap/', $reasonText) && preg_match('/redirect/', $reasonText))) {
+        foreach ($reasonSegments as $reasonText) {
+            if (! preg_match('/page with redirect/', $reasonText)
+                && ! (preg_match('/sitemap/', $reasonText) && preg_match('/redirect/', $reasonText))) {
+                continue;
+            }
+
             $families[] = 'page_with_redirect_in_sitemap';
+            break;
         }
 
         return $families;

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -36,8 +36,9 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties:id,slug,name,property_type,status',
+                'webProperties',
                 'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+                'webProperties.latestSeoBaselineForProperty',
             ])
             ->withLatestCheckStatuses()
             ->withCount([
@@ -85,6 +86,7 @@ class DashboardIssueQueueService
             $coverageStatus = $this->controlCoverageStatus($domain, $property);
             [$mustFixReasons, $shouldFixReasons] = $this->issueReasonsForDomain(
                 $domain,
+                $property,
                 $this->controlCoverageReasonForStatus($coverageStatus)
             );
 
@@ -112,7 +114,7 @@ class DashboardIssueQueueService
     /**
      * @return array{0: array<int, string>, 1: array<int, string>}
      */
-    private function issueReasonsForDomain(Domain $domain, ?string $coverageReason): array
+    private function issueReasonsForDomain(Domain $domain, ?WebProperty $property, ?string $coverageReason): array
     {
         $mustFix = [];
         $shouldFix = [];
@@ -157,10 +159,49 @@ class DashboardIssueQueueService
             $shouldFix[] = $coverageReason;
         }
 
+        [$baselineMustFixReasons, $baselineShouldFixReasons] = $this->seoBaselineReasonSet($property);
+        $mustFix = array_merge($mustFix, $baselineMustFixReasons);
+        $shouldFix = array_merge($shouldFix, $baselineShouldFixReasons);
+
         return [
             array_values(array_unique($mustFix)),
             array_values(array_unique($shouldFix)),
         ];
+    }
+
+    /**
+     * @return array{0: array<int, string>, 1: array<int, string>}
+     */
+    private function seoBaselineReasonSet(?WebProperty $property): array
+    {
+        if (! $property instanceof WebProperty) {
+            return [[], []];
+        }
+
+        $baseline = $property->latestPropertySeoBaselineRecord();
+
+        if ($baseline === null) {
+            return [[], []];
+        }
+
+        $mustFix = [];
+        $shouldFix = [];
+
+        if ((int) ($baseline->pages_with_redirect ?? 0) > 0) {
+            $mustFix[] = sprintf(
+                'Search Console reports page with redirect (%d URLs)',
+                (int) $baseline->pages_with_redirect
+            );
+        }
+
+        if ((int) ($baseline->blocked_by_robots ?? 0) > 0) {
+            $mustFix[] = sprintf(
+                'Search Console reports indexable pages blocked by robots (%d URLs)',
+                (int) $baseline->blocked_by_robots
+            );
+        }
+
+        return [$mustFix, $shouldFix];
     }
 
     /**
@@ -314,7 +355,7 @@ class DashboardIssueQueueService
     private function enrichQueueItem(Domain $domain, ?WebProperty $property, array $item): array
     {
         $standards = config('domain_monitor.priority_queue_standards', []);
-        $issueFamilies = $this->deriveIssueFamilies($domain);
+        $issueFamilies = $this->deriveIssueFamilies($domain, $item);
         if (($item['coverage_gap'] ?? false) === true) {
             $issueFamilies[] = 'control.coverage_required';
         }
@@ -402,9 +443,13 @@ class DashboardIssueQueueService
     /**
      * @return array<int, string>
      */
-    private function deriveIssueFamilies(Domain $domain): array
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<int, string>
+     */
+    private function deriveIssueFamilies(Domain $domain, array $item): array
     {
-        $families = [];
+        $families = $this->reasonDerivedIssueFamilies($item);
 
         if ((int) ($domain->open_critical_alerts_count ?? 0) > 0 || (int) ($domain->open_warning_alerts_count ?? 0) > 0) {
             $families[] = 'alerts.open';
@@ -455,6 +500,67 @@ class DashboardIssueQueueService
         }
 
         return array_values(array_unique($families));
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<int, string>
+     */
+    private function reasonDerivedIssueFamilies(array $item): array
+    {
+        $reasonText = strtolower(trim(implode(' | ', array_merge(
+            array_map('strval', is_array($item['primary_reasons'] ?? null) ? $item['primary_reasons'] : []),
+            array_map('strval', is_array($item['secondary_reasons'] ?? null) ? $item['secondary_reasons'] : []),
+        ))));
+
+        if ($reasonText === '') {
+            return [];
+        }
+
+        $families = [];
+
+        if (preg_match('/http[^|]*200|http url returns 200|http page accessible|http accessible/', $reasonText)) {
+            $families[] = 'health.http';
+            $families[] = 'http_url_returns_200';
+        }
+
+        if (preg_match('/https[^|]*redirect|redirect[^|]*https|force https|https not enforced|missing https redirect|http\\/https duplicate/', $reasonText)) {
+            $families[] = 'duplicate_http_https';
+        }
+
+        if (preg_match('/google chose different canonical/', $reasonText)) {
+            $families[] = 'google_chose_different_canonical';
+        }
+
+        if (preg_match('/canonical/', $reasonText) && preg_match('/(host|www|non-www|domain)/', $reasonText)) {
+            $families[] = 'canonical_host_mismatch';
+        }
+
+        if (preg_match('/canonical/', $reasonText) && preg_match('/(https|http|protocol)/', $reasonText)) {
+            $families[] = 'canonical_protocol_mismatch';
+        }
+
+        if (preg_match('/sitemap/', $reasonText) && preg_match('/noindex/', $reasonText)) {
+            $families[] = 'sitemap_includes_noindex';
+        }
+
+        if (preg_match('/page with redirect/', $reasonText) || (preg_match('/sitemap/', $reasonText) && preg_match('/redirect/', $reasonText))) {
+            $families[] = 'page_with_redirect_in_sitemap';
+        }
+
+        if (preg_match('/robots|blocked by robots|crawl blocked|indexable page blocked/', $reasonText)) {
+            $families[] = 'indexable_page_blocked';
+        }
+
+        if (preg_match('/missing hsts|hsts/', $reasonText)) {
+            $families[] = 'missing_hsts';
+        }
+
+        if (preg_match('/security headers|missing headers|content-security-policy|csp|x-frame-options|permissions-policy/', $reasonText)) {
+            $families[] = 'missing_security_headers';
+        }
+
+        return $families;
     }
 
     private function matchesCheckStatus(Domain $domain, string $checkType): bool

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -552,6 +552,13 @@ return [
             'seo.fundamentals' => [
                 'issue_families' => ['seo.fundamentals'],
             ],
+            'seo.robots_and_sitemap_consistency' => [
+                'issue_families' => [
+                    'sitemap_includes_noindex',
+                    'indexable_page_blocked',
+                    'page_with_redirect_in_sitemap',
+                ],
+            ],
             'seo.broken_links' => [
                 'issue_families' => ['seo.broken_links'],
             ],

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -554,8 +554,6 @@ return [
             ],
             'seo.robots_and_sitemap_consistency' => [
                 'issue_families' => [
-                    'sitemap_includes_noindex',
-                    'indexable_page_blocked',
                     'page_with_redirect_in_sitemap',
                 ],
             ],

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\DomainSeoBaseline;
 use App\Models\PropertyRepository;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
@@ -197,7 +198,7 @@ class DashboardPriorityQueueApiTest extends TestCase
         $astroShouldFix = $shouldFixDomains->firstWhere('domain', 'should-fix.example.com');
 
         $this->assertIsArray($astroShouldFix);
-        $this->assertSame('security.headers_baseline', $astroShouldFix['issue_family']);
+        $this->assertSame('missing_security_headers', $astroShouldFix['issue_family']);
         $this->assertSame('security.headers_baseline', $astroShouldFix['control_id']);
         $this->assertSame('astro_marketing_managed', $astroShouldFix['platform_profile']);
         $this->assertSame('vercel_astro', $astroShouldFix['host_profile']);
@@ -288,5 +289,95 @@ class DashboardPriorityQueueApiTest extends TestCase
         $this->assertSame('Zeta Site', $shouldFix['web_property_name']);
         $this->assertSame('controlled', $shouldFix['coverage_status']);
         $this->assertFalse($shouldFix['coverage_gap']);
+    }
+
+    public function test_priority_queue_promotes_page_with_redirect_baseline_issue_into_fleet_standard_gap(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        $standards = config('domain_monitor.priority_queue_standards', []);
+        $controls = is_array(data_get($standards, 'controls')) ? data_get($standards, 'controls') : [];
+        $controls['seo.robots_and_sitemap_consistency'] = [
+            'issue_families' => [
+                'sitemap_includes_noindex',
+                'indexable_page_blocked',
+                'page_with_redirect_in_sitemap',
+            ],
+        ];
+        $standards['controls'] = $controls;
+        config()->set('domain_monitor.priority_queue_standards', $standards);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'redirect-gap.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Synergy Wholesale PTY',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'redirect-gap-site',
+            'name' => 'Redirect Gap Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => '_wp-house',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '15',
+            'search_console_property_uri' => 'sc-domain:redirect-gap.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 0,
+            'impressions' => 0,
+            'ctr' => 0,
+            'average_position' => 0,
+            'indexed_pages' => 12,
+            'not_indexed_pages' => 18,
+            'pages_with_redirect' => 7,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 7]]],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk()->assertJsonPath('contract_version', 2);
+
+        $mustFix = collect($response->json('must_fix'))->firstWhere('domain', 'redirect-gap.example.com');
+
+        $this->assertIsArray($mustFix);
+        $this->assertContains('Search Console reports page with redirect (7 URLs)', $mustFix['primary_reasons']);
+        $this->assertSame('page_with_redirect_in_sitemap', $mustFix['issue_family']);
+        $this->assertContains('page_with_redirect_in_sitemap', $mustFix['issue_families']);
+        $this->assertSame('seo.robots_and_sitemap_consistency', $mustFix['control_id']);
+        $this->assertSame('wordpress_house_managed', $mustFix['platform_profile']);
+        $this->assertSame('ventra_litespeed_wordpress', $mustFix['host_profile']);
+        $this->assertSame('leadgen_wordpress_core', $mustFix['control_profile']);
+        $this->assertSame('shared_wordpress_house_and_live_host_config', $mustFix['baseline_surface']);
+        $this->assertSame('fleet', $mustFix['rollout_scope']);
+        $this->assertTrue($mustFix['is_standard_gap']);
     }
 }

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -156,6 +156,53 @@ class DashboardPriorityQueueApiTest extends TestCase
             'status' => 'warn',
         ]);
 
+        $emailOnlyProperty = WebProperty::factory()->create([
+            'slug' => 'mail-only-site',
+            'name' => 'Mail Only Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $emailOnlyDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $emailOnlyProperty->id,
+            'domain_id' => $emailOnlyDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $emailOnlyProperty->id,
+            'repo_name' => 'mail-only-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/mail-only-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $emailOnlyDomain->id,
+            'web_property_id' => $emailOnlyProperty->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '99',
+            'search_console_property_uri' => 'sc-domain:mail-only.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 0,
+            'impressions' => 0,
+            'ctr' => 0,
+            'average_position' => 0,
+            'indexed_pages' => 1,
+            'not_indexed_pages' => 3,
+            'pages_with_redirect' => 4,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 4]]],
+        ]);
+
         $response = $this->withHeaders([
             'Authorization' => 'Bearer test-api-key',
         ])->getJson('/api/dashboard/priority-queue');
@@ -198,7 +245,7 @@ class DashboardPriorityQueueApiTest extends TestCase
         $astroShouldFix = $shouldFixDomains->firstWhere('domain', 'should-fix.example.com');
 
         $this->assertIsArray($astroShouldFix);
-        $this->assertSame('missing_security_headers', $astroShouldFix['issue_family']);
+        $this->assertSame('security.headers_baseline', $astroShouldFix['issue_family']);
         $this->assertSame('security.headers_baseline', $astroShouldFix['control_id']);
         $this->assertSame('astro_marketing_managed', $astroShouldFix['platform_profile']);
         $this->assertSame('vercel_astro', $astroShouldFix['host_profile']);
@@ -298,8 +345,6 @@ class DashboardPriorityQueueApiTest extends TestCase
         $controls = is_array(data_get($standards, 'controls')) ? data_get($standards, 'controls') : [];
         $controls['seo.robots_and_sitemap_consistency'] = [
             'issue_families' => [
-                'sitemap_includes_noindex',
-                'indexable_page_blocked',
                 'page_with_redirect_in_sitemap',
             ],
         ];


### PR DESCRIPTION
## Summary
- derive specific fleet issue families from queue reason text instead of only generic domain check buckets
- surface Search Console baseline redirect and robots issues as explicit queue reasons
- map page-with-redirect issues to the sitemap hygiene fleet control for managed sites

## Testing
- ./vendor/bin/phpunit tests/Feature/DashboardPriorityQueueApiTest.php
- ./vendor/bin/phpstan analyse app/Services/DashboardIssueQueueService.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
