### PR TITLE
Preserve capped Search Console drilldown counts

### DIFF
--- a/app/Models/DomainSeoBaseline.php
+++ b/app/Models/DomainSeoBaseline.php
@@ -218,6 +218,8 @@ class DomainSeoBaseline extends Model
         return array_filter([
             'affected_urls' => $affectedUrls !== [] ? $affectedUrls : null,
             'affected_url_count' => $affectedUrls !== [] ? count($affectedUrls) : $count,
+            'exact_example_count' => $affectedUrls !== [] ? count($affectedUrls) : null,
+            'is_example_set_truncated' => null,
             'sample_urls' => $affectedUrls !== [] ? array_slice($affectedUrls, 0, 10) : null,
             'source_report' => 'search_console_page_indexing_summary',
             'source_capture_method' => $this->import_method,

--- a/app/Models/SearchConsoleIssueSnapshot.php
+++ b/app/Models/SearchConsoleIssueSnapshot.php
@@ -149,7 +149,9 @@ class SearchConsoleIssueSnapshot extends Model
 
         $exactExampleCount = count($affectedUrls);
         $affectedUrlCount = $this->affected_url_count;
-        $isExampleSetTruncated = is_int($affectedUrlCount) && $affectedUrlCount > $exactExampleCount;
+        $isExampleSetTruncated = $exactExampleCount > 0
+            && is_int($affectedUrlCount)
+            && $affectedUrlCount > $exactExampleCount;
 
         return array_filter([
             'affected_urls' => $affectedUrls !== [] ? $affectedUrls : null,

--- a/app/Models/SearchConsoleIssueSnapshot.php
+++ b/app/Models/SearchConsoleIssueSnapshot.php
@@ -147,9 +147,15 @@ class SearchConsoleIssueSnapshot extends Model
             )));
         }
 
+        $exactExampleCount = count($affectedUrls);
+        $affectedUrlCount = $this->affected_url_count;
+        $isExampleSetTruncated = is_int($affectedUrlCount) && $affectedUrlCount > $exactExampleCount;
+
         return array_filter([
             'affected_urls' => $affectedUrls !== [] ? $affectedUrls : null,
-            'affected_url_count' => $this->affected_url_count,
+            'affected_url_count' => $affectedUrlCount,
+            'exact_example_count' => $exactExampleCount > 0 ? $exactExampleCount : null,
+            'is_example_set_truncated' => $isExampleSetTruncated ? true : null,
             'sample_urls' => is_array($this->sample_urls) && $this->sample_urls !== [] ? $this->sample_urls : array_slice($affectedUrls, 0, 10),
             'examples' => $examples !== [] ? $examples : null,
             'first_detected' => $this->first_detected_at?->toDateString(),

--- a/app/Services/SearchConsoleIssueSnapshotImporter.php
+++ b/app/Services/SearchConsoleIssueSnapshotImporter.php
@@ -189,7 +189,10 @@ class SearchConsoleIssueSnapshotImporter
             ->map(fn (array $row): array => [
                 'date' => (string) $row['Date'],
                 'affected_pages' => $this->nullableInt($row['Affected pages'] ?? null),
-            ])->values()->all();
+            ])
+            ->sortBy('date')
+            ->values()
+            ->all();
 
         $summaryAffectedCount = collect($chartPoints)
             ->pluck('affected_pages')

--- a/app/Services/SearchConsoleIssueSnapshotImporter.php
+++ b/app/Services/SearchConsoleIssueSnapshotImporter.php
@@ -130,6 +130,7 @@ class SearchConsoleIssueSnapshotImporter
      *   first_detected_at:Carbon|null,
      *   last_updated_at:Carbon|null,
      *   affected_url_count:int,
+     *   exact_example_count:int,
      *   affected_urls:array<int, string>,
      *   sample_urls:array<int, string>,
      *   examples:array<int, array{url:string,last_crawled:?string}>,
@@ -183,22 +184,31 @@ class SearchConsoleIssueSnapshotImporter
             $examples
         )));
 
