### PR TITLE
Add property-level GSC evidence summary

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\WebPropertyHealthSummaryResource;
 use App\Http\Resources\WebPropertyResource;
+use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -86,6 +87,18 @@ class WebPropertyController extends Controller
     private function baseQuery(): Builder
     {
         return WebProperty::query()
+            ->addSelect([
+                'has_gsc_issue_detail' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('1')
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->limit(1),
+                'gsc_issue_detail_snapshot_count' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('web_property_id', 'web_properties.id'),
+                'gsc_issue_detail_last_captured_at' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('max(captured_at)')
+                    ->whereColumn('web_property_id', 'web_properties.id'),
+            ])
             ->with([
                 'primaryDomain',
                 'repositories',

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -457,7 +457,32 @@ class WebProperty extends Model
             'execution_surface' => $executionReadiness['execution_surface'],
             'fleet_managed' => $executionReadiness['fleet_managed'],
             'controller_repo' => $executionReadiness['controller_repo'],
+            'gsc_evidence_summary' => $this->gscEvidenceSummary(),
             'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   has_issue_detail: bool,
+     *   issue_detail_snapshot_count: int,
+     *   latest_issue_detail_captured_at: string|null
+     * }
+     */
+    public function gscEvidenceSummary(): array
+    {
+        $hasIssueDetail = (bool) ($this->getAttribute('has_gsc_issue_detail') ?? false);
+        $snapshotCount = (int) ($this->getAttribute('gsc_issue_detail_snapshot_count') ?? 0);
+        $latestCapturedAt = $this->getAttribute('gsc_issue_detail_last_captured_at');
+
+        return [
+            'has_issue_detail' => $hasIssueDetail,
+            'issue_detail_snapshot_count' => $snapshotCount,
+            'latest_issue_detail_captured_at' => $latestCapturedAt instanceof \DateTimeInterface
+                ? $latestCapturedAt->format(\DateTimeInterface::ATOM)
+                : (is_string($latestCapturedAt) && $latestCapturedAt !== ''
+                    ? \Illuminate\Support\Carbon::parse($latestCapturedAt, 'UTC')->utc()->toIso8601String()
+                    : null),
         ];
     }
 

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -8,6 +8,7 @@ use App\Models\DomainAlert;
 use App\Models\DomainCheck;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
+use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -158,6 +159,9 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
             ->assertJsonPath('web_properties.0.controller_repo', 'moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)
             ->assertJsonPath('web_properties.0.health_summary.active_alerts_count', 1);
     }
 
@@ -215,6 +219,56 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.execution_surface', 'fleet_wordpress_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
             ->assertJsonPath('web_properties.0.controller_repo', '_wp-house');
+    }
+
+    public function test_web_properties_summary_surfaces_property_level_gsc_issue_detail_coverage(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'backloading-au.com.au',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloading-au-com-au',
+            'name' => 'Backloading AU',
+            'property_type' => 'website',
+            'status' => 'active',
+            'platform' => 'WordPress',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'captured_at' => '2026-03-31T14:58:44+00:00',
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'excluded_by_noindex',
+            'captured_at' => '2026-03-31T14:32:19+00:00',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'backloading-au-com-au')
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', true)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 2)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', '2026-03-31T14:58:44+00:00');
     }
 
     public function test_web_property_health_summary_endpoint_returns_property_health(): void


### PR DESCRIPTION
## Summary
- add a property-level Google Search Console evidence summary to the web properties feed
- expose whether a property has issue-detail snapshots, how many exist, and when the latest one was captured
- cover the new summary contract in the web properties API test

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Http/Controllers/Api/WebPropertyController.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
