### PR TITLE
Stabilize domain detail add-record modals

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -33,6 +33,10 @@ $maxWidth = [
         nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
         prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
         close() {
+            if (! this.show) {
+                return
+            }
+
             this.show = false
 
             if (this.closeAction && this.$wire && typeof this.$wire[this.closeAction] === 'function') {
@@ -49,7 +53,7 @@ $maxWidth = [
         }
     })"
     x-on:open-modal.window="$event.detail == '{{ $name }}' ? show = true : null"
-    x-on:close-modal.window="$event.detail == '{{ $name }}' ? show = false : null"
+    x-on:close-modal.window="$event.detail == '{{ $name }}' ? close() : null"
     x-on:close.stop="close()"
     x-on:keydown.escape.window="close()"
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,7 +1,8 @@
 @props([
     'name',
     'show' => false,
-    'maxWidth' => '2xl'
+    'maxWidth' => '2xl',
+    'closeAction' => null,
 ])
 
 @php
@@ -17,6 +18,7 @@ $maxWidth = [
 <div
     x-data="{
         show: @js($show),
+        closeAction: @js($closeAction),
         focusables() {
             // All focusable element types...
             let selector = 'a, button, input:not([type=\'hidden\']), textarea, select, details, [tabindex]:not([tabindex=\'-1\'])'
@@ -30,6 +32,13 @@ $maxWidth = [
         prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
         nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
         prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) -1 },
+        close() {
+            this.show = false
+
+            if (this.closeAction && this.$wire && typeof this.$wire[this.closeAction] === 'function') {
+                this.$wire[this.closeAction]()
+            }
+        },
     }"
     x-init="$watch('show', value => {
         if (value) {
@@ -41,8 +50,8 @@ $maxWidth = [
     })"
     x-on:open-modal.window="$event.detail == '{{ $name }}' ? show = true : null"
     x-on:close-modal.window="$event.detail == '{{ $name }}' ? show = false : null"
-    x-on:close.stop="show = false"
-    x-on:keydown.escape.window="show = false"
+    x-on:close.stop="close()"
+    x-on:keydown.escape.window="close()"
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
     x-show="show"
@@ -52,7 +61,7 @@ $maxWidth = [
     <div
         x-show="show"
         class="fixed inset-0 transform transition-all"
-        x-on:click="show = false"
+        x-on:click="close()"
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"

--- a/resources/views/livewire/domain-detail/sections/modals.blade.php
+++ b/resources/views/livewire/domain-detail/sections/modals.blade.php
@@ -1,145 +1,133 @@
 <!-- DNS Record Add/Edit Modal -->
-@if($showDnsRecordModal)
-    <div class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" style="display: block;">
-        <div class="fixed inset-0 bg-gray-500 dark:bg-gray-900 opacity-75" wire:click="closeDnsRecordModal"></div>
+<x-modal name="dns-record" :show="$showDnsRecordModal" focusable wire:key="dns-record-modal">
+    <form wire:submit="saveDnsRecord" class="p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+            {{ $editingDnsRecordId ? 'Edit DNS Record' : 'Add DNS Record' }}
+        </h2>
 
-        <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:max-w-2xl sm:mx-auto relative">
-            <form wire:submit="saveDnsRecord" class="p-6">
-                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-                    {{ $editingDnsRecordId ? 'Edit DNS Record' : 'Add DNS Record' }}
-                </h2>
+        @if (session()->has('error'))
+            <div class="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded">
+                <p class="text-sm font-medium">{{ session('error') }}</p>
+            </div>
+        @endif
 
-                @if (session()->has('error'))
-                    <div class="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded">
-                        <p class="text-sm font-medium">{{ session('error') }}</p>
-                    </div>
+        @if ($errors->any())
+            <div class="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded">
+                <p class="text-sm font-medium mb-1">Please fix the following errors:</p>
+                <ul class="list-disc list-inside text-sm">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        <div class="space-y-4">
+            <div>
+                <x-input-label for="dns_record_host" value="Host/Subdomain" />
+                <x-text-input wire:model="dnsRecordHost" id="dns_record_host" type="text" class="mt-1 block w-full" placeholder="e.g., www, mail, or leave empty/@ for root" />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Leave empty or use @ for root domain. Enter subdomain name (e.g., www, mail) for subdomain records.</p>
+                <x-input-error :messages="$errors->get('dnsRecordHost')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="dns_record_type" value="Type" />
+                <select wire:model="dnsRecordType" id="dns_record_type" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-blue-500 focus:ring-blue-500 shadow-xs">
+                    <option value="A">A (IPv4 Address)</option>
+                    <option value="AAAA">AAAA (IPv6 Address)</option>
+                    <option value="CNAME">CNAME (Canonical Name)</option>
+                    <option value="MX">MX (Mail Exchange)</option>
+                    <option value="NS">NS (Name Server)</option>
+                    <option value="TXT">TXT (Text Record)</option>
+                    <option value="SRV">SRV (Service Record)</option>
+                    <option value="CAA">CAA (Certificate Authority Authorization)</option>
+                </select>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Use CAA only when you intentionally manage certificate authorities. Format example: <code>0 issue "letsencrypt.org"</code></p>
+                <x-input-error :messages="$errors->get('dnsRecordType')" class="mt-2" />
+            </div>
+
+            <div>
+                <x-input-label for="dns_record_value" value="Value" />
+                <x-text-input wire:model="dnsRecordValue" id="dns_record_value" type="text" class="mt-1 block w-full" placeholder="e.g., 192.0.2.1 or example.com" required />
+                @if($dnsRecordType === 'CAA')
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CAA records must include a numeric flag, tag, and quoted value. Example: <code>0 issue "letsencrypt.org"</code></p>
                 @endif
+                <x-input-error :messages="$errors->get('dnsRecordValue')" class="mt-2" />
+            </div>
 
-                @if ($errors->any())
-                    <div class="mb-4 p-3 bg-red-100 dark:bg-red-900/30 border border-red-400 dark:border-red-700 text-red-700 dark:text-red-300 rounded">
-                        <p class="text-sm font-medium mb-1">Please fix the following errors:</p>
-                        <ul class="list-disc list-inside text-sm">
-                            @foreach ($errors->all() as $error)
-                                <li>{{ $error }}</li>
-                            @endforeach
-                        </ul>
-                    </div>
-                @endif
+            <div>
+                <x-input-label for="dns_record_ttl" value="TTL (seconds)" />
+                <x-text-input wire:model="dnsRecordTtl" id="dns_record_ttl" type="number" min="60" max="86400" class="mt-1 block w-full" required />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Common values: 300 (5 min), 3600 (1 hour), 86400 (1 day)</p>
+                <x-input-error :messages="$errors->get('dnsRecordTtl')" class="mt-2" />
+            </div>
 
-                <div class="space-y-4">
-                    <div>
-                        <x-input-label for="dns_record_host" value="Host/Subdomain" />
-                        <x-text-input wire:model="dnsRecordHost" id="dns_record_host" type="text" class="mt-1 block w-full" placeholder="e.g., www, mail, or leave empty/@ for root" />
-                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Leave empty or use @ for root domain. Enter subdomain name (e.g., www, mail) for subdomain records.</p>
-                        <x-input-error :messages="$errors->get('dnsRecordHost')" class="mt-2" />
-                    </div>
-
-                    <div>
-                        <x-input-label for="dns_record_type" value="Type" />
-                        <select wire:model="dnsRecordType" id="dns_record_type" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-blue-500 focus:ring-blue-500 shadow-xs">
-                            <option value="A">A (IPv4 Address)</option>
-                            <option value="AAAA">AAAA (IPv6 Address)</option>
-                            <option value="CNAME">CNAME (Canonical Name)</option>
-                            <option value="MX">MX (Mail Exchange)</option>
-                            <option value="NS">NS (Name Server)</option>
-                            <option value="TXT">TXT (Text Record)</option>
-                            <option value="SRV">SRV (Service Record)</option>
-                            <option value="CAA">CAA (Certificate Authority Authorization)</option>
-                        </select>
-                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Use CAA only when you intentionally manage certificate authorities. Format example: <code>0 issue "letsencrypt.org"</code></p>
-                        <x-input-error :messages="$errors->get('dnsRecordType')" class="mt-2" />
-                    </div>
-
-                    <div>
-                        <x-input-label for="dns_record_value" value="Value" />
-                        <x-text-input wire:model="dnsRecordValue" id="dns_record_value" type="text" class="mt-1 block w-full" placeholder="e.g., 192.0.2.1 or example.com" required />
-                        @if($dnsRecordType === 'CAA')
-                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">CAA records must include a numeric flag, tag, and quoted value. Example: <code>0 issue "letsencrypt.org"</code></p>
-                        @endif
-                        <x-input-error :messages="$errors->get('dnsRecordValue')" class="mt-2" />
-                    </div>
-
-                    <div>
-                        <x-input-label for="dns_record_ttl" value="TTL (seconds)" />
-                        <x-text-input wire:model="dnsRecordTtl" id="dns_record_ttl" type="number" min="60" max="86400" class="mt-1 block w-full" required />
-                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Common values: 300 (5 min), 3600 (1 hour), 86400 (1 day)</p>
-                        <x-input-error :messages="$errors->get('dnsRecordTtl')" class="mt-2" />
-                    </div>
-
-                    <div>
-                        <x-input-label for="dns_record_priority" value="Priority" />
-                        <x-text-input wire:model="dnsRecordPriority" id="dns_record_priority" type="number" min="0" max="65535" class="mt-1 block w-full" />
-                        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Required for MX records (typically 10-100)</p>
-                        <x-input-error :messages="$errors->get('dnsRecordPriority')" class="mt-2" />
-                    </div>
-                </div>
-
-                <div class="mt-6 flex justify-end gap-3">
-                    <x-secondary-button type="button" wire:click="closeDnsRecordModal" wire:loading.attr="disabled">
-                        Cancel
-                    </x-secondary-button>
-                    <x-primary-button type="submit" wire:loading.attr="disabled" wire:target="saveDnsRecord">
-                        <span wire:loading.remove wire:target="saveDnsRecord">
-                            {{ $editingDnsRecordId ? 'Update' : 'Add' }} Record
-                        </span>
-                        <span wire:loading wire:target="saveDnsRecord">
-                            <span class="inline-flex items-center">
-                                <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                </svg>
-                                Saving...
-                            </span>
-                        </span>
-                    </x-primary-button>
-                </div>
-            </form>
+            <div>
+                <x-input-label for="dns_record_priority" value="Priority" />
+                <x-text-input wire:model="dnsRecordPriority" id="dns_record_priority" type="number" min="0" max="65535" class="mt-1 block w-full" />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">Required for MX records (typically 10-100)</p>
+                <x-input-error :messages="$errors->get('dnsRecordPriority')" class="mt-2" />
+            </div>
         </div>
-    </div>
-@endif
+
+        <div class="mt-6 flex justify-end gap-3">
+            <x-secondary-button type="button" wire:click="closeDnsRecordModal" wire:loading.attr="disabled">
+                Cancel
+            </x-secondary-button>
+            <x-primary-button type="submit" wire:loading.attr="disabled" wire:target="saveDnsRecord">
+                <span wire:loading.remove wire:target="saveDnsRecord">
+                    {{ $editingDnsRecordId ? 'Update' : 'Add' }} Record
+                </span>
+                <span wire:loading wire:target="saveDnsRecord">
+                    <span class="inline-flex items-center">
+                        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        Saving...
+                    </span>
+                </span>
+            </x-primary-button>
+        </div>
+    </form>
+</x-modal>
 
 <!-- Subdomain Add/Edit Modal -->
-@if($showSubdomainModal)
-    <div class="fixed inset-0 overflow-y-auto px-4 py-6 sm:px-0 z-50" style="display: block;">
-        <div class="fixed inset-0 bg-gray-500 dark:bg-gray-900 opacity-75" wire:click="closeSubdomainModal"></div>
+<x-modal name="subdomain" :show="$showSubdomainModal" focusable wire:key="subdomain-modal">
+    <form wire:submit="saveSubdomain" class="p-6">
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+            {{ $editingSubdomainId ? 'Edit Subdomain' : 'Add Subdomain' }}
+        </h2>
 
-        <div class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full sm:max-w-2xl sm:mx-auto relative">
-            <form wire:submit="saveSubdomain" class="p-6">
-                <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
-                    {{ $editingSubdomainId ? 'Edit Subdomain' : 'Add Subdomain' }}
-                </h2>
+        <div class="space-y-4">
+            <div>
+                <x-input-label for="subdomain_name" value="Subdomain Name" />
+                <x-text-input wire:model="subdomainName" id="subdomain_name" type="text" class="mt-1 block w-full" placeholder="www, api, blog, etc." />
+                <x-input-error :messages="$errors->get('subdomainName')" class="mt-2" />
+                @if($domain && $subdomainName)
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        Full domain: <span class="font-mono">{{ $subdomainName }}.{{ $domain->domain }}</span>
+                    </p>
+                @endif
+            </div>
 
-                <div class="space-y-4">
-                    <div>
-                        <x-input-label for="subdomain_name" value="Subdomain Name" />
-                        <x-text-input wire:model="subdomainName" id="subdomain_name" type="text" class="mt-1 block w-full" placeholder="www, api, blog, etc." />
-                        <x-input-error :messages="$errors->get('subdomainName')" class="mt-2" />
-                        @if($domain && $subdomainName)
-                            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                                Full domain: <span class="font-mono">{{ $subdomainName }}.{{ $domain->domain }}</span>
-                            </p>
-                        @endif
-                    </div>
-
-                    <div>
-                        <x-input-label for="subdomain_notes" value="Notes (optional)" />
-                        <textarea wire:model="subdomainNotes" id="subdomain_notes" rows="3" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-blue-500 focus:ring-blue-500 shadow-xs" placeholder="Optional notes about this subdomain..."></textarea>
-                        <x-input-error :messages="$errors->get('subdomainNotes')" class="mt-2" />
-                    </div>
-                </div>
-
-                <div class="mt-6 flex justify-end gap-4">
-                    <x-secondary-button wire:click="closeSubdomainModal" type="button">
-                        Cancel
-                    </x-secondary-button>
-                    <x-primary-button type="submit">
-                        {{ $editingSubdomainId ? 'Update' : 'Add' }} Subdomain
-                    </x-primary-button>
-                </div>
-            </form>
+            <div>
+                <x-input-label for="subdomain_notes" value="Notes (optional)" />
+                <textarea wire:model="subdomainNotes" id="subdomain_notes" rows="3" class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-blue-500 focus:ring-blue-500 shadow-xs" placeholder="Optional notes about this subdomain..."></textarea>
+                <x-input-error :messages="$errors->get('subdomainNotes')" class="mt-2" />
+            </div>
         </div>
-    </div>
-@endif
+
+        <div class="mt-6 flex justify-end gap-4">
+            <x-secondary-button wire:click="closeSubdomainModal" type="button">
+                Cancel
+            </x-secondary-button>
+            <x-primary-button type="submit">
+                {{ $editingSubdomainId ? 'Update' : 'Add' }} Subdomain
+            </x-primary-button>
+        </div>
+    </form>
+</x-modal>
 
 <!-- Delete Confirmation Modal -->
 <x-modal name="delete-domain" :show="$showDeleteModal" focusable>

--- a/resources/views/livewire/domain-detail/sections/modals.blade.php
+++ b/resources/views/livewire/domain-detail/sections/modals.blade.php
@@ -1,5 +1,5 @@
 <!-- DNS Record Add/Edit Modal -->
-<x-modal name="dns-record" :show="$showDnsRecordModal" focusable wire:key="dns-record-modal">
+<x-modal name="dns-record" :show="$showDnsRecordModal" close-action="closeDnsRecordModal" focusable wire:key="dns-record-modal">
     <form wire:submit="saveDnsRecord" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
             {{ $editingDnsRecordId ? 'Edit DNS Record' : 'Add DNS Record' }}
@@ -93,7 +93,7 @@
 </x-modal>
 
 <!-- Subdomain Add/Edit Modal -->
-<x-modal name="subdomain" :show="$showSubdomainModal" focusable wire:key="subdomain-modal">
+<x-modal name="subdomain" :show="$showSubdomainModal" close-action="closeSubdomainModal" focusable wire:key="subdomain-modal">
     <form wire:submit="saveSubdomain" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
             {{ $editingSubdomainId ? 'Edit Subdomain' : 'Add Subdomain' }}
@@ -130,7 +130,7 @@
 </x-modal>
 
 <!-- Delete Confirmation Modal -->
-<x-modal name="delete-domain" :show="$showDeleteModal" focusable>
+<x-modal name="delete-domain" :show="$showDeleteModal" close-action="closeDeleteModal" focusable>
     <form wire:submit="deleteDomain" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
             {{ __('Are you sure you want to delete this domain?') }}

--- a/tests/Feature/DomainDetailActionsTest.php
+++ b/tests/Feature/DomainDetailActionsTest.php
@@ -32,7 +32,30 @@ class DomainDetailActionsTest extends TestCase
             ->set('dnsRecordPriority', 10)
             ->call('openAddDnsRecordModal')
             ->assertSet('showDnsRecordModal', true)
-            ->assertSee('Add DNS Record')
+            ->assertSet('editingDnsRecordId', null)
+            ->assertSet('dnsRecordHost', '')
+            ->assertSet('dnsRecordType', 'A')
+            ->assertSet('dnsRecordValue', '')
+            ->assertSet('dnsRecordTtl', 300)
+            ->assertSet('dnsRecordPriority', 0);
+    }
+
+    public function test_closing_dns_record_modal_resets_form_state(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'example.com.au',
+        ]);
+
+        Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
+            ->call('openAddDnsRecordModal')
+            ->set('editingDnsRecordId', 'existing-record')
+            ->set('dnsRecordHost', 'mail')
+            ->set('dnsRecordType', 'MX')
+            ->set('dnsRecordValue', 'mail.example.com.au')
+            ->set('dnsRecordTtl', 3600)
+            ->set('dnsRecordPriority', 10)
+            ->call('closeDnsRecordModal')
+            ->assertSet('showDnsRecordModal', false)
             ->assertSet('editingDnsRecordId', null)
             ->assertSet('dnsRecordHost', '')
             ->assertSet('dnsRecordType', 'A')
