### PR TITLE
Add execution readiness signals to APIs

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -234,6 +234,63 @@ class WebProperty extends Model
         ])->values()->all();
     }
 
+    public function controllerRepository(): ?PropertyRepository
+    {
+        $repositories = $this->relationLoaded('repositories') ? $this->repositories : $this->repositories()->get();
+        $orderedRepositories = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
+            ->values();
+
+        return $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
+        ) ?? $orderedRepositories->first();
+    }
+
+    /**
+     * @return array{
+     *   control_state:string,
+     *   execution_surface:string|null,
+     *   fleet_managed:bool,
+     *   controller_repo:string|null
+     * }
+     */
+    public function executionReadinessSummary(): array
+    {
+        $eligibility = $this->coverageEligibility();
+        $controllerRepository = $this->controllerRepository();
+        $controllerRepo = $controllerRepository?->repo_name;
+
+        if (! $eligibility['eligible']) {
+            return [
+                'control_state' => 'not_applicable',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                'controller_repo' => $controllerRepo,
+            ];
+        }
+
+        if (! $controllerRepository instanceof PropertyRepository || ! $this->repositoryHasControllerPath($controllerRepository)) {
+            return [
+                'control_state' => 'uncontrolled',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                'controller_repo' => $controllerRepo,
+            ];
+        }
+
+        $executionSurface = $this->executionSurfaceForRepository($controllerRepository);
+
+        return [
+            'control_state' => 'controlled',
+            'execution_surface' => $executionSurface,
+            'fleet_managed' => in_array($executionSurface, [
+                'fleet_wordpress_controlled',
+                'astro_repo_controlled',
+            ], true),
+            'controller_repo' => $controllerRepo,
+        ];
+    }
+
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -365,6 +422,8 @@ class WebProperty extends Model
      */
     public function brainSummary(): array
     {
+        $executionReadiness = $this->executionReadinessSummary();
+
         return [
             'slug' => $this->slug,
             'name' => $this->name,
@@ -384,6 +443,10 @@ class WebProperty extends Model
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
+            'control_state' => $executionReadiness['control_state'],
+            'execution_surface' => $executionReadiness['execution_surface'],
+            'fleet_managed' => $executionReadiness['fleet_managed'],
+            'controller_repo' => $executionReadiness['controller_repo'],
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
     }
@@ -938,6 +1001,26 @@ class WebProperty extends Model
             1 => 'ok',
             default => 'unknown',
         };
+    }
+
+    private function repositoryHasControllerPath(PropertyRepository $repository): bool
+    {
+        return is_string($repository->local_path) && trim($repository->local_path) !== '';
+    }
+
+    private function executionSurfaceForRepository(PropertyRepository $repository): string
+    {
+        $framework = strtolower((string) ($repository->framework ?? $this->platform ?? ''));
+
+        if ($repository->repo_name === '_wp-house') {
+            return 'fleet_wordpress_controlled';
+        }
+
+        if (str_contains($framework, 'astro')) {
+            return 'astro_repo_controlled';
+        }
+
+        return 'repository_controlled';
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\PropertyRepository;
 use App\Models\WebProperty;
 use App\Models\WebsitePlatform;
 use Illuminate\Support\Collection;
@@ -451,6 +452,8 @@ class DashboardIssueQueueService
         $controlId = is_array($canonicalIssue) ? $canonicalIssue['control_id'] : null;
         $rolloutScope = is_array($canonicalIssue) ? $canonicalIssue['rollout_scope'] : 'domain_only';
         $baselineSurface = is_array($canonicalIssue) ? $canonicalIssue['baseline_surface'] : null;
+        $coverageStatus = is_string($item['coverage_status'] ?? null) ? $item['coverage_status'] : 'not_required';
+        $executionReadiness = $this->executionReadinessForQueue($property, $coverageStatus, $platformProfile);
 
         $item['issue_family'] = $issueFamily;
         $item['issue_families'] = $issueFamilies;
@@ -465,6 +468,10 @@ class DashboardIssueQueueService
         $item['property_match_confidence'] = $property ? 'high' : 'none';
         $item['rollout_scope'] = $rolloutScope;
         $item['is_standard_gap'] = $rolloutScope === 'fleet';
+        $item['control_state'] = $executionReadiness['control_state'];
+        $item['execution_surface'] = $executionReadiness['execution_surface'];
+        $item['fleet_managed'] = $executionReadiness['fleet_managed'];
+        $item['controller_repo'] = $executionReadiness['controller_repo'];
 
         return $item;
     }
