### PR TITLE
Add Search Console API bundle enrichment

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -91,13 +91,29 @@ class WebPropertyController extends Controller
                 'has_gsc_issue_detail' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('1')
                     ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', 'gsc_drilldown_zip')
                     ->limit(1),
                 'gsc_issue_detail_snapshot_count' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('count(*)')
-                    ->whereColumn('web_property_id', 'web_properties.id'),
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', 'gsc_drilldown_zip'),
                 'gsc_issue_detail_last_captured_at' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('max(captured_at)')
-                    ->whereColumn('web_property_id', 'web_properties.id'),
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', 'gsc_drilldown_zip'),
+                'has_gsc_api_enrichment' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('1')
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', '!=', 'gsc_drilldown_zip')
+                    ->limit(1),
+                'gsc_api_snapshot_count' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('count(*)')
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', '!=', 'gsc_drilldown_zip'),
+                'gsc_api_last_captured_at' => SearchConsoleIssueSnapshot::query()
+                    ->selectRaw('max(captured_at)')
+                    ->whereColumn('web_property_id', 'web_properties.id')
+                    ->where('capture_method', '!=', 'gsc_drilldown_zip'),
             ])
             ->with([
                 'primaryDomain',

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -466,7 +466,10 @@ class WebProperty extends Model
      * @return array{
      *   has_issue_detail: bool,
      *   issue_detail_snapshot_count: int,
-     *   latest_issue_detail_captured_at: string|null
+     *   latest_issue_detail_captured_at: string|null,
+     *   has_api_enrichment: bool,
+     *   api_snapshot_count: int,
+     *   latest_api_captured_at: string|null
      * }
      */
     public function gscEvidenceSummary(): array
@@ -474,6 +477,9 @@ class WebProperty extends Model
         $hasIssueDetail = (bool) ($this->getAttribute('has_gsc_issue_detail') ?? false);
         $snapshotCount = (int) ($this->getAttribute('gsc_issue_detail_snapshot_count') ?? 0);
         $latestCapturedAt = $this->getAttribute('gsc_issue_detail_last_captured_at');
+        $hasApiEnrichment = (bool) ($this->getAttribute('has_gsc_api_enrichment') ?? false);
+        $apiSnapshotCount = (int) ($this->getAttribute('gsc_api_snapshot_count') ?? 0);
+        $latestApiCapturedAt = $this->getAttribute('gsc_api_last_captured_at');
 
         return [
             'has_issue_detail' => $hasIssueDetail,
@@ -482,6 +488,13 @@ class WebProperty extends Model
                 ? $latestCapturedAt->format(\DateTimeInterface::ATOM)
                 : (is_string($latestCapturedAt) && $latestCapturedAt !== ''
                     ? \Illuminate\Support\Carbon::parse($latestCapturedAt, 'UTC')->utc()->toIso8601String()
+                    : null),
+            'has_api_enrichment' => $hasApiEnrichment,
+            'api_snapshot_count' => $apiSnapshotCount,
+            'latest_api_captured_at' => $latestApiCapturedAt instanceof \DateTimeInterface
+                ? $latestApiCapturedAt->format(\DateTimeInterface::ATOM)
+                : (is_string($latestApiCapturedAt) && $latestApiCapturedAt !== ''
+                    ? \Illuminate\Support\Carbon::parse($latestApiCapturedAt, 'UTC')->utc()->toIso8601String()
                     : null),
         ];
     }

--- a/app/Services/SearchConsoleApiBundleImporter.php
+++ b/app/Services/SearchConsoleApiBundleImporter.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use InvalidArgumentException;
+use RuntimeException;
+
+class SearchConsoleApiBundleImporter
+{
+    private const MAX_JSON_BYTES = 5_242_880;
+
+    public function __construct(
+        private readonly SearchConsoleIssueSnapshotImporter $snapshotImporter,
+    ) {}
+
+    /**
+     * @return array{
+     *   artifact_path: string,
+     *   imported_issue_classes: array<int, string>,
+     *   snapshots: array<int, \App\Models\SearchConsoleIssueSnapshot>
+     * }
+     */
+    public function importBundleForProperty(
+        WebProperty $property,
+        string $jsonPath,
+        string $captureMethod = 'gsc_api',
+        ?string $capturedBy = null
+    ): array {
+        if (! in_array($captureMethod, ['gsc_api', 'gsc_mcp_api'], true)) {
+            throw new InvalidArgumentException('Capture method must be gsc_api or gsc_mcp_api.');
+        }
+
+        if (! is_file($jsonPath)) {
+            throw new InvalidArgumentException(sprintf('Search Console API bundle not found at [%s].', $jsonPath));
+        }
+
+        if (filesize($jsonPath) > self::MAX_JSON_BYTES) {
+            throw new InvalidArgumentException('Search Console API bundle exceeds the supported size limit.');
+        }
+
+        $decoded = json_decode((string) file_get_contents($jsonPath), true);
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Search Console API bundle is not valid JSON.');
+        }
+
+        /** @var array<string, mixed> $sharedPayload */
+        $sharedPayload = is_array($decoded['shared'] ?? null) ? $decoded['shared'] : [];
+        /** @var array<string, mixed> $issueEvidence */
+        $issueEvidence = is_array($decoded['issue_evidence'] ?? null) ? $decoded['issue_evidence'] : [];
+
+        if ($issueEvidence === []) {
+            throw new RuntimeException('Search Console API bundle does not contain any issue_evidence entries.');
+        }
+
+        $artifactPath = $this->snapshotImporter->storeArtifactForProperty($property, $jsonPath, 'search-console-api-evidence');
+        $snapshots = [];
+
+        foreach ($issueEvidence as $issueClass => $payload) {
+            if (! is_array($payload)) {
+                continue;
+            }
+
+            $mergedPayload = array_replace_recursive(
+                $this->bundleDefaults($decoded, $sharedPayload),
+                $payload
+            );
+
+            $result = $this->snapshotImporter->importApiEvidencePayloadForProperty(
+                $property,
+                $issueClass,
+                $mergedPayload,
+                $captureMethod,
+                $capturedBy ?: 'bundle_api_issue_import',
+                $artifactPath
+            );
+
+            $snapshots[] = $result['snapshot'];
+        }
+
+        if ($snapshots === []) {
+            throw new RuntimeException('Search Console API bundle did not contain any importable issue evidence entries.');
+        }
+
+        return [
+            'artifact_path' => $artifactPath,
+            'imported_issue_classes' => array_map(
+                static fn ($snapshot): string => $snapshot->issue_class,
+                $snapshots
+            ),
+            'snapshots' => $snapshots,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $bundle
+     * @param  array<string, mixed>  $sharedPayload
+     * @return array<string, mixed>
+     */
+    private function bundleDefaults(array $bundle, array $sharedPayload): array
+    {
+        $defaults = [];
+
+        foreach (['source_report', 'source_property', 'property_scope', 'first_detected', 'last_update'] as $key) {
+            if (array_key_exists($key, $bundle)) {
+                $defaults[$key] = $bundle[$key];
+            }
+        }
+
+        return array_replace_recursive($defaults, $sharedPayload);
+    }
+}

--- a/app/Services/SearchConsoleIssueSnapshotImporter.php
+++ b/app/Services/SearchConsoleIssueSnapshotImporter.php
@@ -90,8 +90,42 @@ class SearchConsoleIssueSnapshotImporter
             throw new InvalidArgumentException('Issue evidence payload exceeds the supported size limit.');
         }
 
-        $parsed = $this->parseApiEvidenceJson($issueClass, $jsonPath, $captureMethod);
         $artifactPath = $this->storeArtifact($property, $jsonPath, 'search-console-api-evidence');
+        $decoded = json_decode((string) file_get_contents($jsonPath), true);
+
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Issue evidence payload is not valid JSON.');
+        }
+
+        return $this->importApiEvidencePayloadForProperty(
+            $property,
+            $issueClass,
+            $decoded,
+            $captureMethod,
+            $capturedBy,
+            $artifactPath
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{snapshot: SearchConsoleIssueSnapshot, artifact_path: string, parsed: array<string, mixed>}
+     */
+    public function importApiEvidencePayloadForProperty(
+        WebProperty $property,
+        string $issueClass,
+        array $payload,
+        string $captureMethod = 'gsc_api',
+        ?string $capturedBy = null,
+        ?string $artifactPath = null
+    ): array {
+        if (! in_array($captureMethod, ['gsc_api', 'gsc_mcp_api'], true)) {
+            throw new InvalidArgumentException('Capture method must be gsc_api or gsc_mcp_api.');
+        }
+
+        $parsed = $this->parseApiEvidencePayload($issueClass, $payload, $captureMethod);
+        $artifactPath ??= $this->storeJsonArtifact($property, $payload, 'search-console-api-evidence');
+
         $snapshot = $this->persistSnapshot(
             $property,
             $issueClass,
@@ -248,6 +282,32 @@ class SearchConsoleIssueSnapshotImporter
             throw new RuntimeException('Issue evidence payload is not valid JSON.');
         }
 
+        return $this->parseApiEvidencePayload($issueClass, $decoded, $captureMethod);
+    }
+
+    /**
+     * @param  array<string, mixed>  $decoded
+     * @return array{
+     *   source_issue_label:string|null,
+     *   source_report:string,
+     *   source_property:string|null,
+     *   property_scope:string|null,
+     *   first_detected_at:Carbon|null,
+     *   last_updated_at:Carbon|null,
+     *   affected_url_count:int|null,
+     *   sample_urls:array<int, string>|null,
+     *   examples:array<int, array<string, mixed>>|null,
+     *   chart_points:array<int, array<string, mixed>>|null,
+     *   normalized_payload:array<string, mixed>,
+     *   raw_payload:array<string, mixed>
+     * }
+     */
+    public function parseApiEvidencePayload(string $issueClass, array $decoded, string $captureMethod): array
+    {
+        if (! is_array(config('domain_monitor.search_console_issue_catalog.'.$issueClass))) {
+            throw new InvalidArgumentException(sprintf('Unsupported Search Console issue class [%s].', $issueClass));
+        }
+
         $normalizedPayload = array_filter([
             'affected_urls' => $this->stringList($decoded['affected_urls'] ?? []),
             'url_inspection' => is_array($decoded['url_inspection'] ?? null) ? $decoded['url_inspection'] : null,
@@ -339,6 +399,11 @@ class SearchConsoleIssueSnapshotImporter
         return $property->latestPropertySeoBaselineRecord()?->search_console_property_uri;
     }
 
+    public function storeArtifactForProperty(WebProperty $property, string $sourcePath, string $directory): string
+    {
+        return $this->storeArtifact($property, $sourcePath, $directory);
+    }
+
     private function storeArtifact(WebProperty $property, string $sourcePath, string $directory): string
     {
         $extension = pathinfo($sourcePath, PATHINFO_EXTENSION);
@@ -362,6 +427,29 @@ class SearchConsoleIssueSnapshotImporter
         }
 
         return $relativePath;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function storeJsonArtifact(WebProperty $property, array $payload, string $directory): string
+    {
+        $temporaryBasePath = tempnam(sys_get_temp_dir(), 'gsc-api-evidence-');
+
+        if (! is_string($temporaryBasePath)) {
+            throw new RuntimeException('Unable to create a temporary Search Console issue evidence artifact.');
+        }
+
+        $temporaryPath = $temporaryBasePath.'.json';
+
+        try {
+            file_put_contents($temporaryPath, json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+            return $this->storeArtifact($property, $temporaryPath, $directory);
+        } finally {
+            @unlink($temporaryBasePath);
+            @unlink($temporaryPath);
+        }
     }
 
     private function issueClassForLabel(string $label): ?string

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,7 @@
 
 use App\Models\WebProperty;
 use App\Services\ManualSearchConsoleEvidenceImporter;
+use App\Services\SearchConsoleApiBundleImporter;
 use App\Services\SearchConsoleIssueSnapshotImporter;
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Inspiring;
@@ -163,6 +164,50 @@ Artisan::command('analytics:import-search-console-api-evidence {property : Web p
 
     return Command::SUCCESS;
 })->purpose('Import Search Console API or MCP evidence for one issue class on one property.');
+
+Artisan::command('analytics:import-search-console-api-bundle {property : Web property slug} {path : Path to the Search Console API or MCP JSON bundle} {--capture-method=gsc_api : Either gsc_api or gsc_mcp_api} {--captured-by= : Optional captured_by value}', function (SearchConsoleApiBundleImporter $importer) {
+    $propertyArgument = $this->argument('property');
+    $pathArgument = $this->argument('path');
+    $captureMethodOption = $this->option('capture-method');
+    $capturedByOption = $this->option('captured-by');
+
+    $property = WebProperty::query()
+        ->where('slug', is_string($propertyArgument) ? $propertyArgument : '')
+        ->first();
+
+    if (! $property instanceof WebProperty) {
+        $this->error('Could not find the requested web property.');
+
+        return Command::FAILURE;
+    }
+
+    try {
+        $result = $importer->importBundleForProperty(
+            $property,
+            is_string($pathArgument) ? $pathArgument : '',
+            is_string($captureMethodOption) && $captureMethodOption !== ''
+                ? $captureMethodOption
+                : 'gsc_api',
+            is_string($capturedByOption) && $capturedByOption !== ''
+                ? $capturedByOption
+                : 'artisan_api_bundle_import'
+        );
+    } catch (\Throwable $exception) {
+        $this->error($exception->getMessage());
+
+        return Command::FAILURE;
+    }
+
+    $this->info(sprintf(
+        'Imported Search Console API bundle for [%s] and stored [%d] issue snapshots.',
+        $property->slug,
+        count($result['snapshots'])
+    ));
+    $this->line(sprintf('Artifact path: %s', $result['artifact_path']));
+    $this->line(sprintf('Issue classes: %s', implode(', ', $result['imported_issue_classes'])));
+
+    return Command::SUCCESS;
+})->purpose('Import a Search Console API or MCP bundle and fan it out into per-issue snapshots.');
 
 $brainConfigured = filled(config('services.brain.base_url')) && filled(config('services.brain.api_key'));
 

--- a/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
+++ b/tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php
@@ -146,6 +146,70 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
         Storage::disk('local')->assertExists($snapshot->artifact_path);
     }
 
+    public function test_it_imports_search_console_api_bundle_json_into_multiple_issue_snapshots(): void
+    {
+        Storage::fake('local');
+
+        $property = $this->makeProperty('bundle-site', 'bundle.example.au', '85');
+        $jsonPath = $this->makeApiBundleJson([
+            'source_report' => 'search_console_api_bundle',
+            'source_property' => 'sc-domain:bundle.example.au',
+            'shared' => [
+                'sitemaps' => [
+                    ['path' => 'https://bundle.example.au/sitemap_index.xml', 'warnings' => 0, 'errors' => 0],
+                ],
+                'referring_urls' => ['https://bundle.example.au/sitemap_index.xml'],
+                'search_analytics' => [
+                    'date_range' => ['start' => '2026-03-01', 'end' => '2026-03-28'],
+                    'totals' => ['clicks' => 44, 'impressions' => 640],
+                ],
+            ],
+            'issue_evidence' => [
+                'blocked_by_robots_in_indexing' => [
+                    'url_inspection' => [
+                        'coverageState' => 'Blocked by robots.txt',
+                        'robotsTxtState' => 'BLOCKED',
+                    ],
+                ],
+                'page_with_redirect_in_sitemap' => [
+                    'affected_urls' => ['https://bundle.example.au/old-page/'],
+                    'examples' => [
+                        ['url' => 'https://bundle.example.au/old-page/', 'last_crawled' => '2026-03-28'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('analytics:import-search-console-api-bundle', [
+            'property' => $property->slug,
+            'path' => $jsonPath,
+            '--capture-method' => 'gsc_api',
+            '--captured-by' => 'test-suite',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $snapshots = SearchConsoleIssueSnapshot::query()
+            ->orderBy('issue_class')
+            ->get();
+
+        $this->assertCount(2, $snapshots);
+        $this->assertSame(
+            ['blocked_by_robots_in_indexing', 'page_with_redirect_in_sitemap'],
+            $snapshots->pluck('issue_class')->all()
+        );
+        $this->assertTrue($snapshots->every(fn (SearchConsoleIssueSnapshot $snapshot): bool => $snapshot->capture_method === 'gsc_api'));
+        $this->assertTrue($snapshots->every(fn (SearchConsoleIssueSnapshot $snapshot): bool => data_get($snapshot->normalized_payload, 'search_analytics.totals.clicks') === 44));
+        $this->assertTrue($snapshots->every(fn (SearchConsoleIssueSnapshot $snapshot): bool => data_get($snapshot->normalized_payload, 'sitemaps.0.path') === 'https://bundle.example.au/sitemap_index.xml'));
+        $this->assertSame('BLOCKED', data_get($snapshots->firstWhere('issue_class', 'blocked_by_robots_in_indexing'), 'normalized_payload.url_inspection.robotsTxtState'));
+        $this->assertSame(['https://bundle.example.au/old-page/'], data_get($snapshots->firstWhere('issue_class', 'page_with_redirect_in_sitemap'), 'normalized_payload.affected_urls'));
+        $this->assertSame(
+            $snapshots->first()->artifact_path,
+            $snapshots->last()->artifact_path
+        );
+        Storage::disk('local')->assertExists($snapshots->first()->artifact_path);
+    }
+
     public function test_it_rejects_unknown_issue_label_in_drilldown_zip(): void
     {
         Storage::fake('local');
@@ -249,6 +313,17 @@ class ImportSearchConsoleIssueSnapshotCommandTest extends TestCase
     private function makeApiEvidenceJson(array $payload): string
     {
         $path = tempnam(sys_get_temp_dir(), 'gsc-api-');
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+        return $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function makeApiBundleJson(array $payload): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'gsc-api-bundle-');
         file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
 
         return $path;

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -162,6 +162,9 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_api_enrichment', false)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.api_snapshot_count', 0)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_api_captured_at', null)
             ->assertJsonPath('web_properties.0.health_summary.active_alerts_count', 1);
     }
 
@@ -268,7 +271,65 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.slug', 'backloading-au-com-au')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', true)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 2)
-            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', '2026-03-31T14:58:44+00:00');
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', '2026-03-31T14:58:44+00:00')
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_api_enrichment', false)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.api_snapshot_count', 0)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_api_captured_at', null);
+    }
+
+    public function test_web_properties_summary_surfaces_property_level_gsc_api_enrichment_coverage(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'api-enriched.example.au',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'api-enriched-site',
+            'name' => 'API Enriched Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'platform' => 'WordPress',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'capture_method' => 'gsc_api',
+            'captured_at' => '2026-04-01T03:41:19+00:00',
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_mcp_api',
+            'captured_at' => '2026-04-01T05:12:02+00:00',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'api-enriched-site')
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_api_enrichment', true)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.api_snapshot_count', 2)
+            ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_api_captured_at', '2026-04-01T05:12:02+00:00');
     }
 
     public function test_web_property_health_summary_endpoint_returns_property_health(): void


### PR DESCRIPTION
## Summary
- add a bundle importer for official Search Console API or MCP evidence
- fan bundle payloads out into per-issue snapshots while preserving a shared raw artifact
- surface property-level API enrichment coverage alongside drilldown coverage

## Testing
- ./vendor/bin/phpunit tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleApiBundleImporter.php app/Services/SearchConsoleIssueSnapshotImporter.php app/Models/WebProperty.php app/Http/Controllers/Api/WebPropertyController.php tests/Feature/ImportSearchConsoleIssueSnapshotCommandTest.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