+        $chartPoints = collect($chartRows)
+            ->filter(fn (array $row): bool => ($row['Date'] ?? '') !== '')
+            ->map(fn (array $row): array => [
+                'date' => (string) $row['Date'],
+                'affected_pages' => $this->nullableInt($row['Affected pages'] ?? null),
+            ])->values()->all();
+
+        $summaryAffectedCount = collect($chartPoints)
+            ->pluck('affected_pages')
+            ->filter(fn (mixed $value): bool => is_int($value))
+            ->last();
+        $exactExampleCount = count($affectedUrls);
+
         return [
             'issue_class' => $issueClass,
             'source_issue_label' => $issueLabel,
             'property_scope' => is_string($metadata['Sitemap'] ?? null) ? $metadata['Sitemap'] : null,
             'first_detected_at' => $this->parseDate($metadata['First detected'] ?? null),
             'last_updated_at' => $this->parseDate($metadata['Last update'] ?? null),
-            'affected_url_count' => count($affectedUrls),
+            'affected_url_count' => max($exactExampleCount, is_int($summaryAffectedCount) ? $summaryAffectedCount : 0),
+            'exact_example_count' => $exactExampleCount,
             'affected_urls' => $affectedUrls,
             'sample_urls' => array_slice($affectedUrls, 0, 10),
             'examples' => $examples,
-            'chart_points' => collect($chartRows)
-                ->filter(fn (array $row): bool => ($row['Date'] ?? '') !== '')
-                ->map(fn (array $row): array => [
-                    'date' => (string) $row['Date'],
-                    'affected_pages' => $this->nullableInt($row['Affected pages'] ?? null),
-                ])->values()->all(),
+            'chart_points' => $chartPoints,
             'raw_payload' => [
                 'table' => $tableRows,
                 'chart' => $chartRows,

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -85,7 +85,7 @@ class DetectedIssueApiTest extends TestCase
             'source_property' => 'sc-domain:redirect-issue.example.com',
             'captured_at' => now(),
             'captured_by' => 'test',
-            'affected_url_count' => 2,
+            'affected_url_count' => 7,
             'sample_urls' => [
                 'https://redirect-issue.example.com/',
                 'http://redirect-issue.example.com/',
@@ -271,7 +271,9 @@ class DetectedIssueApiTest extends TestCase
             ['https://redirect-issue.example.com/', 'http://redirect-issue.example.com/'],
             $redirectIssue['evidence']['affected_urls']
         );
-        $this->assertSame(2, $redirectIssue['evidence']['affected_url_count']);
+        $this->assertSame(7, $redirectIssue['evidence']['affected_url_count']);
+        $this->assertSame(2, $redirectIssue['evidence']['exact_example_count']);
+        $this->assertTrue($redirectIssue['evidence']['is_example_set_truncated']);
         $this->assertSame('search_console_page_indexing_drilldown', $redirectIssue['evidence']['source_report']);
         $this->assertSame('gsc_drilldown_zip', $redirectIssue['evidence']['source_capture_method']);
         $this->assertSame('2026-03-28', $redirectIssue['evidence']['examples'][0]['last_crawled']);

--- a/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
+++ b/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
@@ -75,6 +75,36 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
         $this->assertNull(data_get($snapshot->issueEvidence(), 'examples.0.last_crawled'));
     }
 
+    public function test_it_preserves_higher_summary_count_than_exported_examples_for_large_drilldown_exports(): void
+    {
+        Storage::fake('local');
+
+        $property = $this->makeProperty('large-drilldown-site', 'large-drilldown.example.au', '44');
+        $zipPath = $this->makeDrilldownExportZip(
+            'Discovered - currently not indexed',
+            [
+                ['https://large-drilldown.example.au/example-one/', '2026-03-28'],
+                ['https://large-drilldown.example.au/example-two/', '2026-03-27'],
+            ],
+            1741
+        );
+
+        $exitCode = Artisan::call('analytics:import-search-console-issue-detail', [
+            'property' => $property->slug,
+            'path' => $zipPath,
+            '--captured-by' => 'test-suite',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $snapshot = SearchConsoleIssueSnapshot::query()->firstOrFail();
+        $this->assertSame(1741, $snapshot->affected_url_count);
+        $this->assertSame(2, count($snapshot->sample_urls ?? []));
+        $this->assertSame(2, count($snapshot->examples ?? []));
+        $this->assertSame(2, data_get($snapshot->issueEvidence(), 'exact_example_count'));
+        $this->assertTrue((bool) data_get($snapshot->issueEvidence(), 'is_example_set_truncated'));
+    }
+
     public function test_it_imports_search_console_api_evidence_json(): void
     {
         Storage::fake('local');
@@ -189,7 +219,7 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
     /**
      * @param  array<int, array{0:string,1:string}>  $rows
      */
-    private function makeDrilldownExportZip(string $issueLabel, array $rows): string
+    private function makeDrilldownExportZip(string $issueLabel, array $rows, ?int $chartAffectedPages = null): string
     {
         $path = tempnam(sys_get_temp_dir(), 'gsc-drilldown-');
         $zip = new ZipArchive;
@@ -201,7 +231,7 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
         ]));
         $zip->addFromString('Chart.csv', implode("\n", [
             'Date,Affected pages',
-            '2026-03-28,'.count($rows),
+            '2026-03-28,'.($chartAffectedPages ?? count($rows)),
         ]));
         $tableRows = ['URL,Last crawled'];
         foreach ($rows as [$url, $lastCrawled]) {


### PR DESCRIPTION
## Summary
- preserve the higher Search Console summary count when drilldown exports cap the example rows
- expose exact example count plus a truncation flag in issue evidence
- cover the capped-export case in importer and API tests

## Verification
- composer dump-autoload
- php artisan list | rg 'analytics:import-search-console-(issue-detail|api-evidence)'
- ./vendor/bin/phpstan analyse app/Models/DomainSeoBaseline.php app/Models/SearchConsoleIssueSnapshot.php app/Services/SearchConsoleIssueSnapshotImporter.php tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
- php smoke test for parseDrilldownArchive preserving 1741 summary count with 2 exported examples
- php smoke test for SearchConsoleIssueSnapshot::issueEvidence exposing exact_example_count and is_example_set_truncated

## Notes
- The clean /tmp worktree PHPUnit harness still hit unrelated Laravel test-environment issues around command discovery/migrations, so I verified the new logic with focused smoke checks plus PHPStan while keeping the patch small and isolated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
