### PR TITLE
Store authoritative controller repo metadata

### DIFF
--- a/app/Console/Commands/BootstrapWebProperties.php
+++ b/app/Console/Commands/BootstrapWebProperties.php
@@ -437,7 +437,10 @@ class BootstrapWebProperties extends Command
             return true;
         }
 
+        $fillableKeys = (new PropertyRepository)->getFillable();
+
         $changedAttributes = collect($repository)
+            ->only($fillableKeys)
             ->filter(fn ($value, $key) => $existingRepository->getAttribute($key) !== $value)
             ->all();
 

--- a/app/Console/Commands/BootstrapWebProperties.php
+++ b/app/Console/Commands/BootstrapWebProperties.php
@@ -412,7 +412,11 @@ class BootstrapWebProperties extends Command
      */
     private function syncRepositoryLink(WebProperty $property, array $repository, bool $dryRun): bool
     {
-        if (! $property->exists || ! is_string($repository['repo_name'] ?? null)) {
+        if (! is_string($repository['repo_name'] ?? null)) {
+            return false;
+        }
+
+        if (! $property->exists) {
             return true;
         }
 

--- a/app/Console/Commands/BootstrapWebProperties.php
+++ b/app/Console/Commands/BootstrapWebProperties.php
@@ -180,20 +180,7 @@ class BootstrapWebProperties extends Command
         $analyticsAttached = 0;
 
         $repository = $this->resolveRepository($domain, $override);
-        if (is_array($repository) && $this->shouldAttachRepository($property, $repository['repo_name'])) {
-            if ($dryRun) {
-                $this->line(sprintf(
-                    '  [dry-run] would attach repo %s to %s',
-                    $repository['repo_name'],
-                    $property->slug
-                ));
-            } else {
-                PropertyRepository::create([
-                    'web_property_id' => $property->id,
-                    ...$repository,
-                ]);
-            }
-
+        if (is_array($repository) && $this->syncRepositoryLink($property, $repository, $dryRun)) {
             $repoAttached++;
         }
 
@@ -295,6 +282,10 @@ class BootstrapWebProperties extends Command
                     'deployment_branch' => null,
                     'framework' => $this->detectFramework($repoName, is_array($packageJson) ? $packageJson : []),
                     'is_primary' => true,
+                    'is_controller' => false,
+                    'deployment_provider' => null,
+                    'deployment_project_name' => null,
+                    'deployment_project_id' => null,
                     'notes' => 'Auto-matched from local websites inventory.',
                 ];
             })
@@ -361,6 +352,10 @@ class BootstrapWebProperties extends Command
                 'deployment_branch' => $repoOverride['deployment_branch'] ?? null,
                 'framework' => $repoOverride['framework'] ?? null,
                 'is_primary' => (bool) ($repoOverride['is_primary'] ?? true),
+                'is_controller' => (bool) ($repoOverride['is_controller'] ?? false),
+                'deployment_provider' => $repoOverride['deployment_provider'] ?? null,
+                'deployment_project_name' => $repoOverride['deployment_project_name'] ?? null,
+                'deployment_project_id' => $repoOverride['deployment_project_id'] ?? null,
                 'notes' => $repoOverride['notes'] ?? 'Mapped from bootstrap override.',
             ];
         }
@@ -412,15 +407,58 @@ class BootstrapWebProperties extends Command
         return is_array($override) ? $override : [];
     }
 