@@ -516,6 +523,86 @@ class DashboardIssueQueueService
             'missing_local_path' => 'Fleet controller path is missing',
             default => null,
         };
+    }
+
+    /**
+     * @return array{
+     *   control_state:string,
+     *   execution_surface:string|null,
+     *   fleet_managed:bool,
+     *   controller_repo:string|null
+     * }
+     */
+    private function executionReadinessForQueue(?WebProperty $property, string $coverageStatus, string $platformProfile): array
+    {
+        $controllerRepository = $this->controllerRepositoryForProperty($property);
+        $controllerRepo = $controllerRepository?->repo_name;
+
+        if ($coverageStatus === 'not_required') {
+            return [
+                'control_state' => 'not_applicable',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                'controller_repo' => $controllerRepo,
+            ];
+        }
+
+        if ($coverageStatus !== 'controlled') {
+            return [
+                'control_state' => 'uncontrolled',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                'controller_repo' => $controllerRepo,
+            ];
+        }
+
+        $executionSurface = $this->executionSurfaceForQueue($controllerRepository, $platformProfile);
+
+        return [
+            'control_state' => 'controlled',
+            'execution_surface' => $executionSurface,
+            'fleet_managed' => in_array($executionSurface, [
+                'fleet_wordpress_controlled',
+                'astro_repo_controlled',
+            ], true),
+            'controller_repo' => $controllerRepo,
+        ];
+    }
+
+    private function controllerRepositoryForProperty(?WebProperty $property): ?PropertyRepository
+    {
+        if (! $property instanceof WebProperty) {
+            return null;
+        }
+
+        $repositories = $property->relationLoaded('repositories')
+            ? $property->getRelation('repositories')
+            : $property->repositories()->get();
+        $orderedRepositories = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
+            ->values();
+
+        return $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
+        ) ?? $orderedRepositories->first();
+    }
+
+    private function repositoryHasControllerPath(PropertyRepository $repository): bool
+    {
+        return is_string($repository->local_path) && trim($repository->local_path) !== '';
+    }
+
+    private function executionSurfaceForQueue(?PropertyRepository $repository, string $platformProfile): string
+    {
+        if ($repository?->repo_name === '_wp-house') {
+            return 'fleet_wordpress_controlled';
+        }
+
+        if ($platformProfile === 'astro_marketing_managed') {
+            return 'astro_repo_controlled';
+        }
+
+        return 'repository_controlled';
     }
 
     /**

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -117,6 +117,10 @@ class DetectedIssueSummaryService
                 'platform_profile' => is_string($item['platform_profile'] ?? null) ? $item['platform_profile'] : null,
                 'host_profile' => is_string($item['host_profile'] ?? null) ? $item['host_profile'] : null,
                 'control_profile' => is_string($item['control_profile'] ?? null) ? $item['control_profile'] : null,
+                'control_state' => is_string($item['control_state'] ?? null) ? $item['control_state'] : null,
+                'execution_surface' => is_string($item['execution_surface'] ?? null) ? $item['execution_surface'] : null,
+                'fleet_managed' => (bool) ($item['fleet_managed'] ?? false),
+                'controller_repo' => is_string($item['controller_repo'] ?? null) ? $item['controller_repo'] : null,
                 'evidence' => [
                     'primary_reasons' => array_values(array_filter($item['primary_reasons'] ?? [], 'is_string')),
                     'secondary_reasons' => array_values(array_filter($item['secondary_reasons'] ?? [], 'is_string')),

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -43,9 +43,9 @@ class DetectedIssueApiTest extends TestCase
 
         PropertyRepository::create([
             'web_property_id' => $redirectProperty->id,
-            'repo_name' => 'redirect-issue-site',
+            'repo_name' => '_wp-house',
             'repo_provider' => 'local_only',
-            'local_path' => '/Users/jasonhill/Projects/websites/redirect-issue-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
             'framework' => 'WordPress',
             'is_primary' => true,
         ]);
@@ -138,7 +138,16 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('seo.robots_and_sitemap_consistency', $redirectIssue['control_id']);
         $this->assertSame('domain_only', $redirectIssue['rollout_scope']);
         $this->assertSame('domain_monitor.priority_queue', $redirectIssue['detector']);
+        $this->assertSame('controlled', $redirectIssue['control_state']);
+        $this->assertSame('fleet_wordpress_controlled', $redirectIssue['execution_surface']);
+        $this->assertTrue($redirectIssue['fleet_managed']);
+        $this->assertSame('_wp-house', $redirectIssue['controller_repo']);
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
+        $this->assertSame('security.headers_baseline', $headersIssue['issue_class']);
+        $this->assertSame('controlled', $headersIssue['control_state']);
+        $this->assertSame('astro_repo_controlled', $headersIssue['execution_surface']);
+        $this->assertTrue($headersIssue['fleet_managed']);
+        $this->assertSame('headers-issue-site', $headersIssue['controller_repo']);
 
         $detailResponse = $this->withHeaders([
             'Authorization' => 'Bearer test-api-key',
@@ -250,5 +259,78 @@ class DetectedIssueApiTest extends TestCase
             collect($relatedIssueClasses)->sort()->values()->all()
         );
         $this->assertCount(2, $issues->pluck('issue_id')->unique());
+    }
+
+    public function test_issues_endpoint_reports_uncontrolled_when_no_controller_path_exists(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'uncontrolled.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'uncontrolled-site',
+            'name' => 'Uncontrolled Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => '_wp-house',
+            'repo_provider' => 'local_only',
+            'local_path' => null,
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '31',
+            'search_console_property_uri' => 'sc-domain:uncontrolled.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.3,
+            'indexed_pages' => 20,
+            'not_indexed_pages' => 5,
+            'pages_with_redirect' => 4,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 4]]],
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
+            ->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('property_slug', 'uncontrolled-site');
+
+        $this->assertNotNull($issue);
+        $this->assertSame('uncontrolled', $issue['control_state']);
+        $this->assertNull($issue['execution_surface']);
+        $this->assertFalse($issue['fleet_managed']);
+        $this->assertSame('_wp-house', $issue['controller_repo']);
     }
 }

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -154,7 +154,67 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.health_summary.checks.uptime', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.http', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.ssl', 'warn')
+            ->assertJsonPath('web_properties.0.control_state', 'controlled')
+            ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
+            ->assertJsonPath('web_properties.0.fleet_managed', true)
+            ->assertJsonPath('web_properties.0.controller_repo', 'moveroo-website-astro')
             ->assertJsonPath('web_properties.0.health_summary.active_alerts_count', 1);
+    }
+
+    public function test_web_properties_summary_prefers_any_controller_repo_with_local_path(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'secondary-controller.example.com',
+            'platform' => 'WordPress',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'secondary-controller-site',
+            'name' => 'Secondary Controller Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'platform' => 'WordPress',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'secondary-controller-site',
+            'repo_provider' => 'local_only',
+            'local_path' => null,
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => '_wp-house',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+            'framework' => 'WordPress',
+            'is_primary' => false,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'secondary-controller-site')
+            ->assertJsonPath('web_properties.0.control_state', 'controlled')
+            ->assertJsonPath('web_properties.0.execution_surface', 'fleet_wordpress_controlled')
+            ->assertJsonPath('web_properties.0.fleet_managed', true)
+            ->assertJsonPath('web_properties.0.controller_repo', '_wp-house');
     }
 
     public function test_web_property_health_summary_endpoint_returns_property_health(): void


### PR DESCRIPTION
## Summary
- add explicit control state and execution surface signals to the web property summary API
- carry the same readiness signals into the detected issues API
- mark controllable _wp-house WordPress properties as fleet_wordpress_controlled without changing existing platform profile labels

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
