### PR TITLE
Add dedicated fleet-control integration contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,8 @@ VITE_APP_NAME="${APP_NAME}"
 # Brain API Configuration
 BRAIN_BASE_URL=
 BRAIN_API_KEY=
+OPS_API_KEY=
+FLEET_CONTROL_API_KEY=
 
 # Synergy Wholesale API Configuration
 SYNERGY_WHOLESALE_API_URL=https://api.synergywholesale.com

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ See `DEPLOYMENT.md` for a complete list of required environment variables.
 - `BRAIN_BASE_URL` - Brain API base URL
 - `BRAIN_API_KEY` - Brain API key
 
+### Integration API Keys
+- `BRAIN_API_KEY` - Existing Brain/MM BRAIN bearer token for `Authorization: Bearer <token>`
+- `OPS_API_KEY` - Optional separate bearer token for ops-style integrations
+- `FLEET_CONTROL_API_KEY` - Preferred dedicated bearer token for `fleet-control`
+
+Use dedicated integration keys per client where possible instead of reusing one shared token across every external service.
+
 ### Optional
 - `SYNERGY_WHOLESALE_*` - Synergy Wholesale API credentials (for .com.au domains)
 - `HORIZON_ALLOWED_EMAILS` - Comma-separated allowlist for Horizon dashboard access in non-local environments (recommended in production).
@@ -136,6 +143,7 @@ The detailed project documentation has been moved to the `docs/` folder:
 ### Integrations
 - [Synergy Wholesale Setup](docs/SYNERGY-SETUP.md)
 - [Synergy API Fields](docs/SYNERGY-API-FIELDS.md)
+- [Domain Monitor API Integration](docs/DOMAIN-MONITOR-API-INTEGRATION.md)
 
 ## Contributing
 