-    private function shouldAttachRepository(WebProperty $property, string $repoName): bool
+    /**
+     * @param  array<string, mixed>  $repository
+     */
+    private function syncRepositoryLink(WebProperty $property, array $repository, bool $dryRun): bool
     {
-        if (! $property->exists) {
+        if (! $property->exists || ! is_string($repository['repo_name'] ?? null)) {
             return true;
         }
 
-        return ! $property->repositories()
-            ->where('repo_name', $repoName)
-            ->exists();
+        $existingRepository = $property->repositories()
+            ->where('repo_name', $repository['repo_name'])
+            ->first();
+
+        if (! $existingRepository instanceof PropertyRepository) {
+            if ($dryRun) {
+                $this->line(sprintf(
+                    '  [dry-run] would attach repo %s to %s',
+                    $repository['repo_name'],
+                    $property->slug
+                ));
+            } else {
+                PropertyRepository::create([
+                    'web_property_id' => $property->id,
+                    ...$repository,
+                ]);
+            }
+
+            return true;
+        }
+
+        $changedAttributes = collect($repository)
+            ->filter(fn ($value, $key) => $existingRepository->getAttribute($key) !== $value)
+            ->all();
+
+        if ($changedAttributes === []) {
+            return false;
+        }
+
+        if ($dryRun) {
+            $this->line(sprintf(
+                '  [dry-run] would refresh repo %s on %s',
+                $repository['repo_name'],
+                $property->slug
+            ));
+
+            return true;
+        }
+
+        $existingRepository->fill($changedAttributes);
+        $existingRepository->save();
+
+        return true;
     }
 
     private function shouldAttachAnalytics(WebProperty $property, string $provider, string $externalId): bool

--- a/app/Console/Commands/RefreshShouldFixQueue.php
+++ b/app/Console/Commands/RefreshShouldFixQueue.php
@@ -41,7 +41,7 @@ class RefreshShouldFixQueue extends Command
             ->with([
                 'platform',
                 'webProperties:id,slug,name,property_type,status',
-                'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+                'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
             ])
             ->withLatestCheckStatuses()

--- a/app/Models/PropertyRepository.php
+++ b/app/Models/PropertyRepository.php
@@ -16,7 +16,11 @@ use Illuminate\Support\Str;
  * @property string|null $default_branch
  * @property string|null $deployment_branch
  * @property string|null $framework
+ * @property string|null $deployment_provider
+ * @property string|null $deployment_project_name
+ * @property string|null $deployment_project_id
  * @property bool $is_primary
+ * @property bool $is_controller
  * @property string|null $notes
  */
 class PropertyRepository extends Model
@@ -34,7 +38,11 @@ class PropertyRepository extends Model
         'default_branch',
         'deployment_branch',
         'framework',
+        'deployment_provider',
+        'deployment_project_name',
+        'deployment_project_id',
         'is_primary',
+        'is_controller',
         'notes',
     ];
 
@@ -42,6 +50,7 @@ class PropertyRepository extends Model
     {
         return [
             'is_primary' => 'boolean',
+            'is_controller' => 'boolean',
         ];
     }
 

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -256,6 +256,10 @@ class WebProperty extends Model
             'deployment_branch' => $repository->deployment_branch,
             'framework' => $repository->framework,
             'is_primary' => $repository->is_primary,
+            'is_controller' => $repository->is_controller,
+            'deployment_provider' => $repository->deployment_provider,
+            'deployment_project_name' => $repository->deployment_project_name,
+            'deployment_project_id' => $repository->deployment_project_id,
             'notes' => $repository->notes,
         ])->values()->all();
     }
@@ -264,8 +268,17 @@ class WebProperty extends Model
     {
         $repositories = $this->relationLoaded('repositories') ? $this->repositories : $this->repositories()->get();
         $orderedRepositories = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_controller)
             ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
             ->values();
+
+        $explicitController = $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $repository->is_controller
+        );
+
+        if ($explicitController instanceof PropertyRepository) {
+            return $explicitController;
+        }
 
         return $orderedRepositories->first(
             fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
@@ -277,21 +290,26 @@ class WebProperty extends Model
      *   control_state:string,
      *   execution_surface:string|null,
      *   fleet_managed:bool,
-     *   controller_repo:string|null
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
      * }
      */
     public function executionReadinessSummary(): array
     {
         $eligibility = $this->coverageEligibility();
         $controllerRepository = $this->controllerRepository();
-        $controllerRepo = $controllerRepository?->repo_name;
+        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
 
         if (! $eligibility['eligible']) {
             return [
                 'control_state' => 'not_applicable',
                 'execution_surface' => null,
                 'fleet_managed' => false,
-                'controller_repo' => $controllerRepo,
+                ...$controllerRepositorySummary,
             ];
         }
 
@@ -300,7 +318,7 @@ class WebProperty extends Model
                 'control_state' => 'uncontrolled',
                 'execution_surface' => null,
                 'fleet_managed' => false,
-                'controller_repo' => $controllerRepo,
+                ...$controllerRepositorySummary,
             ];
         }
 
@@ -313,7 +331,7 @@ class WebProperty extends Model
                 'fleet_wordpress_controlled',
                 'astro_repo_controlled',
             ], true),
-            'controller_repo' => $controllerRepo,
+            ...$controllerRepositorySummary,
         ];
     }
 
