### PR TITLE
Expand Search Console API analytics coverage

### DIFF
--- a/app/Services/GoogleSearchConsoleClient.php
+++ b/app/Services/GoogleSearchConsoleClient.php
@@ -43,16 +43,23 @@ class GoogleSearchConsoleClient
     }
 
     /**
+     * @param  array<int, string>  $dimensions
      * @return array<string, mixed>
      */
-    public function querySearchAnalytics(string $siteUrl, string $startDate, string $endDate, int $rowLimit = 250): array
-    {
+    public function querySearchAnalytics(
+        string $siteUrl,
+        string $startDate,
+        string $endDate,
+        int $rowLimit = 250,
+        array $dimensions = ['page'],
+        string $type = 'web'
+    ): array {
         $response = $this->request()
             ->post($this->apiBaseUrl().'/webmasters/v3/sites/'.rawurlencode($siteUrl).'/searchAnalytics/query', [
                 'startDate' => $startDate,
                 'endDate' => $endDate,
-                'dimensions' => ['page'],
-                'type' => 'web',
+                'dimensions' => $dimensions,
+                'type' => $type,
                 'rowLimit' => $rowLimit,
             ]);
 

--- a/app/Services/SearchConsoleApiBundleCollector.php
+++ b/app/Services/SearchConsoleApiBundleCollector.php
@@ -4,7 +4,9 @@ namespace App\Services;
 
 use App\Models\WebProperty;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
+use Throwable;
 
 class SearchConsoleApiBundleCollector
 {
@@ -46,11 +48,7 @@ class SearchConsoleApiBundleCollector
         $startDate = $baseline?->date_range_start?->toDateString() ?: now()->subDays(max(1, $days))->toDateString();
 
         $sitemaps = $this->normalizeSitemaps($this->client->listSitemaps($siteUrl));
-        $searchAnalytics = $this->normalizeSearchAnalytics(
-            $this->client->querySearchAnalytics($siteUrl, $startDate, $endDate, $analyticsRowLimit),
-            $startDate,
-            $endDate
-        );
+        $searchAnalytics = $this->collectSearchAnalytics($siteUrl, $startDate, $endDate, $analyticsRowLimit);
 
         $issueEvidence = [];
 
@@ -138,37 +136,45 @@ class SearchConsoleApiBundleCollector
         return array_values(array_map(
             static fn (array $sitemap): array => array_filter([
                 'path' => $sitemap['path'] ?? null,
+                'last_submitted' => $sitemap['lastSubmitted'] ?? null,
                 'last_downloaded' => $sitemap['lastDownloaded'] ?? null,
                 'warnings' => is_numeric($sitemap['warnings'] ?? null) ? (int) $sitemap['warnings'] : null,
                 'errors' => is_numeric($sitemap['errors'] ?? null) ? (int) $sitemap['errors'] : null,
                 'is_pending' => is_bool($sitemap['isPending'] ?? null) ? $sitemap['isPending'] : null,
                 'is_sitemaps_index' => is_bool($sitemap['isSitemapsIndex'] ?? null) ? $sitemap['isSitemapsIndex'] : null,
                 'type' => $sitemap['type'] ?? null,
+                'contents' => collect(is_array($sitemap['contents'] ?? null) ? $sitemap['contents'] : [])
+                    ->filter(static fn (mixed $content): bool => is_array($content))
+                    ->map(static fn (array $content): array => array_filter([
+                        'type' => $content['type'] ?? null,
+                        'submitted' => is_numeric($content['submitted'] ?? null) ? (int) $content['submitted'] : null,
+                        'indexed' => is_numeric($content['indexed'] ?? null) ? (int) $content['indexed'] : null,
+                    ], static fn (mixed $value): bool => $value !== null && $value !== []))
+                    ->filter(static fn (array $content): bool => $content !== [])
+                    ->values()
+                    ->all() ?: null,
             ], static fn (mixed $value): bool => $value !== null && $value !== []),
             array_filter($sitemaps, 'is_array')
         ));
     }
 
     /**
-     * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */
-    private function normalizeSearchAnalytics(array $payload, string $startDate, string $endDate): array
+    private function collectSearchAnalytics(string $siteUrl, string $startDate, string $endDate, int $analyticsRowLimit): array
     {
-        $rows = array_values(array_map(
-            static fn (array $row): array => [
-                'page' => is_array($row['keys'] ?? null) ? ($row['keys'][0] ?? null) : null,
-                'clicks' => is_numeric($row['clicks'] ?? null) ? (float) $row['clicks'] : null,
-                'impressions' => is_numeric($row['impressions'] ?? null) ? (float) $row['impressions'] : null,
-                'ctr' => is_numeric($row['ctr'] ?? null) ? (float) $row['ctr'] : null,
-                'position' => is_numeric($row['position'] ?? null) ? (float) $row['position'] : null,
-            ],
-            array_filter(is_array($payload['rows'] ?? null) ? $payload['rows'] : [], 'is_array')
-        ));
+        $topPages = $this->normalizeSearchAnalyticsRows(
+            $this->client->querySearchAnalytics($siteUrl, $startDate, $endDate, $analyticsRowLimit, ['page'], 'web'),
+            'page'
+        );
+        $topQueries = $this->optionalSearchAnalyticsRows($siteUrl, $startDate, $endDate, $analyticsRowLimit, 'query', 'query');
+        $topCountries = $this->optionalSearchAnalyticsRows($siteUrl, $startDate, $endDate, $analyticsRowLimit, 'country', 'country');
+        $topDevices = $this->optionalSearchAnalyticsRows($siteUrl, $startDate, $endDate, $analyticsRowLimit, 'device', 'device');
+        $searchAppearance = $this->optionalSearchAnalyticsRows($siteUrl, $startDate, $endDate, $analyticsRowLimit, 'searchAppearance', 'search_appearance');
 
         $totals = [
-            'clicks' => array_sum(array_map(static fn (array $row): float => (float) ($row['clicks'] ?? 0), $rows)),
-            'impressions' => array_sum(array_map(static fn (array $row): float => (float) ($row['impressions'] ?? 0), $rows)),
+            'clicks' => array_sum(array_map(static fn (array $row): float => (float) ($row['clicks'] ?? 0), $topPages)),
+            'impressions' => array_sum(array_map(static fn (array $row): float => (float) ($row['impressions'] ?? 0), $topPages)),
         ];
 
         return [
@@ -176,9 +182,63 @@ class SearchConsoleApiBundleCollector
                 'start' => $startDate,
                 'end' => $endDate,
             ],
+            'type' => 'web',
             'totals' => $totals,
-            'top_pages' => array_values(array_filter($rows, static fn (array $row): bool => is_string($row['page'] ?? null))),
+            'top_pages' => array_values(array_filter($topPages, static fn (array $row): bool => is_string($row['page'] ?? null))),
+            'top_queries' => array_values(array_filter($topQueries, static fn (array $row): bool => is_string($row['query'] ?? null))),
+            'top_countries' => array_values(array_filter($topCountries, static fn (array $row): bool => is_string($row['country'] ?? null))),
+            'top_devices' => array_values(array_filter($topDevices, static fn (array $row): bool => is_string($row['device'] ?? null))),
+            'search_appearance' => array_values(array_filter($searchAppearance, static fn (array $row): bool => is_string($row['search_appearance'] ?? null))),
         ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function optionalSearchAnalyticsRows(
+        string $siteUrl,
+        string $startDate,
+        string $endDate,
+        int $analyticsRowLimit,
+        string $requestDimension,
+        string $normalizedDimension
+    ): array {
+        try {
+            return $this->normalizeSearchAnalyticsRows(
+                $this->client->querySearchAnalytics($siteUrl, $startDate, $endDate, $analyticsRowLimit, [$requestDimension], 'web'),
+                $normalizedDimension
+            );
+        } catch (Throwable $exception) {
+            Log::warning('Optional Search Console analytics slice failed.', [
+                'site_url' => $siteUrl,
+                'dimension' => $requestDimension,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSearchAnalyticsRows(array $payload, string $dimensionKey): array
+    {
+        return array_values(array_map(
+            static function (array $row) use ($dimensionKey): array {
+                $keys = is_array($row['keys'] ?? null) ? $row['keys'] : [];
+
+                return array_filter([
+                    $dimensionKey => $keys[0] ?? null,
+                    'clicks' => is_numeric($row['clicks'] ?? null) ? (float) $row['clicks'] : null,
+                    'impressions' => is_numeric($row['impressions'] ?? null) ? (float) $row['impressions'] : null,
+                    'ctr' => is_numeric($row['ctr'] ?? null) ? (float) $row['ctr'] : null,
+                    'position' => is_numeric($row['position'] ?? null) ? (float) $row['position'] : null,
+                ], static fn (mixed $value): bool => $value !== null && $value !== []);
+            },
+            array_filter(is_array($payload['rows'] ?? null) ? $payload['rows'] : [], 'is_array')
+        ));
     }
 
     /**

--- a/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
+++ b/tests/Feature/CollectSearchConsoleApiBundleCommandTest.php
@@ -57,22 +57,63 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
                 'sitemap' => [
                     [
                         'path' => 'https://collector.example.au/sitemap_index.xml',
+                        'lastSubmitted' => '2026-03-31T23:00:00Z',
                         'warnings' => '0',
                         'errors' => '0',
+                        'contents' => [
+                            [
+                                'type' => 'web',
+                                'submitted' => '24',
+                                'indexed' => '21',
+                            ],
+                        ],
                     ],
                 ],
             ], 200),
-            'https://www.googleapis.com/webmasters/v3/sites/*/searchAnalytics/query' => Http::response([
-                'rows' => [
-                    [
-                        'keys' => ['https://collector.example.au/old-page/'],
-                        'clicks' => 3,
-                        'impressions' => 40,
-                        'ctr' => 0.075,
-                        'position' => 12.4,
-                    ],
-                ],
-            ], 200),
+            'https://www.googleapis.com/webmasters/v3/sites/*/searchAnalytics/query' => function ($request) {
+                $dimension = data_get($request->data(), 'dimensions.0');
+
+                return Http::response([
+                    'rows' => match ($dimension) {
+                        'page' => [[
+                            'keys' => ['https://collector.example.au/old-page/'],
+                            'clicks' => 3,
+                            'impressions' => 40,
+                            'ctr' => 0.075,
+                            'position' => 12.4,
+                        ]],
+                        'query' => [[
+                            'keys' => ['old page redirect'],
+                            'clicks' => 2,
+                            'impressions' => 18,
+                            'ctr' => 0.111,
+                            'position' => 6.2,
+                        ]],
+                        'country' => [[
+                            'keys' => ['aus'],
+                            'clicks' => 3,
+                            'impressions' => 35,
+                            'ctr' => 0.085,
+                            'position' => 11.7,
+                        ]],
+                        'device' => [[
+                            'keys' => ['mobile'],
+                            'clicks' => 2,
+                            'impressions' => 22,
+                            'ctr' => 0.09,
+                            'position' => 10.1,
+                        ]],
+                        'searchAppearance' => [[
+                            'keys' => ['AMP_BLUE_LINK'],
+                            'clicks' => 1,
+                            'impressions' => 12,
+                            'ctr' => 0.083,
+                            'position' => 7.4,
+                        ]],
+                        default => [],
+                    },
+                ], 200);
+            },
             'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect' => Http::response([
                 'inspectionResult' => [
                     'verdict' => 'PASS',
@@ -128,8 +169,16 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
         $this->assertSame('page_with_redirect_in_sitemap', $apiSnapshot->issue_class);
         $this->assertSame('search_console_api_bundle', $apiSnapshot->source_report);
         $this->assertSame('sc-domain:collector.example.au', $apiSnapshot->source_property);
+        $this->assertSame('web', data_get($apiSnapshot->normalized_payload, 'search_analytics.type'));
         $this->assertSame(3, data_get($apiSnapshot->normalized_payload, 'search_analytics.totals.clicks'));
+        $this->assertSame('https://collector.example.au/old-page/', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_pages.0.page'));
         $this->assertSame('https://collector.example.au/sitemap_index.xml', data_get($apiSnapshot->normalized_payload, 'sitemaps.0.path'));
+        $this->assertSame('2026-03-31T23:00:00Z', data_get($apiSnapshot->normalized_payload, 'sitemaps.0.last_submitted'));
+        $this->assertSame(24, data_get($apiSnapshot->normalized_payload, 'sitemaps.0.contents.0.submitted'));
+        $this->assertSame('old page redirect', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_queries.0.query'));
+        $this->assertSame('aus', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_countries.0.country'));
+        $this->assertSame('mobile', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_devices.0.device'));
+        $this->assertSame('AMP_BLUE_LINK', data_get($apiSnapshot->normalized_payload, 'search_analytics.search_appearance.0.search_appearance'));
         $this->assertSame(1, data_get($apiSnapshot->normalized_payload, 'url_inspection.summary.coverage_states.Page with redirect'));
         $this->assertSame('MOBILE', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.crawled_as'));
         $this->assertSame('https://search.google.com/search-console/inspect?resource_id=sc-domain:collector.example.au&id=abc123', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.verdict'));
@@ -142,7 +191,6 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
         $this->assertSame('WARNING', data_get($apiSnapshot->normalized_payload, 'url_inspection.inspected_urls.0.rich_results.detected_items.0.issues.0.severity'));
         Storage::disk('local')->assertExists($apiSnapshot->artifact_path);
 
-        Http::assertSentCount(4);
         Http::assertSent(function ($request): bool {
             return $request->url() === 'https://oauth2.googleapis.com/token'
                 && $request['grant_type'] === 'refresh_token'
@@ -157,10 +205,130 @@ class CollectSearchConsoleApiBundleCommandTest extends TestCase
                 && str_contains($request->url(), '/searchAnalytics/query');
         });
         Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/searchAnalytics/query')
+                && $request['dimensions'] === ['page']
+                && $request['type'] === 'web';
+        });
+        Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/searchAnalytics/query')
+                && $request['dimensions'] === ['query']
+                && $request['type'] === 'web';
+        });
+        Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/searchAnalytics/query')
+                && $request['dimensions'] === ['country']
+                && $request['type'] === 'web';
+        });
+        Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/searchAnalytics/query')
+                && $request['dimensions'] === ['device']
+                && $request['type'] === 'web';
+        });
+        Http::assertSent(function ($request): bool {
+            return str_contains($request->url(), '/searchAnalytics/query')
+                && $request['dimensions'] === ['searchAppearance']
+                && $request['type'] === 'web';
+        });
+        Http::assertSent(function ($request): bool {
             return $request->url() === 'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect'
                 && $request['inspectionUrl'] === 'https://collector.example.au/old-page/'
                 && $request['languageCode'] === 'en-US';
         });
+
+        $analyticsRequests = collect(Http::recorded())
+            ->filter(static fn (array $entry): bool => str_contains($entry[0]->url(), '/searchAnalytics/query'));
+
+        $this->assertCount(5, $analyticsRequests);
+    }
+
+    public function test_it_keeps_collecting_when_an_optional_search_analytics_slice_fails(): void
+    {
+        Storage::fake('local');
+
+        config()->set('services.google.search_console.access_token', 'direct-access-token');
+        config()->set('services.google.search_console.refresh_token', null);
+        config()->set('services.google.search_console.inspection_request_delay_micros', 0);
+
+        $property = $this->makeProperty('collector-site-fallback', 'collector-fallback.example.au', '88');
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://collector-fallback.example.au/old-page/'],
+            'examples' => [
+                ['url' => 'https://collector-fallback.example.au/old-page/', 'last_crawled' => '2026-03-28'],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://collector-fallback.example.au/old-page/'],
+            ],
+        ]);
+
+        Http::fake([
+            'https://www.googleapis.com/webmasters/v3/sites/*/sitemaps' => Http::response([
+                'sitemap' => [
+                    ['path' => 'https://collector-fallback.example.au/sitemap_index.xml'],
+                ],
+            ], 200),
+            'https://www.googleapis.com/webmasters/v3/sites/*/searchAnalytics/query' => function ($request) {
+                $dimension = data_get($request->data(), 'dimensions.0');
+
+                if ($dimension === 'query') {
+                    return Http::response([
+                        'error' => [
+                            'message' => 'Quota exceeded',
+                            'status' => 'RESOURCE_EXHAUSTED',
+                        ],
+                    ], 429);
+                }
+
+                return Http::response([
+                    'rows' => [[
+                        'keys' => match ($dimension) {
+                            'page' => ['https://collector-fallback.example.au/old-page/'],
+                            'country' => ['aus'],
+                            'device' => ['mobile'],
+                            'searchAppearance' => ['AMP_BLUE_LINK'],
+                            default => ['fallback'],
+                        },
+                        'clicks' => 1,
+                        'impressions' => 10,
+                        'ctr' => 0.1,
+                        'position' => 9.5,
+                    ]],
+                ], 200);
+            },
+            'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect' => Http::response([
+                'inspectionResult' => [
+                    'verdict' => 'PASS',
+                    'indexStatusResult' => [
+                        'coverageState' => 'Page with redirect',
+                        'robotsTxtState' => 'ALLOWED',
+                        'indexingState' => 'INDEXING_ALLOWED',
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $exitCode = Artisan::call('analytics:collect-search-console-api-bundle', [
+            'property' => $property->slug,
+            '--capture-method' => 'gsc_api',
+            '--captured-by' => 'test-suite',
+        ]);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+
+        $apiSnapshot = SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $property->id)
+            ->where('capture_method', 'gsc_api')
+            ->firstOrFail();
+
+        $this->assertSame('https://collector-fallback.example.au/old-page/', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_pages.0.page'));
+        $this->assertNull(data_get($apiSnapshot->normalized_payload, 'search_analytics.top_queries.0.query'));
+        $this->assertSame('aus', data_get($apiSnapshot->normalized_payload, 'search_analytics.top_countries.0.country'));
+        $this->assertSame(1, data_get($apiSnapshot->normalized_payload, 'url_inspection.summary.coverage_states.Page with redirect'));
     }
 
     private function makeProperty(string $slug, string $domainName, string $matomoSiteId): WebProperty


### PR DESCRIPTION
## Summary
- expand Search Console API enrichment with broader web search analytics slices and fuller sitemap metadata
- keep page-based analytics and totals stable while making the new slices best-effort instead of hard-failing bundle collection
- harden collector coverage so legacy page analytics and the exact per-dimension request set stay pinned

## Testing
- ./vendor/bin/phpunit tests/Feature/CollectSearchConsoleApiBundleCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleApiBundleCollector.php app/Services/GoogleSearchConsoleClient.php app/Services/SearchConsoleIssueEvidenceService.php app/Models/SearchConsoleIssueSnapshot.php tests/Feature/CollectSearchConsoleApiBundleCommandTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
