### PR TITLE
Add normalized detected issues feed

### DIFF
--- a/app/Http/Controllers/Api/DetectedIssueController.php
+++ b/app/Http/Controllers/Api/DetectedIssueController.php
@@ -21,6 +21,6 @@ class DetectedIssueController extends Controller
             return response()->json(['error' => 'Not found'], 404);
         }
 
-        return response()->json(['data' => $issue]);
+        return response()->json($issue);
     }
 }

--- a/app/Http/Controllers/Api/DetectedIssueController.php
+++ b/app/Http/Controllers/Api/DetectedIssueController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\DetectedIssueSummaryService;
+use Illuminate\Http\JsonResponse;
+
+class DetectedIssueController extends Controller
+{
+    public function index(DetectedIssueSummaryService $service): JsonResponse
+    {
+        return response()->json($service->snapshot());
+    }
+
+    public function show(string $issueId, DetectedIssueSummaryService $service): JsonResponse
+    {
+        $issue = $service->find($issueId);
+
+        if ($issue === null) {
+            return response()->json(['error' => 'Not found'], 404);
+        }
+
+        return response()->json(['data' => $issue]);
+    }
+}

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Collection;
+
+class DetectedIssueSummaryService
+{
+    public function __construct(
+        private readonly DashboardIssueQueueService $queueService
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function snapshot(): array
+    {
+        $queueSnapshot = $this->queueService->snapshot();
+        $mustFix = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix');
+        $shouldFix = $this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix');
+        $issues = $mustFix->concat($shouldFix)->values();
+
+        return [
+            'source_system' => 'domain-monitor-issues',
+            'contract_version' => 1,
+            'generated_at' => $queueSnapshot['generated_at'] ?? now()->toIso8601String(),
+            'stats' => [
+                'open' => $issues->count(),
+                'must_fix' => $mustFix->count(),
+                'should_fix' => $shouldFix->count(),
+                'issue_class_counts' => $this->countByStringKey($issues, 'issue_class'),
+                'control_counts' => $this->countByStringKey($issues, 'control_id'),
+                'rollout_scope_counts' => $this->countByStringKey($issues, 'rollout_scope'),
+            ],
+            'issues' => $issues->all(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function find(string $issueId): ?array
+    {
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->snapshot()['issues'] ?? [];
+        /** @var array<string, mixed>|null $issue */
+        $issue = collect($issues)->firstWhere('issue_id', $issueId);
+
+        return $issue;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function flattenIssues(array $items, string $severity): Collection
+    {
+        return collect($items)
+            ->map(fn (array $item): array => $this->makeIssue($item, $severity))
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function makeIssue(array $item, string $severity): array
+    {
+        $issueClass = is_string($item['issue_family'] ?? null) && $item['issue_family'] !== ''
+            ? $item['issue_family']
+            : 'unclassified';
+        $domainId = (string) ($item['id'] ?? '');
+        $domain = is_string($item['domain'] ?? null) ? $item['domain'] : null;
+        $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+        $detectedAt = is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
+            ? $item['updated_at_iso']
+            : now()->toIso8601String();
+
+        return [
+            'issue_id' => "{$domainId}:{$severity}:{$issueClass}",
+            'property_slug' => $propertySlug,
+            'property_name' => is_string($item['web_property_name'] ?? null) ? $item['web_property_name'] : null,
+            'domain' => $domain,
+            'issue_class' => $issueClass,
+            'severity' => $severity,
+            'detector' => 'domain_monitor.priority_queue',
+            'status' => 'open',
+            'detected_at' => $detectedAt,
+            'rollout_scope' => is_string($item['rollout_scope'] ?? null) ? $item['rollout_scope'] : 'domain_only',
+            'control_id' => is_string($item['control_id'] ?? null) ? $item['control_id'] : null,
+            'platform_profile' => is_string($item['platform_profile'] ?? null) ? $item['platform_profile'] : null,
+            'host_profile' => is_string($item['host_profile'] ?? null) ? $item['host_profile'] : null,
+            'control_profile' => is_string($item['control_profile'] ?? null) ? $item['control_profile'] : null,
+            'evidence' => [
+                'primary_reasons' => array_values(array_filter($item['primary_reasons'] ?? [], 'is_string')),
+                'secondary_reasons' => array_values(array_filter($item['secondary_reasons'] ?? [], 'is_string')),
+                'related_issue_classes' => array_values(array_filter($item['issue_families'] ?? [], 'is_string')),
+                'coverage_required' => (bool) ($item['coverage_required'] ?? false),
+                'coverage_status' => is_string($item['coverage_status'] ?? null) ? $item['coverage_status'] : null,
+                'coverage_gap' => (bool) ($item['coverage_gap'] ?? false),
+                'property_match_confidence' => is_string($item['property_match_confidence'] ?? null) ? $item['property_match_confidence'] : null,
+                'baseline_surface' => is_string($item['baseline_surface'] ?? null) ? $item['baseline_surface'] : null,
+                'source_domain_id' => $domainId,
+            ],
+        ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $issues
+     * @return array<string, int>
+     */
+    private function countByStringKey(Collection $issues, string $key): array
+    {
+        $counts = [];
+
+        foreach ($issues as $issue) {
+            $value = $issue[$key] ?? null;
+
+            if (! is_string($value) || $value === '') {
+                continue;
+            }
+
+            $counts[$value] = ($counts[$value] ?? 0) + 1;
+        }
+
+        ksort($counts);
+
+        return $counts;
+    }
+}

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Collection;
 
 class DetectedIssueSummaryService
 {
+    /**
+     * @var array<string, mixed>|null
+     */
+    private ?array $cachedSnapshot = null;
+
     public function __construct(
         private readonly DashboardIssueQueueService $queueService
     ) {}
@@ -15,12 +20,16 @@ class DetectedIssueSummaryService
      */
     public function snapshot(): array
     {
+        if ($this->cachedSnapshot !== null) {
+            return $this->cachedSnapshot;
+        }
+
         $queueSnapshot = $this->queueService->snapshot();
         $mustFix = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix');
         $shouldFix = $this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix');
         $issues = $mustFix->concat($shouldFix)->values();
 
-        return [
+        return $this->cachedSnapshot = [
             'source_system' => 'domain-monitor-issues',
             'contract_version' => 1,
             'generated_at' => $queueSnapshot['generated_at'] ?? now()->toIso8601String(),
@@ -75,9 +84,23 @@ class DetectedIssueSummaryService
         $detectedAt = is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
             ? $item['updated_at_iso']
             : now()->toIso8601String();
+        $issueFamilies = array_values(array_unique(array_filter($item['issue_families'] ?? [], 'is_string')));
+        sort($issueFamilies);
+        $issueIdentity = [
+            'source_domain_id' => $domainId,
+            'property_slug' => $propertySlug,
+            'control_id' => is_string($item['control_id'] ?? null) ? $item['control_id'] : null,
+            'issue_families' => $issueFamilies,
+            'coverage_status' => is_string($item['coverage_status'] ?? null) ? $item['coverage_status'] : null,
+        ];
+        $issueId = sprintf(
+            'dm:%s:%s',
+            $domainId !== '' ? $domainId : 'unknown',
+            substr(sha1(json_encode($issueIdentity, JSON_THROW_ON_ERROR)), 0, 16)
+        );
 
         return [
-            'issue_id' => "{$domainId}:{$severity}:{$issueClass}",
+            'issue_id' => $issueId,
             'property_slug' => $propertySlug,
             'property_name' => is_string($item['web_property_name'] ?? null) ? $item['web_property_name'] : null,
             'domain' => $domain,

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\DashboardPriorityQueueController;
 use App\Http\Controllers\Api\DeploymentController;
+use App\Http\Controllers\Api\DetectedIssueController;
 use App\Http\Controllers\Api\DomainController;
 use App\Http\Controllers\Api\TagController;
 use App\Http\Controllers\Api\WebPropertyController;
@@ -32,6 +33,8 @@ Route::middleware(['api-key'])->group(function () {
     Route::get('/web-properties/{slug}', [WebPropertyController::class, 'show']);
     Route::get('/web-properties/{slug}/health-summary', [WebPropertyController::class, 'healthSummary']);
     Route::get('/dashboard/priority-queue', DashboardPriorityQueueController::class);
+    Route::get('/issues', [DetectedIssueController::class, 'index']);
+    Route::get('/issues/{issueId}', [DetectedIssueController::class, 'show']);
 
     // Tags
     Route::get('/tags', [TagController::class, 'index']);

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyRepository;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DetectedIssueApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_issues_endpoint_returns_normalized_open_issue_feed(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $redirectDomain = Domain::factory()->create([
+            'domain' => 'redirect-issue.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $redirectProperty = WebProperty::factory()->create([
+            'slug' => 'redirect-issue-site',
+            'name' => 'Redirect Issue Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $redirectDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $redirectProperty->id,
+            'domain_id' => $redirectDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $redirectProperty->id,
+            'repo_name' => 'redirect-issue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/redirect-issue-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $redirectDomain->id,
+            'web_property_id' => $redirectProperty->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '30',
+            'search_console_property_uri' => 'sc-domain:redirect-issue.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.3,
+            'indexed_pages' => 20,
+            'not_indexed_pages' => 5,
+            'pages_with_redirect' => 7,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 7]]],
+        ]);
+
+        $headersDomain = Domain::factory()->create([
+            'domain' => 'headers-issue.example.com',
+            'is_active' => true,
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $headersProperty = WebProperty::factory()->create([
+            'slug' => 'headers-issue-site',
+            'name' => 'Headers Issue Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $headersDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $headersProperty->id,
+            'domain_id' => $headersDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $headersProperty->id,
+            'repo_name' => 'headers-issue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/headers-issue-site',
+            'framework' => 'Astro',
+            'is_primary' => true,
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $headersDomain->id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('source_system', 'domain-monitor-issues')
+            ->assertJsonPath('contract_version', 1)
+            ->assertJsonPath('stats.open', 2)
+            ->assertJsonPath('stats.must_fix', 1)
+            ->assertJsonPath('stats.should_fix', 1);
+
+        $issueClassCounts = $response->json('stats.issue_class_counts');
+        $this->assertSame(1, $issueClassCounts['page_with_redirect_in_sitemap'] ?? null);
+        $this->assertSame(1, $issueClassCounts['security.headers_baseline'] ?? null);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues');
+        $issues = collect($payloadIssues);
+
+        $redirectIssue = $issues->firstWhere('property_slug', 'redirect-issue-site');
+        $headersIssue = $issues->firstWhere('property_slug', 'headers-issue-site');
+
+        $this->assertNotNull($redirectIssue);
+        $this->assertNotNull($headersIssue);
+        $this->assertSame('page_with_redirect_in_sitemap', $redirectIssue['issue_class']);
+        $this->assertSame('must_fix', $redirectIssue['severity']);
+        $this->assertSame('seo.robots_and_sitemap_consistency', $redirectIssue['control_id']);
+        $this->assertSame('domain_only', $redirectIssue['rollout_scope']);
+        $this->assertSame('domain_monitor.priority_queue', $redirectIssue['detector']);
+        $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
+
+        $detailResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($redirectIssue['issue_id']));
+
+        $detailResponse
+            ->assertOk()
+            ->assertJsonPath('data.issue_id', $redirectIssue['issue_id'])
+            ->assertJsonPath('data.issue_class', 'page_with_redirect_in_sitemap')
+            ->assertJsonPath('data.evidence.source_domain_id', $redirectDomain->id);
+    }
+}

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -148,8 +148,8 @@ class DetectedIssueApiTest extends TestCase
 
         $detailResponse
             ->assertOk()
-            ->assertJsonPath('data.issue_id', $redirectIssue['issue_id'])
-            ->assertJsonPath('data.issue_class', 'page_with_redirect_in_sitemap')
-            ->assertJsonPath('data.evidence.source_domain_id', $redirectDomain->id);
+            ->assertJsonPath('issue_id', $redirectIssue['issue_id'])
+            ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
+            ->assertJsonPath('evidence.source_domain_id', $redirectDomain->id);
     }
 }


### PR DESCRIPTION
## Summary
- add a normalized detected issues API derived from the existing dashboard priority queue
- expose list and detail endpoints for open issues in domain-monitor
- add focused feature coverage for the issue feed contract

## Testing
- ./vendor/bin/phpunit tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php
- ./vendor/bin/phpstan analyse app/Services/DetectedIssueSummaryService.php app/Http/Controllers/Api/DetectedIssueController.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