@@ -473,6 +491,11 @@ class WebProperty extends Model
             'execution_surface' => $executionReadiness['execution_surface'],
             'fleet_managed' => $executionReadiness['fleet_managed'],
             'controller_repo' => $executionReadiness['controller_repo'],
+            'controller_repo_url' => $executionReadiness['controller_repo_url'],
+            'controller_local_path' => $executionReadiness['controller_local_path'],
+            'deployment_provider' => $executionReadiness['deployment_provider'],
+            'deployment_project_name' => $executionReadiness['deployment_project_name'],
+            'deployment_project_id' => $executionReadiness['deployment_project_id'],
             'gsc_evidence_summary' => $this->gscEvidenceSummary(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
@@ -1070,6 +1093,28 @@ class WebProperty extends Model
     private function repositoryHasControllerPath(PropertyRepository $repository): bool
     {
         return is_string($repository->local_path) && trim($repository->local_path) !== '';
+    }
+
+    /**
+     * @return array{
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
+     * }
+     */
+    private function controllerRepositorySummary(?PropertyRepository $repository): array
+    {
+        return [
+            'controller_repo' => $repository?->repo_name,
+            'controller_repo_url' => $repository?->repo_url,
+            'controller_local_path' => $repository?->local_path,
+            'deployment_provider' => $repository?->deployment_provider,
+            'deployment_project_name' => $repository?->deployment_project_name,
+            'deployment_project_id' => $repository?->deployment_project_id,
+        ];
     }
 
     private function executionSurfaceForRepository(PropertyRepository $repository): string

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -39,7 +39,7 @@ class DashboardIssueQueueService
             ->with([
                 'platform',
                 'webProperties:id,slug,name,property_type,status',
-                'webProperties.repositories:id,web_property_id,repo_name,local_path,is_primary',
+                'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
             ])
             ->withLatestCheckStatuses()
@@ -493,6 +493,11 @@ class DashboardIssueQueueService
         $item['execution_surface'] = $executionReadiness['execution_surface'];
         $item['fleet_managed'] = $executionReadiness['fleet_managed'];
         $item['controller_repo'] = $executionReadiness['controller_repo'];
+        $item['controller_repo_url'] = $executionReadiness['controller_repo_url'];
+        $item['controller_local_path'] = $executionReadiness['controller_local_path'];
+        $item['deployment_provider'] = $executionReadiness['deployment_provider'];
+        $item['deployment_project_name'] = $executionReadiness['deployment_project_name'];
+        $item['deployment_project_id'] = $executionReadiness['deployment_project_id'];
 
         return $item;
     }
@@ -529,9 +534,13 @@ class DashboardIssueQueueService
             return 'missing_repository';
         }
 
-        $hasControllerPath = $repositories->contains(
-            fn ($repository): bool => is_string($repository->local_path) && trim($repository->local_path) !== ''
-        );
+        $controllerRepository = $this->controllerRepositoryForProperty($property);
+
+        if (! $controllerRepository instanceof PropertyRepository) {
+            return 'missing_repository';
+        }
+
+        $hasControllerPath = $this->repositoryHasControllerPath($controllerRepository);
 
         return $hasControllerPath ? 'controlled' : 'missing_local_path';
     }
@@ -551,20 +560,25 @@ class DashboardIssueQueueService
      *   control_state:string,
      *   execution_surface:string|null,
      *   fleet_managed:bool,
-     *   controller_repo:string|null
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
      * }
      */
     private function executionReadinessForQueue(?WebProperty $property, string $coverageStatus, string $platformProfile): array
     {
         $controllerRepository = $this->controllerRepositoryForProperty($property);
-        $controllerRepo = $controllerRepository?->repo_name;
+        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
 
         if ($coverageStatus === 'not_required') {
             return [
                 'control_state' => 'not_applicable',
                 'execution_surface' => null,
                 'fleet_managed' => false,
-                'controller_repo' => $controllerRepo,
+                ...$controllerRepositorySummary,
             ];
         }
 
@@ -573,7 +587,7 @@ class DashboardIssueQueueService
                 'control_state' => 'uncontrolled',
                 'execution_surface' => null,
                 'fleet_managed' => false,
-                'controller_repo' => $controllerRepo,
+                ...$controllerRepositorySummary,
             ];
         }
 
