### PR TITLE
Expose redirect issue URLs in detected issues

### DIFF
--- a/app/Models/DomainSeoBaseline.php
+++ b/app/Models/DomainSeoBaseline.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 /**
@@ -183,6 +184,150 @@ class DomainSeoBaseline extends Model
             ['label' => 'Alternate with canonical', 'value' => $this->alternate_with_canonical],
             ['label' => 'Duplicate without user-selected canonical', 'value' => $this->duplicate_without_user_selected_canonical],
         ])->filter(fn (array $issue): bool => (int) ($issue['value'] ?? 0) > 0)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function issueEvidence(string $issueClass): array
+    {
+        return match ($issueClass) {
+            'page_with_redirect_in_sitemap' => $this->pageIndexingIssueEvidence(
+                ['Page with redirect'],
+                (int) ($this->pages_with_redirect ?? 0)
+            ),
+            default => [],
+        };
+    }
+
+    /**
+     * @param  array<int, string>  $labels
+     * @return array<string, mixed>
+     */
+    private function pageIndexingIssueEvidence(array $labels, int $fallbackCount): array
+    {
+        $affectedUrls = $this->extractAffectedUrlsForLabels($labels);
+
+        return [
+            'affected_urls' => $affectedUrls,
+            'affected_url_count' => $affectedUrls !== [] ? count($affectedUrls) : $fallbackCount,
+            'sample_urls' => array_slice($affectedUrls, 0, 10),
+            'source_report' => 'search_console_page_indexing',
+            'source_property' => $this->search_console_property_uri,
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $labels
+     * @return array<int, string>
+     */
+    private function extractAffectedUrlsForLabels(array $labels): array
+    {
+        $matches = collect();
+
+        foreach ($this->candidateIssuePayloads() as $payload) {
+            $this->collectUrlsFromPayload($payload, $labels, $matches);
+        }
+
+        return $matches
+            ->map(fn (string $url): string => trim($url))
+            ->filter(fn (string $url): bool => str_starts_with($url, 'http://') || str_starts_with($url, 'https://'))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function candidateIssuePayloads(): array
+    {
+        $payloads = [];
+
+        foreach ([
+            $this->raw_payload,
+            data_get($this->raw_payload, 'parsed_export'),
+            data_get($this->raw_payload, 'issue_details'),
+            data_get($this->raw_payload, 'page_indexing_details'),
+        ] as $payload) {
+            if (is_array($payload)) {
+                $payloads[] = $payload;
+            }
+        }
+
+        return $payloads;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<int, string>  $labels
+     * @param  Collection<int, string>  $matches
+     */
+    private function collectUrlsFromPayload(array $payload, array $labels, Collection $matches): void
+    {
+        $label = $this->payloadLabel($payload);
+
+        if ($label !== null && in_array($label, $labels, true)) {
+            foreach (['affected_urls', 'urls', 'sample_urls', 'examples', 'example_urls', 'example_url'] as $key) {
+                $matches->push(...$this->normalizeUrls(data_get($payload, $key)));
+            }
+        }
+
+        foreach ($payload as $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if (array_is_list($value)) {
+                foreach ($value as $entry) {
+                    if (is_array($entry)) {
+                        $this->collectUrlsFromPayload($entry, $labels, $matches);
+                    }
+                }
+
+                continue;
+            }
+
+            $this->collectUrlsFromPayload($value, $labels, $matches);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function payloadLabel(array $payload): ?string
+    {
+        foreach (['label', 'Label', 'reason', 'Reason', 'issue', 'Issue'] as $key) {
+            $value = data_get($payload, $key);
+
+            if (is_string($value) && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeUrls(mixed $value): array
+    {
+        if (is_array($value)) {
+            return collect($value)
+                ->flatMap(fn (mixed $entry): array => $this->normalizeUrls($entry))
+                ->all();
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        return collect(preg_split('/[\r\n,]+/', $value) ?: [])
+            ->map(fn (string $entry): string => trim($entry))
+            ->filter(fn (string $entry): bool => str_starts_with($entry, 'http://') || str_starts_with($entry, 'https://'))
             ->values()
             ->all();
     }

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\WebProperty;
 use Illuminate\Support\Collection;
 
 class DetectedIssueSummaryService
@@ -25,8 +26,12 @@ class DetectedIssueSummaryService
         }
 
         $queueSnapshot = $this->queueService->snapshot();
-        $mustFix = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix');
-        $shouldFix = $this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix');
+        $baselineEvidence = $this->baselineEvidenceMap([
+            ...($queueSnapshot['must_fix'] ?? []),
+            ...($queueSnapshot['should_fix'] ?? []),
+        ]);
+        $mustFix = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $baselineEvidence);
+        $shouldFix = $this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $baselineEvidence);
         $issues = $mustFix->concat($shouldFix)->values();
 
         return $this->cachedSnapshot = [
@@ -60,24 +65,27 @@ class DetectedIssueSummaryService
 
     /**
      * @param  array<int, array<string, mixed>>  $items
+     * @param  array<string, array<string, array<string, mixed>>>  $baselineEvidence
      * @return Collection<int, array<string, mixed>>
      */
-    private function flattenIssues(array $items, string $severity): Collection
+    private function flattenIssues(array $items, string $severity, array $baselineEvidence): Collection
     {
         return collect($items)
-            ->flatMap(fn (array $item): array => $this->makeIssues($item, $severity))
+            ->flatMap(fn (array $item): array => $this->makeIssues($item, $severity, $baselineEvidence))
             ->values();
     }
 
     /**
      * @param  array<string, mixed>  $item
+     * @param  array<string, array<string, array<string, mixed>>>  $baselineEvidence
      * @return array<int, array<string, mixed>>
      */
-    private function makeIssues(array $item, string $severity): array
+    private function makeIssues(array $item, string $severity, array $baselineEvidence): array
     {
         $domainId = (string) ($item['id'] ?? '');
         $domain = is_string($item['domain'] ?? null) ? $item['domain'] : null;
         $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+        $evidenceKey = $propertySlug ?: $domainId;
         $detectedAt = is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
             ? $item['updated_at_iso']
             : now()->toIso8601String();
@@ -131,11 +139,46 @@ class DetectedIssueSummaryService
                     'property_match_confidence' => is_string($item['property_match_confidence'] ?? null) ? $item['property_match_confidence'] : null,
                     'baseline_surface' => $issueEntry['baseline_surface'],
                     'source_domain_id' => $domainId,
+                    ...($baselineEvidence[$evidenceKey][$issueClass] ?? []),
                 ],
             ];
         }
 
         return $issues;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<string, array<string, array<string, mixed>>>
+     */
+    private function baselineEvidenceMap(array $items): array
+    {
+        $propertySlugs = collect($items)
+            ->pluck('web_property_slug')
+            ->filter(fn (mixed $slug): bool => is_string($slug) && $slug !== '')
+            ->values()
+            ->all();
+
+        if ($propertySlugs === []) {
+            return [];
+        }
+
+        return WebProperty::query()
+            ->whereIn('slug', $propertySlugs)
+            ->with('latestSeoBaselineForProperty')
+            ->get(['id', 'slug'])
+            ->mapWithKeys(function (WebProperty $property): array {
+                $baseline = $property->latestPropertySeoBaselineRecord();
+
+                if ($baseline === null) {
+                    return [$property->slug => []];
+                }
+
+                return [$property->slug => [
+                    'page_with_redirect_in_sitemap' => $baseline->issueEvidence('page_with_redirect_in_sitemap'),
+                ]];
+            })
+            ->all();
     }
 
     /**

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -70,7 +70,14 @@ class DetectedIssueApiTest extends TestCase
             'indexed_pages' => 20,
             'not_indexed_pages' => 5,
             'pages_with_redirect' => 7,
-            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 7]]],
+            'raw_payload' => ['issues' => [[
+                'label' => 'Page with redirect',
+                'count' => 7,
+                'affected_urls' => [
+                    'https://redirect-issue.example.com/old-page/',
+                    'https://redirect-issue.example.com/another-page/',
+                ],
+            ]]],
         ]);
 
         $headersDomain = Domain::factory()->create([
@@ -143,6 +150,17 @@ class DetectedIssueApiTest extends TestCase
         $this->assertTrue($redirectIssue['fleet_managed']);
         $this->assertSame('_wp-house', $redirectIssue['controller_repo']);
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
+        $this->assertSame([
+            'https://redirect-issue.example.com/old-page/',
+            'https://redirect-issue.example.com/another-page/',
+        ], $redirectIssue['evidence']['affected_urls']);
+        $this->assertSame(2, $redirectIssue['evidence']['affected_url_count']);
+        $this->assertSame([
+            'https://redirect-issue.example.com/old-page/',
+            'https://redirect-issue.example.com/another-page/',
+        ], $redirectIssue['evidence']['sample_urls']);
+        $this->assertSame('search_console_page_indexing', $redirectIssue['evidence']['source_report']);
+        $this->assertSame('sc-domain:redirect-issue.example.com', $redirectIssue['evidence']['source_property']);
         $this->assertSame('security.headers_baseline', $headersIssue['issue_class']);
         $this->assertSame('controlled', $headersIssue['control_state']);
         $this->assertSame('astro_repo_controlled', $headersIssue['execution_surface']);
@@ -157,6 +175,7 @@ class DetectedIssueApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('issue_id', $redirectIssue['issue_id'])
             ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
+            ->assertJsonPath('evidence.affected_urls.0', 'https://redirect-issue.example.com/old-page/')
             ->assertJsonPath('evidence.source_domain_id', $redirectDomain->id);
     }
 


### PR DESCRIPTION
## Summary
- enrich page_with_redirect_in_sitemap issue evidence with affected URLs when baseline raw payload includes them
- add affected_url_count, sample_urls, source_report, and source_property to the detected issue evidence
- preload latest property baselines in the issues feed so queue payloads do not need to change

## Testing
- ./vendor/bin/phpunit tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Models/DomainSeoBaseline.php app/Services/DetectedIssueSummaryService.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