@@ -162,7 +185,6 @@ class DomainDetailActionsTest extends TestCase
         $synergyAlias->shouldReceive('isAustralianTld')
             ->with($domain->domain)
             ->andReturnTrue();
-        /** @phpstan-ignore-next-line */
         $synergyAlias->shouldNotReceive('fromEncryptedCredentials');
 
         Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
@@ -184,7 +206,6 @@ class DomainDetailActionsTest extends TestCase
 
         Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
             ->call('openAddSubdomainModal')
-            ->assertSee('Add Subdomain')
             ->set('subdomainName', 'api')
             ->set('subdomainNotes', 'Primary API')
             ->call('saveSubdomain')
@@ -197,6 +218,24 @@ class DomainDetailActionsTest extends TestCase
             'notes' => 'Primary API',
             'is_active' => 1,
         ]);
+    }
+
+    public function test_closing_subdomain_modal_resets_form_state(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'example.com',
+        ]);
+
+        Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
+            ->call('openAddSubdomainModal')
+            ->set('editingSubdomainId', 'existing-subdomain')
+            ->set('subdomainName', 'api')
+            ->set('subdomainNotes', 'Primary API')
+            ->call('closeSubdomainModal')
+            ->assertSet('showSubdomainModal', false)
+            ->assertSet('editingSubdomainId', null)
+            ->assertSet('subdomainName', '')
+            ->assertSet('subdomainNotes', '');
     }
 
     public function test_discover_subdomains_from_dns_only_adds_new_valid_hosts(): void

--- a/tests/Feature/DomainDetailActionsTest.php
+++ b/tests/Feature/DomainDetailActionsTest.php
@@ -32,6 +32,7 @@ class DomainDetailActionsTest extends TestCase
             ->set('dnsRecordPriority', 10)
             ->call('openAddDnsRecordModal')
             ->assertSet('showDnsRecordModal', true)
+            ->assertSee('Add DNS Record')
             ->assertSet('editingDnsRecordId', null)
             ->assertSet('dnsRecordHost', '')
             ->assertSet('dnsRecordType', 'A')
@@ -183,6 +184,7 @@ class DomainDetailActionsTest extends TestCase
 
         Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
             ->call('openAddSubdomainModal')
+            ->assertSee('Add Subdomain')
             ->set('subdomainName', 'api')
             ->set('subdomainNotes', 'Primary API')
             ->call('saveSubdomain')


### PR DESCRIPTION
## Summary
- switch the domain detail DNS and subdomain modals onto the shared x-modal component
- keep the modal DOM stable so Livewire no longer crashes when Add Record is clicked
- add small Livewire assertions that the modal content is actually rendered when opened

## Testing
- ./vendor/bin/phpunit tests/Feature/DomainDetailActionsTest.php

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