@@ -586,7 +600,7 @@ class DashboardIssueQueueService
                 'fleet_wordpress_controlled',
                 'astro_repo_controlled',
             ], true),
-            'controller_repo' => $controllerRepo,
+            ...$controllerRepositorySummary,
         ];
     }
 
@@ -600,12 +614,43 @@ class DashboardIssueQueueService
             ? $property->getRelation('repositories')
             : $property->repositories()->get();
         $orderedRepositories = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_controller)
             ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
             ->values();
+
+        $explicitController = $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $repository->is_controller
+        );
+
+        if ($explicitController instanceof PropertyRepository) {
+            return $explicitController;
+        }
 
         return $orderedRepositories->first(
             fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
         ) ?? $orderedRepositories->first();
+    }
+
+    /**
+     * @return array{
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
+     * }
+     */
+    private function controllerRepositorySummary(?PropertyRepository $repository): array
+    {
+        return [
+            'controller_repo' => $repository?->repo_name,
+            'controller_repo_url' => $repository?->repo_url,
+            'controller_local_path' => $repository?->local_path,
+            'deployment_provider' => $repository?->deployment_provider,
+            'deployment_project_name' => $repository?->deployment_project_name,
+            'deployment_project_id' => $repository?->deployment_project_id,
+        ];
     }
 
     private function repositoryHasControllerPath(PropertyRepository $repository): bool

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -126,6 +126,7 @@ class DetectedIssueSummaryService
                 'execution_surface' => is_string($item['execution_surface'] ?? null) ? $item['execution_surface'] : null,
                 'fleet_managed' => (bool) ($item['fleet_managed'] ?? false),
                 'controller_repo' => is_string($item['controller_repo'] ?? null) ? $item['controller_repo'] : null,