--- a/app/Http/Controllers/Api/IntegrationMetaController.php
+++ b/app/Http/Controllers/Api/IntegrationMetaController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class IntegrationMetaController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json([
+            'service' => 'domain-monitor',
+            'generated_at' => now()->toIso8601String(),
+            'auth' => [
+                'scheme' => 'Bearer',
+                'header' => 'Authorization',
+                'accepted_tokens' => [
+                    'BRAIN_API_KEY',
+                    'OPS_API_KEY',
+                    'FLEET_CONTROL_API_KEY',
+                ],
+            ],
+            'feeds' => [
+                [
+                    'path' => '/api/web-properties-summary',
+                    'source_system' => 'domain-monitor',
+                    'contract_version' => 1,
+                    'purpose' => 'authoritative web property summary',
+                ],
+                [
+                    'path' => '/api/issues',
+                    'source_system' => 'domain-monitor-issues',
+                    'contract_version' => 1,
+                    'purpose' => 'normalized detected issue feed',
+                ],
+                [
+                    'path' => '/api/issues/{issue_id}',
+                    'source_system' => 'domain-monitor-issues',
+                    'contract_version' => 1,
+                    'purpose' => 'detected issue detail',
+                ],
+                [
+                    'path' => '/api/dashboard/priority-queue',
+                    'source_system' => 'domain-monitor-priority-queue',
+                    'contract_version' => 2,
+                    'purpose' => 'enriched operational queue context',
+                    'optional' => true,
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Middleware/AuthenticateApiKey.php
+++ b/app/Http/Middleware/AuthenticateApiKey.php
@@ -32,6 +32,7 @@ class AuthenticateApiKey
         $allowedKeys = [
             config('services.domain_monitor.brain_api_key'),
             config('services.domain_monitor.ops_api_key'),
+            config('services.domain_monitor.fleet_control_api_key'),
         ];
 
         // Filter out empty values

--- a/config/services.php
+++ b/config/services.php
@@ -59,6 +59,7 @@ return [
     'domain_monitor' => [
         'brain_api_key' => env('BRAIN_API_KEY'),
         'ops_api_key' => env('OPS_API_KEY'),
+        'fleet_control_api_key' => env('FLEET_CONTROL_API_KEY'),
     ],
 
 ];

--- a/docs/DOMAIN-MONITOR-API-INTEGRATION.md
+++ b/docs/DOMAIN-MONITOR-API-INTEGRATION.md
@@ -1,0 +1,113 @@
+# Domain Monitor API Integration
+
+This document defines the stable read-only integration contract for external
+services such as MM BRAIN, fleet-control, or future operator tools.
+
+## Base URL
+
+Production:
+
+```text
+https://monitor.again.com.au
+```
+
+## Authentication
+
+All integration endpoints use bearer authentication:
+
+```http
+Authorization: Bearer <token>
+```
+
+Accepted environment variables on the Domain Monitor side:
+
+- `BRAIN_API_KEY`
+- `OPS_API_KEY`
+- `FLEET_CONTROL_API_KEY`
+
+Recommended usage:
+
+- MM BRAIN: `BRAIN_API_KEY`
+- fleet-control: `FLEET_CONTROL_API_KEY`
+- other operator tooling: dedicated token where practical
+
+## Discovery
+
+Authenticated clients can inspect:
+
+```text
+GET /api/meta/integrations
+```
+
+This returns the supported feeds, contract versions, and auth metadata.
+
+## Authoritative Feeds
+
+### Properties
+
+```text
+GET /api/web-properties-summary
+```
+
+- `source_system`: `domain-monitor`
+- `contract_version`: `1`
+
+Purpose:
+- authoritative property identity
+- linked domains, repositories, analytics sources
+- current health summary
+
+### Normalized Issues
+
+```text
+GET /api/issues
+GET /api/issues/{issue_id}
+```
+
+- `source_system`: `domain-monitor-issues`
+- `contract_version`: `1`
+
+Purpose:
+- normalized open issue feed for cross-system remediation and rollout logic
+
+Core fields:
+- `issue_id`
+- `property_slug`
+- `property_name`
+- `domain`
+- `issue_class`
+- `severity`
+- `detector`
+- `status`
+- `detected_at`
+- `rollout_scope`
+- `control_id`
+- `platform_profile`
+- `host_profile`
+- `control_profile`
+- `evidence`
+
+### Optional Operational Queue
+
+```text
+GET /api/dashboard/priority-queue
+```
+
+- `source_system`: `domain-monitor-priority-queue`
+- `contract_version`: `2`
+
+Purpose:
+- enriched queue/context layer for operator views
+- not required for basic property/issue synchronization
+
+## Integration Guidance
+
+- Treat Domain Monitor as the source of truth for property identity and detected
+  issue records.
+- Prefer `/api/web-properties-summary` plus `/api/issues` as the core read
+  model.
+- Use `/api/dashboard/priority-queue` only as supplemental operational context.
+- Fail loudly if `source_system` or `contract_version` do not match expected
+  values.
+- Do not scrape random local `.env` files from other repos to discover tokens.
+  Provision the token explicitly for the consuming service.

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\DashboardPriorityQueueController;
 use App\Http\Controllers\Api\DeploymentController;
 use App\Http\Controllers\Api\DetectedIssueController;
 use App\Http\Controllers\Api\DomainController;
+use App\Http\Controllers\Api\IntegrationMetaController;
 use App\Http\Controllers\Api\TagController;
 use App\Http\Controllers\Api\WebPropertyController;
 use Illuminate\Support\Facades\Route;
@@ -20,6 +21,8 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::middleware(['api-key'])->group(function () {
+    Route::get('/meta/integrations', IntegrationMetaController::class);
+
     // Domains
     Route::get('/domains', [DomainController::class, 'index']);
     Route::get('/domains/{domain}', [DomainController::class, 'show']);

--- a/tests/Feature/IntegrationMetaApiTest.php
+++ b/tests/Feature/IntegrationMetaApiTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IntegrationMetaApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_integration_meta_endpoint_requires_api_authentication(): void
+    {
+        $this->getJson('/api/meta/integrations')
+            ->assertUnauthorized();
+    }
+
+    public function test_integration_meta_endpoint_accepts_fleet_control_api_key(): void
+    {
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->getJson('/api/meta/integrations')
+            ->assertOk()
+            ->assertJsonPath('service', 'domain-monitor')
+            ->assertJsonPath('auth.scheme', 'Bearer')
+            ->assertJsonPath('auth.accepted_tokens.2', 'FLEET_CONTROL_API_KEY')
+            ->assertJsonPath('feeds.0.path', '/api/web-properties-summary')
+            ->assertJsonPath('feeds.1.path', '/api/issues')
+            ->assertJsonPath('feeds.3.contract_version', 2);
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated FLEET_CONTROL_API_KEY support alongside the existing bearer tokens
- expose an authenticated integration meta endpoint for feed discovery and contract versions
- document the stable Domain Monitor integration contract for external services

## Testing
- ./vendor/bin/phpunit tests/Feature/IntegrationMetaApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Http/Middleware/AuthenticateApiKey.php app/Http/Controllers/Api/IntegrationMetaController.php tests/Feature/IntegrationMetaApiTest.php --memory-limit=2G
- php -l config/services.php
- php -l routes/api.php
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/38" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
