### PR TITLE
Expand Search Console issue evidence coverage

### DIFF
--- a/app/Models/SearchConsoleIssueSnapshot.php
+++ b/app/Models/SearchConsoleIssueSnapshot.php
@@ -130,7 +130,7 @@ class SearchConsoleIssueSnapshot extends Model
 
             $examples[] = [
                 'url' => $url,
-                'last_crawled' => is_string($example['last_crawled'] ?? null) ? $example['last_crawled'] : null,
+                'last_crawled' => $this->normalizeLastCrawledValue($example['last_crawled'] ?? null),
             ];
         }
         /** @var array<int, string> $affectedUrlRows */
@@ -164,5 +164,28 @@ class SearchConsoleIssueSnapshot extends Model
             'canonical_state' => is_array($normalizedPayload['canonical_state'] ?? null) ? $normalizedPayload['canonical_state'] : null,
             'search_analytics' => is_array($normalizedPayload['search_analytics'] ?? null) ? $normalizedPayload['search_analytics'] : null,
         ], static fn (mixed $value): bool => $value !== null && $value !== []);
+    }
+
+    private function normalizeLastCrawledValue(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (in_array(strtolower($trimmed), ['n/a', 'na', '-', '--', 'not available'], true)) {
+            return null;
+        }
+
+        if ($trimmed === '1970-01-01') {
+            return null;
+        }
+
+        return $trimmed;
     }
 }

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -8,6 +8,7 @@ use App\Models\PropertyRepository;
 use App\Models\WebProperty;
 use App\Models\WebsitePlatform;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class DashboardIssueQueueService
 {
@@ -237,34 +238,54 @@ class DashboardIssueQueueService
         $mustFixIssues = [];
         $shouldFixIssues = [];
 
-        if ((int) ($baseline->pages_with_redirect ?? 0) > 0) {
-            $reason = sprintf(
-                'Search Console reports page with redirect (%d URLs)',
-                (int) $baseline->pages_with_redirect
-            );
-            $mustFix[] = $reason;
-            $mustFixIssues[] = $this->issueRecord('page_with_redirect_in_sitemap', $reason, 'must_fix');
-        }
+        foreach ([
+            'page_with_redirect_in_sitemap',
+            'blocked_by_robots_in_indexing',
+            'duplicate_without_user_selected_canonical',
+            'alternate_with_canonical',
+            'not_found_404',
+            'crawled_currently_not_indexed',
+            'discovered_currently_not_indexed',
+        ] as $issueClass) {
+            $count = $baseline->issueCount($issueClass);
 
-        if ((int) ($baseline->blocked_by_robots ?? 0) > 0) {
-            $reason = sprintf(
-                'Search Console reports blocked by robots.txt (%d URLs)',
-                (int) $baseline->blocked_by_robots
-            );
-            $mustFix[] = $reason;
-            $mustFixIssues[] = $this->issueRecord('blocked_by_robots_in_indexing', $reason, 'must_fix');
-        }
+            if ($count === null || $count <= 0) {
+                continue;
+            }
 
-        if ((int) ($baseline->duplicate_without_user_selected_canonical ?? 0) > 0) {
-            $reason = sprintf(
-                'Search Console reports duplicate without user-selected canonical (%d URLs)',
-                (int) $baseline->duplicate_without_user_selected_canonical
-            );
+            $reason = $this->searchConsoleReason($issueClass, $count);
+            $severity = $this->searchConsoleSeverity($issueClass);
+
+            if ($severity === 'must_fix') {
+                $mustFix[] = $reason;
+                $mustFixIssues[] = $this->issueRecord($issueClass, $reason, $severity);
+
+                continue;
+            }
+
             $shouldFix[] = $reason;
-            $shouldFixIssues[] = $this->issueRecord('duplicate_without_user_selected_canonical', $reason, 'should_fix');
+            $shouldFixIssues[] = $this->issueRecord($issueClass, $reason, $severity);
         }
 
         return [$mustFix, $shouldFix, $mustFixIssues, $shouldFixIssues];
+    }
+
+    private function searchConsoleReason(string $issueClass, int $count): string
+    {
+        $label = data_get(config('domain_monitor.search_console_issue_catalog.'.$issueClass), 'label', $issueClass);
+
+        return sprintf(
+            'Search Console reports %s (%d URLs)',
+            Str::of((string) $label)->lower()->toString(),
+            $count
+        );
+    }
+
+    private function searchConsoleSeverity(string $issueClass): string
+    {
+        return in_array($issueClass, ['page_with_redirect_in_sitemap', 'blocked_by_robots_in_indexing'], true)
+            ? 'must_fix'
+            : 'should_fix';
     }
 
     /**

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -6,11 +6,6 @@ use Illuminate\Support\Collection;
 
 class DetectedIssueSummaryService
 {
-    /**
-     * @var array<string, mixed>|null
-     */
-    private ?array $cachedSnapshot = null;
-
     public function __construct(
         private readonly DashboardIssueQueueService $queueService,
         private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
@@ -21,10 +16,6 @@ class DetectedIssueSummaryService
      */
     public function snapshot(): array
     {
-        if ($this->cachedSnapshot !== null) {
-            return $this->cachedSnapshot;
-        }
-
         $queueSnapshot = $this->queueService->snapshot();
         $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems([
             ...($queueSnapshot['must_fix'] ?? []),
@@ -36,7 +27,7 @@ class DetectedIssueSummaryService
         $mustFix = $issues->where('severity', 'must_fix')->values();
         $shouldFix = $issues->where('severity', 'should_fix')->values();
 
-        return $this->cachedSnapshot = [
+        return [
             'source_system' => 'domain-monitor-issues',
             'contract_version' => 1,
             'generated_at' => $queueSnapshot['generated_at'] ?? now()->toIso8601String(),

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -30,9 +30,11 @@ class DetectedIssueSummaryService
             ...($queueSnapshot['must_fix'] ?? []),
             ...($queueSnapshot['should_fix'] ?? []),
         ]);
-        $mustFix = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence);
-        $shouldFix = $this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence);
-        $issues = $mustFix->concat($shouldFix)->values();
+        $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence)
+            ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence))
+            ->values();
+        $mustFix = $issues->where('severity', 'must_fix')->values();
+        $shouldFix = $issues->where('severity', 'should_fix')->values();
 
         return $this->cachedSnapshot = [
             'source_system' => 'domain-monitor-issues',
@@ -89,7 +91,11 @@ class DetectedIssueSummaryService
         $detectedAt = is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
             ? $item['updated_at_iso']
             : now()->toIso8601String();
-        $issueEntries = $this->normalizedIssueEntries($item, $severity);
+        $queueIssueEntries = $this->normalizedIssueEntries($item, $severity);
+        $issueEntries = array_merge(
+            $queueIssueEntries,
+            $this->supplementalIssueEntries($item, $issueEvidence[$evidenceKey] ?? [], $queueIssueEntries)
+        );
         $relatedIssueClasses = array_values(array_unique(array_map(
             static fn (array $entry): string => $entry['issue_class'],
             $issueEntries
@@ -151,6 +157,51 @@ class DetectedIssueSummaryService
         }
 
         return $issues;
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @param  array<string, array<string, mixed>>  $propertyEvidence
+     * @param  array<int, array{issue_class:string, reason:string, severity:string, control_id:?string, rollout_scope:string, baseline_surface:?string}>  $existingIssueEntries
+     * @return array<int, array{issue_class:string, reason:string, severity:string, control_id:?string, rollout_scope:string, baseline_surface:?string}>
+     */
+    private function supplementalIssueEntries(array $item, array $propertyEvidence, array $existingIssueEntries): array
+    {
+        $existingIssueClasses = array_values(array_unique(array_map(
+            static fn (array $entry): string => $entry['issue_class'],
+            $existingIssueEntries
+        )));
+        $entries = [];
+
+        foreach ($propertyEvidence as $issueClass => $evidence) {
+            if (in_array($issueClass, $existingIssueClasses, true)) {
+                continue;
+            }
+
+            if (! $this->shouldEmitSupplementalIssue($issueClass, $evidence)) {
+                continue;
+            }
+
+            $controlId = $this->controlIdForIssueClass($issueClass);
+            $baselineSurface = $this->defaultBaselineSurfaceForPlatformProfile(
+                is_string($item['platform_profile'] ?? null) ? $item['platform_profile'] : null
+            );
+            $configuredRolloutScope = $this->configuredRolloutScopeForControl($controlId);
+
+            $entries[] = [
+                'issue_class' => $issueClass,
+                'reason' => $this->supplementalIssueReason($issueClass, $evidence),
+                'severity' => $this->defaultSeverityForIssueClass($issueClass),
+                'control_id' => $controlId,
+                'rollout_scope' => $configuredRolloutScope
+                    ?? (($controlId && $baselineSurface) ? 'fleet' : 'domain_only'),
+                'baseline_surface' => ($configuredRolloutScope === 'domain_only' || ! $controlId || ! $baselineSurface)
+                    ? null
+                    : $baselineSurface,
+            ];
+        }
+
+        return $entries;
     }
 
     /**
@@ -221,5 +272,82 @@ class DetectedIssueSummaryService
         ksort($counts);
 
         return $counts;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function shouldEmitSupplementalIssue(string $issueClass, array $evidence): bool
+    {
+        if (! is_array(config('domain_monitor.search_console_issue_catalog.'.$issueClass))) {
+            return false;
+        }
+
+        if (is_numeric($evidence['affected_url_count'] ?? null) && (int) $evidence['affected_url_count'] > 0) {
+            return true;
+        }
+
+        foreach (['affected_urls', 'examples', 'url_inspection', 'sitemaps', 'referring_urls', 'canonical_state', 'search_analytics'] as $key) {
+            if (! empty($evidence[$key])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function supplementalIssueReason(string $issueClass, array $evidence): string
+    {
+        $label = data_get(config('domain_monitor.search_console_issue_catalog.'.$issueClass), 'label', $issueClass);
+        $count = is_numeric($evidence['affected_url_count'] ?? null) ? (int) $evidence['affected_url_count'] : null;
+
+        if ($count !== null && $count > 0) {
+            return sprintf('Search Console reports %s (%d URLs)', strtolower((string) $label), $count);
+        }
+
+        return sprintf('Search Console reports %s', strtolower((string) $label));
+    }
+
+    private function defaultSeverityForIssueClass(string $issueClass): string
+    {
+        return in_array($issueClass, ['page_with_redirect_in_sitemap', 'blocked_by_robots_in_indexing'], true)
+            ? 'must_fix'
+            : 'should_fix';
+    }
+
+    private function controlIdForIssueClass(string $issueClass): ?string
+    {
+        $controls = data_get(config('domain_monitor.priority_queue_standards'), 'controls', []);
+
+        if (! is_array($controls)) {
+            return null;
+        }
+
+        foreach ($controls as $controlId => $controlConfig) {
+            $mappedFamilies = data_get($controlConfig, 'issue_families', []);
+
+            if (is_array($mappedFamilies) && in_array($issueClass, $mappedFamilies, true)) {
+                return is_string($controlId) ? $controlId : null;
+            }
+        }
+
+        return null;
+    }
+
+    private function configuredRolloutScopeForControl(?string $controlId): ?string
+    {
+        return is_string($controlId)
+            ? data_get(config('domain_monitor.priority_queue_standards'), 'controls.'.$controlId.'.rollout_scope')
+            : null;
+    }
+
+    private function defaultBaselineSurfaceForPlatformProfile(?string $platformProfile): ?string
+    {
+        return is_string($platformProfile)
+            ? data_get(config('domain_monitor.priority_queue_standards'), 'platform_profiles.'.$platformProfile.'.baseline_surface')
+            : null;
     }
 }

--- a/app/Services/SearchConsoleIssueSnapshotImporter.php
+++ b/app/Services/SearchConsoleIssueSnapshotImporter.php
@@ -454,12 +454,18 @@ class SearchConsoleIssueSnapshotImporter
 
     private function parseDate(mixed $value): ?Carbon
     {
-        if (! is_string($value) || trim($value) === '') {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '' || in_array(strtolower($trimmed), ['n/a', 'na', '-', '--', 'not available'], true)) {
             return null;
         }
 
         try {
-            return Carbon::parse($value);
+            return Carbon::parse($trimmed);
         } catch (\Throwable) {
             return null;
         }

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -609,6 +609,16 @@ return [
             'seo.canonical_consistency' => [
                 'issue_families' => [
                     'duplicate_without_user_selected_canonical',
+                    'alternate_with_canonical',
+                    'google_chose_different_canonical',
+                ],
+            ],
+            'seo.indexation_coverage' => [
+                'issue_families' => [
+                    'excluded_by_noindex',
+                    'not_found_404',
+                    'crawled_currently_not_indexed',
+                    'discovered_currently_not_indexed',
                 ],
             ],
             'seo.broken_links' => [

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -132,6 +132,60 @@ class DetectedIssueApiTest extends TestCase
             'raw_payload' => ['source' => 'api'],
         ]);
 
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $redirectDomain->id,
+            'web_property_id' => $redirectProperty->id,
+            'issue_class' => 'excluded_by_noindex',
+            'source_issue_label' => "Excluded by 'noindex' tag",
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:redirect-issue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://redirect-issue.example.com/noindex-page/',
+            ],
+            'examples' => [
+                ['url' => 'https://redirect-issue.example.com/noindex-page/', 'last_crawled' => '2026-03-26'],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://redirect-issue.example.com/noindex-page/',
+                ],
+            ],
+            'raw_payload' => ['source' => 'drilldown'],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $redirectDomain->id,
+            'web_property_id' => $redirectProperty->id,
+            'issue_class' => 'discovered_currently_not_indexed',
+            'source_issue_label' => 'Discovered - currently not indexed',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:redirect-issue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://redirect-issue.example.com/new-page/',
+            ],
+            'examples' => [
+                ['url' => 'https://redirect-issue.example.com/new-page/', 'last_crawled' => '1970-01-01'],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://redirect-issue.example.com/new-page/',
+                ],
+            ],
+            'raw_payload' => [
+                'table' => [
+                    ['URL' => 'https://redirect-issue.example.com/new-page/', 'Last crawled' => 'N/A'],
+                ],
+            ],
+        ]);
+
         $headersDomain = Domain::factory()->create([
             'domain' => 'headers-issue.example.com',
             'is_active' => true,
@@ -177,13 +231,15 @@ class DetectedIssueApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('source_system', 'domain-monitor-issues')
             ->assertJsonPath('contract_version', 1)
-            ->assertJsonPath('stats.open', 3)
+            ->assertJsonPath('stats.open', 5)
             ->assertJsonPath('stats.must_fix', 2)
-            ->assertJsonPath('stats.should_fix', 1);
+            ->assertJsonPath('stats.should_fix', 3);
 
         $issueClassCounts = $response->json('stats.issue_class_counts');
         $this->assertSame(1, $issueClassCounts['page_with_redirect_in_sitemap'] ?? null);
         $this->assertSame(1, $issueClassCounts['blocked_by_robots_in_indexing'] ?? null);
+        $this->assertSame(1, $issueClassCounts['excluded_by_noindex'] ?? null);
+        $this->assertSame(1, $issueClassCounts['discovered_currently_not_indexed'] ?? null);
         $this->assertSame(1, $issueClassCounts['security.headers_baseline'] ?? null);
 
         /** @var array<int, array<string, mixed>> $payloadIssues */
@@ -192,10 +248,14 @@ class DetectedIssueApiTest extends TestCase
 
         $redirectIssue = $issues->firstWhere('property_slug', 'redirect-issue-site');
         $blockedIssue = $issues->firstWhere('issue_class', 'blocked_by_robots_in_indexing');
+        $noindexIssue = $issues->firstWhere('issue_class', 'excluded_by_noindex');
+        $discoveredIssue = $issues->firstWhere('issue_class', 'discovered_currently_not_indexed');
         $headersIssue = $issues->firstWhere('property_slug', 'headers-issue-site');
 
         $this->assertNotNull($redirectIssue);
         $this->assertNotNull($blockedIssue);
+        $this->assertNotNull($noindexIssue);
+        $this->assertNotNull($discoveredIssue);
         $this->assertNotNull($headersIssue);
         $this->assertSame('page_with_redirect_in_sitemap', $redirectIssue['issue_class']);
         $this->assertSame('must_fix', $redirectIssue['severity']);
@@ -226,6 +286,12 @@ class DetectedIssueApiTest extends TestCase
             'https://redirect-issue.example.com/blocked-page/',
             data_get($blockedIssue, 'evidence.canonical_state.google_canonical')
         );
+        $this->assertSame('should_fix', $noindexIssue['severity']);
+        $this->assertSame('seo.indexation_coverage', $noindexIssue['control_id']);
+        $this->assertSame('https://redirect-issue.example.com/noindex-page/', data_get($noindexIssue, 'evidence.examples.0.url'));
+        $this->assertSame('should_fix', $discoveredIssue['severity']);
+        $this->assertSame('seo.indexation_coverage', $discoveredIssue['control_id']);
+        $this->assertNull(data_get($discoveredIssue, 'evidence.examples.0.last_crawled'));
         $this->assertSame('security.headers_baseline', $headersIssue['issue_class']);
         $this->assertSame('controlled', $headersIssue['control_state']);
         $this->assertSame('astro_repo_controlled', $headersIssue['execution_surface']);

--- a/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
+++ b/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
@@ -49,6 +49,32 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
         Storage::disk('local')->assertExists($snapshot->artifact_path);
     }
 
+    public function test_it_treats_na_last_crawled_values_as_null_in_drilldown_zip(): void
+    {
+        Storage::fake('local');
+
+        $property = $this->makeProperty('na-crawl-site', 'na-crawl.example.au', '43');
+        $zipPath = $this->makeDrilldownExportZip(
+            'Discovered - currently not indexed',
+            [
+                ['https://na-crawl.example.au/new-page/', 'N/A'],
+            ]
+        );
+
+        $exitCode = Artisan::call('analytics:import-search-console-issue-detail', [
+            'property' => $property->slug,
+            'path' => $zipPath,
+            '--captured-by' => 'test-suite',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $snapshot = SearchConsoleIssueSnapshot::query()->firstOrFail();
+        $this->assertSame('discovered_currently_not_indexed', $snapshot->issue_class);
+        $this->assertNull(data_get($snapshot->examples, '0.last_crawled'));
+        $this->assertNull(data_get($snapshot->issueEvidence(), 'examples.0.last_crawled'));
+    }
+
     public function test_it_imports_search_console_api_evidence_json(): void
     {
         Storage::fake('local');

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -257,6 +257,35 @@ class WebPropertyUiTest extends TestCase
             ],
         ]);
 
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'issue_class' => 'discovered_currently_not_indexed',
+            'source_issue_label' => 'Discovered - currently not indexed',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:checklist.example.au',
+            'captured_at' => now(),
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://checklist.example.au/new-page/',
+            ],
+            'examples' => [
+                ['url' => 'https://checklist.example.au/new-page/', 'last_crawled' => '1970-01-01'],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://checklist.example.au/new-page/',
+                ],
+            ],
+            'raw_payload' => [
+                'table' => [
+                    ['URL' => 'https://checklist.example.au/new-page/', 'Last crawled' => 'N/A'],
+                ],
+            ],
+        ]);
+
         $response = $this->actingAs($user)->get('/web-properties/checklist-site');
 
         $response->assertOk();
@@ -267,5 +296,7 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('Search Console Issue Evidence');
         $response->assertSee('Exact examples captured');
         $response->assertSee('https://checklist.example.au/');
+        $response->assertSee('https://checklist.example.au/new-page/');
+        $response->assertDontSee('1970-01-01');
     }
 }


### PR DESCRIPTION
## Summary
- normalize Search Console drilldown crawl-date placeholders so unavailable crawl dates do not surface as epoch values
- emit additional Search Console issue families from stored evidence, including snapshot-backed families the priority queue did not previously surface
- map the new issue families to explicit SEO controls and remove stale in-memory issue snapshot caching in the detected-issues feed

## Testing
- ./vendor/bin/phpunit tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Models/SearchConsoleIssueSnapshot.php app/Services/SearchConsoleIssueSnapshotImporter.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