+                'controller_repo_url' => is_string($item['controller_repo_url'] ?? null) ? $item['controller_repo_url'] : null,
                 'evidence' => [
                     'primary_reasons' => [$issueEntry['reason']],
                     'secondary_reasons' => array_values(array_filter(

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -458,9 +458,13 @@ return [
                 'name' => 'Moving Again Car Transport',
                 'property_type' => 'website',
                 'repository' => [
-                    'repo_name' => 'ma-car-transport-astro',
+                    'repo_name' => 'moveroo/ma-catrans-program',
+                    'repo_provider' => 'github',
+                    'repo_url' => 'https://github.com/moveroo/ma-catrans-program',
                     'local_path' => '/Users/jasonhill/Projects/websites/ma-car-transport-astro',
                     'framework' => 'Astro',
+                    'is_controller' => true,
+                    'deployment_provider' => 'vercel',
                 ],
                 'analytics_sources' => [
                     [

--- a/database/migrations/2026_04_02_000001_add_controller_authority_fields_to_property_repositories.php
+++ b/database/migrations/2026_04_02_000001_add_controller_authority_fields_to_property_repositories.php
@@ -1,0 +1,100 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('property_repositories', function (Blueprint $table) {
+            $table->boolean('is_controller')->default(false)->after('is_primary');
+            $table->string('deployment_provider')->nullable()->after('framework');
+            $table->string('deployment_project_name')->nullable()->after('deployment_provider');
+            $table->string('deployment_project_id')->nullable()->after('deployment_project_name');
+            $table->index(['web_property_id', 'is_controller']);
+        });
+
+        $property = DB::table('web_properties')
+            ->join('web_property_domains', 'web_property_domains.web_property_id', '=', 'web_properties.id')
+            ->join('domains', 'domains.id', '=', 'web_property_domains.domain_id')
+            ->select('web_properties.id')
+            ->where('domains.domain', 'cartransport.movingagain.com.au')
+            ->where('web_property_domains.usage_type', 'primary')
+            ->first();
+
+        if (! $property || ! is_string($property->id)) {
+            return;
+        }
+
+        DB::table('property_repositories')
+            ->where('web_property_id', $property->id)
+            ->update([
+                'is_controller' => false,
+                'updated_at' => now(),
+            ]);
+
+        $existingRepository = DB::table('property_repositories')
+            ->select('id')
+            ->where('web_property_id', $property->id)
+            ->where('repo_name', 'moveroo/ma-catrans-program')
+            ->first();
+
+        $attributes = [
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/ma-catrans-program',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/ma-catrans-program',
+            'local_path' => '/Users/jasonhill/Projects/websites/ma-car-transport-astro',
+            'default_branch' => 'main',
+            'deployment_branch' => 'main',
+            'framework' => 'Astro',
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => null,
+            'deployment_project_id' => null,
+            'is_controller' => true,
+            'notes' => 'Authoritative controller repo confirmed from live Vercel deployment status for cartransport.movingagain.com.au.',
+            'updated_at' => now(),
+        ];
+
+        if ($existingRepository && is_string($existingRepository->id)) {
+            DB::table('property_repositories')
+                ->where('id', $existingRepository->id)
+                ->update($attributes);
+
+            return;
+        }
+
+        DB::table('property_repositories')->insert([
+            'id' => (string) Str::uuid(),
+            ...$attributes,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasTable('property_repositories')) {
+            return;
+        }
+
+        Schema::table('property_repositories', function (Blueprint $table) {
+            $table->dropIndex(['web_property_id', 'is_controller']);
+            $table->dropColumn([
+                'is_controller',
+                'deployment_provider',
+                'deployment_project_name',
+                'deployment_project_id',
+            ]);
+        });
+    }
+};

--- a/docs/DOMAIN-MONITOR-API-INTEGRATION.md
+++ b/docs/DOMAIN-MONITOR-API-INTEGRATION.md
@@ -56,6 +56,18 @@ Purpose:
 - authoritative property identity
 - linked domains, repositories, analytics sources
 - current health summary
+- controller authority and deployment-readiness metadata for managed surfaces
+
+Selected property fields now include:
+- `control_state`
+- `execution_surface`
+- `fleet_managed`
+- `controller_repo`
+- `controller_repo_url`
+- `controller_local_path`
+- `deployment_provider`
+- `deployment_project_name`
+- `deployment_project_id`
 
 ### Normalized Issues
 
@@ -82,6 +94,11 @@ Core fields:
 - `detected_at`
 - `rollout_scope`
 - `control_id`
+- `control_state`
+- `execution_surface`
+- `fleet_managed`
+- `controller_repo`
+- `controller_repo_url`
 - `platform_profile`
 - `host_profile`
 - `control_profile`

--- a/tests/Feature/BootstrapWebPropertiesCommandTest.php
+++ b/tests/Feature/BootstrapWebPropertiesCommandTest.php
@@ -8,8 +8,8 @@ use App\Models\PropertyRepository;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 class BootstrapWebPropertiesCommandTest extends TestCase
@@ -68,9 +68,7 @@ class BootstrapWebPropertiesCommandTest extends TestCase
             'dns_config_name' => 'Parked',
         ]);
 
-        $command = $this->artisan('web-properties:bootstrap');
-        $this->assertInstanceOf(PendingCommand::class, $command);
-        $command->assertSuccessful();
+        $this->assertSame(0, Artisan::call('web-properties:bootstrap'));
 
         $this->assertDatabaseCount('web_properties', 2);
         $this->assertDatabaseCount('web_property_domains', 2);
@@ -154,9 +152,7 @@ class BootstrapWebPropertiesCommandTest extends TestCase
             'is_controller' => false,
         ]);
 
-        $command = $this->artisan('web-properties:bootstrap', ['--refresh-links' => true]);
-        $this->assertInstanceOf(PendingCommand::class, $command);
-        $command->assertSuccessful();
+        $this->assertSame(0, Artisan::call('web-properties:bootstrap', ['--refresh-links' => true]));
 
         $repository = PropertyRepository::query()
             ->where('web_property_id', $property->id)
@@ -167,5 +163,70 @@ class BootstrapWebPropertiesCommandTest extends TestCase
         $this->assertSame('/Users/jasonhill/Projects/websites/ma-car-transport-astro', $repository->local_path);
         $this->assertTrue($repository->is_controller);
         $this->assertSame('vercel', $repository->deployment_provider);
+    }
+
+    public function test_refresh_links_does_not_count_non_fillable_repository_keys_as_changes(): void
+    {
+        $websitesRoot = storage_path('framework/testing/websites');
+        File::deleteDirectory($websitesRoot);
+        File::ensureDirectoryExists($websitesRoot.'/example-astro');
+        $packageJson = json_encode([
+            'dependencies' => [
+                'astro' => '^5.0.0',
+            ],
+        ], JSON_PRETTY_PRINT);
+        $this->assertIsString($packageJson);
+        File::put($websitesRoot.'/example-astro/package.json', $packageJson);
+
+        config()->set('domain_monitor.web_property_bootstrap', [
+            'websites_root' => $websitesRoot,
+            'overrides' => [],
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'example-astro.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'example-astro-com-au',
+            'name' => 'Example Astro',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'example-astro',
+            'repo_provider' => 'local_only',
+            'local_path' => $websitesRoot.'/example-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => false,
+        ]);
+
+        $command = $this->app->make(\App\Console\Commands\BootstrapWebProperties::class);
+        $method = new \ReflectionMethod($command, 'syncRepositoryLink');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($command, $property, [
+            'repo_name' => 'example-astro',
+            'repo_provider' => 'local_only',
+            'local_path' => $websitesRoot.'/example-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => false,
+            'match_key' => 'example-astro',
+        ], false);
+
+        $this->assertFalse($result);
     }
 }

