### PR TITLE
Enrich URL inspection evidence with rich results

### DIFF
--- a/app/Services/SearchConsoleApiBundleCollector.php
+++ b/app/Services/SearchConsoleApiBundleCollector.php
@@ -191,6 +191,8 @@ class SearchConsoleApiBundleCollector
         $result = is_array($payload['inspectionResult'] ?? null) ? $payload['inspectionResult'] : [];
         /** @var array<string, mixed> $indexStatus */
         $indexStatus = is_array($result['indexStatusResult'] ?? null) ? $result['indexStatusResult'] : [];
+        /** @var array<string, mixed> $richResults */
+        $richResults = is_array($result['richResultsResult'] ?? null) ? $result['richResultsResult'] : [];
 
         return array_filter([
             'url' => $url,
@@ -199,13 +201,18 @@ class SearchConsoleApiBundleCollector
             'indexing_state' => $indexStatus['indexingState'] ?? null,
             'page_fetch_state' => $indexStatus['pageFetchState'] ?? null,
             'last_crawl_time' => $indexStatus['lastCrawlTime'] ?? null,
+            'crawled_as' => $indexStatus['crawledAs'] ?? null,
             'google_canonical' => $indexStatus['googleCanonical'] ?? null,
             'user_canonical' => $indexStatus['userCanonical'] ?? null,
             'referring_urls' => is_array($indexStatus['referringUrls'] ?? null) ? array_values(array_filter($indexStatus['referringUrls'], 'is_string')) : null,
             'sitemaps' => is_array($indexStatus['sitemap'] ?? null)
                 ? array_values(array_filter($indexStatus['sitemap'], 'is_string'))
                 : (is_string($indexStatus['sitemap'] ?? null) ? [(string) $indexStatus['sitemap']] : null),
+            // Keep the historical key as a compatibility alias for the inspection deep link.
             'verdict' => $result['inspectionResultLink'] ?? null,
+            'inspection_verdict' => $result['verdict'] ?? null,
+            'inspection_link' => $result['inspectionResultLink'] ?? null,
+            'rich_results' => $this->normalizeRichResults($richResults),
         ], static fn (mixed $value): bool => $value !== null && $value !== []);
     }
 
@@ -239,6 +246,45 @@ class SearchConsoleApiBundleCollector
         }
 
         return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $richResults