--- a/tests/Feature/BootstrapWebPropertiesCommandTest.php
+++ b/tests/Feature/BootstrapWebPropertiesCommandTest.php
@@ -9,6 +9,7 @@ use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
+use Illuminate\Testing\PendingCommand;
 use Tests\TestCase;
 
 class BootstrapWebPropertiesCommandTest extends TestCase
@@ -20,13 +21,15 @@ class BootstrapWebPropertiesCommandTest extends TestCase
         $websitesRoot = storage_path('framework/testing/websites');
         File::deleteDirectory($websitesRoot);
         File::ensureDirectoryExists($websitesRoot.'/moveroo-website-astro');
+        $packageJson = json_encode([
+            'dependencies' => [
+                'astro' => '^5.0.0',
+            ],
+        ], JSON_PRETTY_PRINT);
+        $this->assertIsString($packageJson);
         File::put(
             $websitesRoot.'/moveroo-website-astro/package.json',
-            json_encode([
-                'dependencies' => [
-                    'astro' => '^5.0.0',
-                ],
-            ], JSON_PRETTY_PRINT)
+            $packageJson
         );
 
         config()->set('domain_monitor.web_property_bootstrap', [
@@ -65,8 +68,9 @@ class BootstrapWebPropertiesCommandTest extends TestCase
             'dns_config_name' => 'Parked',
         ]);
 
-        $this->artisan('web-properties:bootstrap')
-            ->assertSuccessful();
+        $command = $this->artisan('web-properties:bootstrap');
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->assertSuccessful();
 
         $this->assertDatabaseCount('web_properties', 2);
         $this->assertDatabaseCount('web_property_domains', 2);
@@ -95,5 +99,73 @@ class BootstrapWebPropertiesCommandTest extends TestCase
 
         $moverooLink = WebPropertyDomain::query()->where('web_property_id', $moverooProperty->id)->firstOrFail();
         $this->assertSame($moveroo->id, $moverooLink->domain_id);
+    }
+
+    public function test_it_refreshes_existing_repository_metadata_from_bootstrap_overrides(): void
+    {
+        config()->set('domain_monitor.web_property_bootstrap', [
+            'websites_root' => storage_path('framework/testing/websites'),
+            'overrides' => [
+                'cartransport.movingagain.com.au' => [
+                    'slug' => 'ma-car-transport',
+                    'name' => 'Moving Again Car Transport',
+                    'property_type' => 'website',
+                    'repository' => [
+                        'repo_name' => 'moveroo/ma-catrans-program',
+                        'repo_provider' => 'github',
+                        'repo_url' => 'https://github.com/moveroo/ma-catrans-program',
+                        'local_path' => '/Users/jasonhill/Projects/websites/ma-car-transport-astro',
+                        'framework' => 'Astro',
+                        'is_controller' => true,
+                        'deployment_provider' => 'vercel',
+                    ],
+                ],
+            ],
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'cartransport.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'ma-car-transport',
+            'name' => 'Moving Again Car Transport',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/ma-catrans-program',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/iamjasonhill/cartransport-astro',
+            'local_path' => '/Users/jasonhill/Projects/websites/cartransport-new-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => false,
+        ]);
+
+        $command = $this->artisan('web-properties:bootstrap', ['--refresh-links' => true]);
+        $this->assertInstanceOf(PendingCommand::class, $command);
+        $command->assertSuccessful();
+
+        $repository = PropertyRepository::query()
+            ->where('web_property_id', $property->id)
+            ->where('repo_name', 'moveroo/ma-catrans-program')
+            ->firstOrFail();
+
+        $this->assertSame('https://github.com/moveroo/ma-catrans-program', $repository->repo_url);
+        $this->assertSame('/Users/jasonhill/Projects/websites/ma-car-transport-astro', $repository->local_path);
+        $this->assertTrue($repository->is_controller);
+        $this->assertSame('vercel', $repository->deployment_provider);
     }
 }

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -443,6 +443,7 @@ class DashboardPriorityQueueApiTest extends TestCase
             'is_active' => true,
             'platform' => 'Astro',
             'hosting_provider' => 'Vercel',