+     * @return array<string, mixed>|null
+     */
+    private function normalizeRichResults(array $richResults): ?array
+    {
+        if ($richResults === []) {
+            return null;
+        }
+
+        $detectedItems = collect(is_array($richResults['detectedItems'] ?? null) ? $richResults['detectedItems'] : [])
+            ->filter(static fn (mixed $item): bool => is_array($item))
+            ->map(static function (array $item): array {
+                $issues = collect(is_array($item['issues'] ?? null) ? $item['issues'] : [])
+                    ->filter(static fn (mixed $issue): bool => is_array($issue))
+                    ->map(static fn (array $issue): array => array_filter([
+                        'issue_message' => $issue['issueMessage'] ?? null,
+                        'severity' => $issue['severity'] ?? null,
+                    ], static fn (mixed $value): bool => $value !== null && $value !== []))
+                    ->values()
+                    ->all();
+
+                return array_filter([
+                    'rich_result_type' => $item['richResultType'] ?? null,
+                    'items' => is_numeric($item['items'] ?? null) ? (int) $item['items'] : null,
+                    'issues' => $issues !== [] ? $issues : null,
+                ], static fn (mixed $value): bool => $value !== null && $value !== []);
+            })
+            ->values()
+            ->all();
+
+        $normalized = array_filter([
+            'verdict' => $richResults['verdict'] ?? null,
+            'detected_items' => $detectedItems !== [] ? $detectedItems : null,
+        ], static fn (mixed $value): bool => $value !== null && $value !== []);
+
+        return $normalized !== [] ? $normalized : null;
     }
 
     /**

--- a/app/Services/SearchConsoleApiBundleCollector.php
+++ b/app/Services/SearchConsoleApiBundleCollector.php
@@ -267,12 +267,31 @@ class SearchConsoleApiBundleCollector
                         'issue_message' => $issue['issueMessage'] ?? null,
                         'severity' => $issue['severity'] ?? null,
                     ], static fn (mixed $value): bool => $value !== null && $value !== []))
+                    ->filter(static fn (array $issue): bool => $issue !== [])
+                    ->values()
+                    ->all();
+
+                $items = collect(is_array($item['items'] ?? null) ? $item['items'] : [])
+                    ->filter(static fn (mixed $detectedItem): bool => is_array($detectedItem))
+                    ->map(static fn (array $detectedItem): array => array_filter([
+                        'name' => $detectedItem['name'] ?? null,
+                        'issues' => collect(is_array($detectedItem['issues'] ?? null) ? $detectedItem['issues'] : [])
+                            ->filter(static fn (mixed $issue): bool => is_array($issue))
+                            ->map(static fn (array $issue): array => array_filter([
+                                'issue_message' => $issue['issueMessage'] ?? null,
+                                'severity' => $issue['severity'] ?? null,
+                            ], static fn (mixed $value): bool => $value !== null && $value !== []))
+                            ->filter(static fn (array $issue): bool => $issue !== [])
+                            ->values()
+                            ->all() ?: null,
+                    ], static fn (mixed $value): bool => $value !== null && $value !== []))
+                    ->filter(static fn (array $detectedItem): bool => $detectedItem !== [])
                     ->values()
                     ->all();
 
                 return array_filter([
                     'rich_result_type' => $item['richResultType'] ?? null,
-                    'items' => is_numeric($item['items'] ?? null) ? (int) $item['items'] : null,
+                    'items' => $items !== [] ? $items : null,
                     'issues' => $issues !== [] ? $issues : null,
                 ], static fn (mixed $value): bool => $value !== null && $value !== []);
             })

--- a/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
+++ b/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
@@ -75,17 +75,35 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
             ], 200),
             'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect' => Http::response([
                 'inspectionResult' => [
+                    'verdict' => 'PASS',
                     'indexStatusResult' => [
                         'coverageState' => 'Page with redirect',
                         'robotsTxtState' => 'ALLOWED',
                         'indexingState' => 'INDEXING_ALLOWED',
                         'pageFetchState' => 'SUCCESSFUL',
                         'lastCrawlTime' => '2026-04-01T00:00:00Z',
+                        'crawledAs' => 'MOBILE',
                         'googleCanonical' => 'https://collector.example.au/new-page/',
                         'userCanonical' => 'https://collector.example.au/old-page/',
                         'referringUrls' => ['https://collector.example.au/sitemap_index.xml'],
                         'sitemap' => ['https://collector.example.au/sitemap_index.xml'],
                     ],
+                    'richResultsResult' => [
+                        'verdict' => 'PASS',
+                        'detectedItems' => [
+                            [
+                                'richResultType' => 'Breadcrumbs',
+                                'items' => 1,
+                                'issues' => [
+                                    [
+                                        'issueMessage' => 'Optional field missing',
+                                        'severity' => 'WARNING',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'inspectionResultLink' => 'https://search.google.com/search-console/inspect?resource_id=sc-domain:collector.example.au&id=abc123',
                 ],
             ], 200),
         ]);
@@ -96,7 +114,7 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
             '--captured-by' => 'test-suite',
         ]);
 
-        $this->assertSame(0, $exitCode);
+        $this->assertSame(0, $exitCode, Artisan::output());
 
         $apiSnapshot = SearchConsoleIssueSnapshot::query()
             ->where('web_property_id', $property->id)
@@ -109,6 +127,12 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
         $this->assertSame(3, data_get($apiSnapshot->normalized_payload, 'search_analytics.totals.clicks'));
         $this->assertSame('https://collector.example.au/sitemap_index.xml', data_get($apiSnapshot->normalized_payload, 'sitemaps.0.path'));
         $this->assertSame(1, data_get($apiSnapshot->normalized_payload, 'url_inspection.summary.coverage_states.Page with redirect'));
+        $this->assertSame('MOBILE', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.crawled_as'));
+        $this->assertSame('https://search.google.com/search-console/inspect?resource_id=sc-domain:collector.example.au&id=abc123', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.verdict'));
+        $this->assertSame('PASS', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.inspection_verdict'));
+        $this->assertSame('https://search.google.com/search-console/inspect?resource_id=sc-domain:collector.example.au&id=abc123', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.inspection_link'));
+        $this->assertSame('PASS', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.verdict'));
+        $this->assertSame('Breadcrumbs', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.rich_result_type'));
         Storage::disk('local')->assertExists($apiSnapshot->artifact_path);
 
         Http::assertSentCount(4);
@@ -118,7 +142,16 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
                 && $request['refresh_token'] === 'test-refresh-token';
         });
         Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/webmasters/v3/sites/')
+                && str_contains($request->url(), '/sitemaps');
+        });
+        Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/webmasters/v3/sites/')
+                && str_contains($request->url(), '/searchAnalytics/query');
+        });
+        Http::assertSent(function ($request): bool {
             return $request->url() === 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect'
+                && $request['inspectionUrl'] === 'https://collector.example.au/old-page/'
                 && $request['languageCode'] === 'en-US';
         });
     }

--- a/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
+++ b/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
@@ -93,7 +93,11 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
                         'detectedItems' => [
                             [
                                 'richResultType' => 'Breadcrumbs',
-                                'items' => 1,
+                                'items' => [
+                                    [
+                                        'name' => 'BreadcrumbList',
+                                    ],
+                                ],
                                 'issues' => [
                                     [
                                         'issueMessage' => 'Optional field missing',
@@ -133,6 +137,9 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
         $this->assertSame('https://search.google.com/search-console/inspect?resource_id=sc-domain:collector.example.au&id=abc123', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.inspection_link'));
         $this->assertSame('PASS', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.verdict'));
         $this->assertSame('Breadcrumbs', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.rich_result_type'));
+        $this->assertSame('BreadcrumbList', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.items.0.name'));
+        $this->assertSame('Optional field missing', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.issues.0.issue_message'));
+        $this->assertSame('WARNING', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.issues.0.severity'));
         Storage::disk('local')->assertExists($apiSnapshot->artifact_path);
 
         Http::assertSentCount(4);


### PR DESCRIPTION
## Summary
- enrich collected Search Console URL inspection payloads with rich results and additional index-status detail
- keep the historical inspection link field for compatibility while adding explicit inspection_verdict and inspection_link fields
- tighten collector coverage so the exact inspection link and single inspected URL request stay protected

## Testing
- ./vendor/bin/phpunit tests/Feature/CollectSearchConsoleApiBundleCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleApiBundleCollector.php app/Services/SearchConsoleIssueEvidenceService.php app/Models/SearchConsoleIssueSnapshot.php tests/Feature/CollectSearchConsoleApiBundleCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