+            'expires_at' => null,
         ]);
 
         $blockedProperty = WebProperty::factory()->create([
@@ -503,6 +504,7 @@ class DashboardPriorityQueueApiTest extends TestCase
             'is_active' => true,
             'platform' => 'Astro',
             'hosting_provider' => 'Vercel',
+            'expires_at' => null,
         ]);
 
         $canonicalProperty = WebProperty::factory()->create([

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -241,11 +241,16 @@ class DetectedIssueApiTest extends TestCase
 
         PropertyRepository::create([
             'web_property_id' => $headersProperty->id,
-            'repo_name' => 'headers-issue-site',
-            'repo_provider' => 'local_only',
+            'repo_name' => 'moveroo/headers-issue-site',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/headers-issue-site',
             'local_path' => '/Users/jasonhill/Projects/websites/headers-issue-site',
             'framework' => 'Astro',
             'is_primary' => true,
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => 'headers-issue-site',
+            'deployment_project_id' => 'prj_headers123',
         ]);
 
         DomainCheck::factory()->create([
@@ -297,6 +302,7 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('fleet_wordpress_controlled', $redirectIssue['execution_surface']);
         $this->assertTrue($redirectIssue['fleet_managed']);
         $this->assertSame('_wp-house', $redirectIssue['controller_repo']);
+        $this->assertNull($redirectIssue['controller_repo_url']);
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
         $this->assertSame(
             ['https://redirect-issue.example.com/', 'http://redirect-issue.example.com/'],
@@ -333,7 +339,8 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('controlled', $headersIssue['control_state']);
         $this->assertSame('astro_repo_controlled', $headersIssue['execution_surface']);
         $this->assertTrue($headersIssue['fleet_managed']);
-        $this->assertSame('headers-issue-site', $headersIssue['controller_repo']);
+        $this->assertSame('moveroo/headers-issue-site', $headersIssue['controller_repo']);
+        $this->assertSame('https://github.com/moveroo/headers-issue-site', $headersIssue['controller_repo_url']);
 
         $detailResponse = $this->withHeaders([
             'Authorization' => 'Bearer test-api-key',
@@ -519,5 +526,78 @@ class DetectedIssueApiTest extends TestCase
         $this->assertNull($issue['execution_surface']);
         $this->assertFalse($issue['fleet_managed']);
         $this->assertSame('_wp-house', $issue['controller_repo']);
+        $this->assertNull($issue['controller_repo_url']);
+    }
+
+    public function test_issues_endpoint_prefers_explicit_controller_repo_and_requires_its_local_path(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'cartransport.movingagain.com.au',
+            'is_active' => true,
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'ma-car-transport',
+            'name' => 'Moving Again Car Transport',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'cartransport-new-astro',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/iamjasonhill/cartransport-astro',
+            'local_path' => '/Users/jasonhill/Projects/websites/cartransport-new-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_id' => 'prj_old123',
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/ma-catrans-program',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/ma-catrans-program',
+            'local_path' => null,
+            'framework' => 'Astro',
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => 'ma-catrans-program',
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $domain->id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
+            ->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('property_slug', 'ma-car-transport');
+
+        $this->assertNotNull($issue);
+        $this->assertSame('moveroo/ma-catrans-program', $issue['controller_repo']);
+        $this->assertSame('https://github.com/moveroo/ma-catrans-program', $issue['controller_repo_url']);
+        $this->assertSame('uncontrolled', $issue['control_state']);
+        $this->assertNull($issue['execution_surface']);
+        $this->assertFalse($issue['fleet_managed']);
     }
 }

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -62,11 +62,16 @@ class WebPropertyApiTest extends TestCase
 
         PropertyRepository::create([
             'web_property_id' => $property->id,
-            'repo_name' => 'moveroo-website-astro',
-            'repo_provider' => 'local_only',
+            'repo_name' => 'moveroo/moveroo-website-astro',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/moveroo-website-astro',
             'local_path' => '/Users/jasonhill/Projects/websites/moveroo-website-astro',
             'framework' => 'Astro',
             'is_primary' => true,
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => 'moveroo-website',
+            'deployment_project_id' => 'prj_moveroo123',
         ]);
 
         PropertyAnalyticsSource::create([
@@ -149,7 +154,7 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('contract_version', 1)
             ->assertJsonPath('web_properties.0.slug', 'moveroo-website')
             ->assertJsonPath('web_properties.0.primary_domain', 'moveroo.com.au')
-            ->assertJsonPath('web_properties.0.repositories.0.repo_name', 'moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.repositories.0.repo_name', 'moveroo/moveroo-website-astro')
             ->assertJsonPath('web_properties.0.analytics_sources.0.external_id', '6')
             ->assertJsonPath('web_properties.0.analytics_sources.0.install_audit.install_verdict', 'installed_match')
             ->assertJsonPath('web_properties.0.health_summary.checks.uptime', 'ok')
@@ -158,7 +163,12 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.control_state', 'controlled')
             ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
-            ->assertJsonPath('web_properties.0.controller_repo', 'moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.controller_repo', 'moveroo/moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.controller_repo_url', 'https://github.com/moveroo/moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.controller_local_path', '/Users/jasonhill/Projects/websites/moveroo-website-astro')
+            ->assertJsonPath('web_properties.0.deployment_provider', 'vercel')
+            ->assertJsonPath('web_properties.0.deployment_project_name', 'moveroo-website')
+            ->assertJsonPath('web_properties.0.deployment_project_id', 'prj_moveroo123')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)
@@ -222,6 +232,71 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.execution_surface', 'fleet_wordpress_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
             ->assertJsonPath('web_properties.0.controller_repo', '_wp-house');
+    }
+
+    public function test_web_properties_summary_prefers_explicit_controller_repo_for_astro_surface(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'cartransport.movingagain.com.au',
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'cartransport-movingagain-com-au',
+            'name' => 'Car Transport Moving Again',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'platform' => 'Astro',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'cartransport-new-astro',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/iamjasonhill/cartransport-astro',
+            'local_path' => '/Users/jasonhill/Projects/websites/cartransport-new-astro',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_id' => 'prj_gbL0tfky9oasyIcDr1GWj8eYOyeR',
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/ma-catrans-program',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/ma-catrans-program',
+            'local_path' => '/Users/jasonhill/Projects/websites/ma-car-transport-astro',
+            'framework' => 'Astro',
+            'is_primary' => false,
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'cartransport-movingagain-com-au')
+            ->assertJsonPath('web_properties.0.controller_repo', 'moveroo/ma-catrans-program')
+            ->assertJsonPath('web_properties.0.controller_repo_url', 'https://github.com/moveroo/ma-catrans-program')
+            ->assertJsonPath('web_properties.0.controller_local_path', '/Users/jasonhill/Projects/websites/ma-car-transport-astro')
+            ->assertJsonPath('web_properties.0.deployment_provider', 'vercel')
+            ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
+            ->assertJsonPath('web_properties.0.fleet_managed', true);
     }
 
     public function test_web_properties_summary_surfaces_property_level_gsc_issue_detail_coverage(): void


### PR DESCRIPTION
## Summary
- store explicit authoritative controller metadata for managed Astro/static properties
- expose controller repo identity in property summaries and issue feed, while keeping local path and deployment metadata on the property summary
- make bootstrap refresh existing repo mappings, align the movingagain car transport override, and harden queue/controller selection around the explicit controller repo

## Testing
- ./vendor/bin/phpunit tests/Feature/BootstrapWebPropertiesCommandTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/RefreshShouldFixQueueCommandTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/BootstrapWebProperties.php app/Console/Commands/RefreshShouldFixQueue.php app/Models/PropertyRepository.php app/Models/WebProperty.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/BootstrapWebPropertiesCommandTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/RefreshShouldFixQueueCommandTest.php database/migrations/2026_04_02_000001_add_controller_authority_fields_to_property_repositories.php config/domain_monitor.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/51" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
