### PR TITLE
Add Fleet focus property view and priority controls

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -23,12 +23,15 @@ class WebPropertyController extends Controller
         $validated = $request->validate([
             'status' => 'nullable|in:active,planned,paused,archived',
             'property_type' => 'nullable|string|max:50',
+            'fleet_focus' => 'nullable|boolean',
             'per_page' => 'nullable|integer|min:1',
         ]);
 
         $perPage = min((int) ($validated['per_page'] ?? self::DEFAULT_PER_PAGE), self::MAX_PER_PAGE);
 
         $query = $this->baseQuery()->orderBy('name');
+
+        $this->applyFleetFocusFilter($query, $validated);
 
         if (isset($validated['status'])) {
             $query->where('status', $validated['status']);
@@ -56,9 +59,16 @@ class WebPropertyController extends Controller
         return new WebPropertyResource($property);
     }
 
-    public function summary(): JsonResponse
+    public function summary(Request $request): JsonResponse
     {
-        $properties = $this->baseQuery()->orderBy('name')->get();
+        $validated = $request->validate([
+            'fleet_focus' => 'nullable|boolean',
+        ]);
+
+        $query = $this->baseQuery()->orderBy('name');
+        $this->applyFleetFocusFilter($query, $validated);
+
+        $properties = $query->get();
 
         return response()->json([
             'source_system' => 'domain-monitor',
@@ -137,5 +147,30 @@ class WebPropertyController extends Controller
         return $this->baseQuery()
             ->where('slug', $slug)
             ->first();
+    }
+
+    /**
+     * @param  Builder<WebProperty>  $query
+     * @param  array<string, mixed>  $validated
+     */
+    private function applyFleetFocusFilter(Builder $query, array $validated): void
+    {
+        if (! array_key_exists('fleet_focus', $validated)) {
+            return;
+        }
+
+        $tagName = (string) config('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        if ($tagName === '') {
+            return;
+        }
+
+        if ((bool) $validated['fleet_focus']) {
+            $query->fleetFocus();
+
+            return;
+        }
+
+        $query->fleetFocus(false);
     }
 }

--- a/app/Livewire/WebPropertiesList.php
+++ b/app/Livewire/WebPropertiesList.php
@@ -6,6 +6,7 @@ use App\Models\WebProperty;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Validator;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -14,6 +15,7 @@ class WebPropertiesList extends Component
 {
     use WithPagination;
 
+    #[Locked]
     public bool $fleetFocusMode = false;
 
     #[Url(as: 'search', history: true, keep: false)]

--- a/app/Livewire/WebPropertiesList.php
+++ b/app/Livewire/WebPropertiesList.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\WebProperty;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Url;
 use Livewire\Component;
@@ -12,6 +13,8 @@ use Livewire\WithPagination;
 class WebPropertiesList extends Component
 {
     use WithPagination;
+
+    public bool $fleetFocusMode = false;
 
     #[Url(as: 'search', history: true, keep: false)]
     public string $search = '';
@@ -107,19 +110,61 @@ class WebPropertiesList extends Component
     {
         $query = $this->baseQuery();
 
+        if ($this->fleetFocusMode) {
+            $this->applyFleetFocusFilter($query);
+        }
+
         return [
             'total' => (clone $query)->count(),
             'multi_domain' => (clone $query)->has('propertyDomains', '>', 1)->count(),
             'missing_repositories' => (clone $query)->doesntHave('repositories')->count(),
             'missing_analytics' => (clone $query)->doesntHave('analyticsSources')->count(),
+            'prioritized' => (clone $query)->whereNotNull('priority')->count(),
         ];
+    }
+
+    public function updatePropertyPriority(string $propertyId, mixed $newPriority): void
+    {
+        abort_unless(auth()->check() && $this->fleetFocusMode, 403);
+
+        $priority = $newPriority;
+
+        if (is_string($priority)) {
+            $priority = trim($priority);
+            $priority = $priority === '' ? null : $priority;
+        }
+
+        Validator::make(
+            ['priority' => $priority],
+            ['priority' => 'nullable|integer|min:0|max:255']
+        )->validate();
+
+        $property = WebProperty::query()
+            ->fleetFocus()
+            ->whereKey($propertyId)
+            ->first();
+
+        abort_unless($property instanceof WebProperty, 403);
+
+        $property->update(['priority' => is_null($priority) ? null : (int) $priority]);
+
+        $this->resetPage();
     }
 
     public function render(): \Illuminate\View\View
     {
-        $properties = $this->filteredQuery()
-            ->orderBy('name')
-            ->paginate(20);
+        $query = $this->filteredQuery();
+
+        if ($this->fleetFocusMode) {
+            $query
+                ->orderByRaw('CASE WHEN priority IS NULL THEN 1 ELSE 0 END')
+                ->orderByDesc('priority')
+                ->orderBy('name');
+        } else {
+            $query->orderBy('name');
+        }
+
+        $properties = $query->paginate(20);
 
         return view('livewire.web-properties-list', [
             'properties' => $properties,
@@ -132,6 +177,10 @@ class WebPropertiesList extends Component
     private function filteredQuery(): Builder
     {
         $query = $this->baseQuery();
+
+        if ($this->fleetFocusMode) {
+            $this->applyFleetFocusFilter($query);
+        }
 
         if ($this->filterStatus) {
             $query->where('status', $this->filterStatus);
@@ -195,6 +244,20 @@ class WebPropertiesList extends Component
         }
 
         return $query;
+    }
+
+    /**
+     * @param  Builder<WebProperty>  $query
+     */
+    private function applyFleetFocusFilter(Builder $query): void
+    {
+        $tagName = (string) config('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        if ($tagName === '') {
+            return;
+        }
+
+        $query->fleetFocus();
     }
 
     /**

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -373,6 +374,70 @@ class WebProperty extends Model
             ->all();
     }
 
+    public function isFleetFocus(): bool
+    {
+        $tagName = (string) config('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        if ($tagName === '') {
+            return false;
+        }
+
+        $primaryDomain = $this->primaryDomainModel();
+
+        foreach ($this->orderedDomainLinks() as $link) {
+            $domain = $link->domain;
+
+            if (! $domain instanceof Domain) {
+                continue;
+            }
+
+            $isPrimaryOrCanonical = $link->is_canonical || ($primaryDomain instanceof Domain && $domain->is($primaryDomain));
+
+            if (! $isPrimaryOrCanonical) {
+                continue;
+            }
+
+            $tags = $domain->relationLoaded('tags')
+                ? $domain->tags
+                : $domain->tags()->get();
+
+            if ($tags->contains(fn (DomainTag $tag): bool => $tag->name === $tagName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  Builder<WebProperty>  $query
+     */
+    public function scopeFleetFocus(Builder $query, bool $value = true): void
+    {
+        $tagName = (string) config('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        if ($tagName === '') {
+            return;
+        }
+
+        $callback = function (Builder $builder) use ($tagName): void {
+            $builder
+                ->whereHas('primaryDomain.tags', fn (Builder $tagQuery) => $tagQuery->where('name', $tagName))
+                ->orWhereHas('propertyDomains', function (Builder $linkQuery) use ($tagName): void {
+                    $linkQuery
+                        ->where('is_canonical', true)
+                        ->whereHas('domain.tags', fn (Builder $tagQuery) => $tagQuery->where('name', $tagName));
+                });
+        };
+
+        if ($value) {
+            $query->where($callback);
+
+            return;
+        }
+
+        $query->whereNot($callback);
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -480,6 +545,8 @@ class WebProperty extends Model
             'target_platform' => $this->target_platform,
             'owner' => $this->owner,
             'priority' => $this->priority,
+            'fleet_priority' => $this->priority,
+            'is_fleet_focus' => $this->isFleetFocus(),
             'notes' => $this->notes,
             'domains' => $this->domainSummaries(),
             'repositories' => $this->repositorySummaries(),

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -381,31 +381,18 @@ class WebProperty extends Model
             return false;
         }
 
-        $primaryDomain = $this->primaryDomainModel();
+        $primaryDomain = $this->relationLoaded('primaryDomain')
+            ? $this->primaryDomain
+            : $this->primaryDomain()->with('tags')->first();
 
-        foreach ($this->orderedDomainLinks() as $link) {
-            $domain = $link->domain;
-
-            if (! $domain instanceof Domain) {
-                continue;
-            }
-
-            $isPrimaryOrCanonical = $link->is_canonical || ($primaryDomain instanceof Domain && $domain->is($primaryDomain));
-
-            if (! $isPrimaryOrCanonical) {
-                continue;
-            }
-
-            $tags = $domain->relationLoaded('tags')
-                ? $domain->tags
-                : $domain->tags()->get();
-
-            if ($tags->contains(fn (DomainTag $tag): bool => $tag->name === $tagName)) {
-                return true;
-            }
+        if ($this->domainHasFleetFocusTag($primaryDomain, $tagName)) {
+            return true;
         }
 
-        return false;
+        return $this->orderedDomainLinks()->contains(function (WebPropertyDomain $link) use ($tagName): bool {
+            return $link->is_canonical
+                && $this->domainHasFleetFocusTag($link->domain, $tagName);
+        });
     }
 
     /**
@@ -436,6 +423,19 @@ class WebProperty extends Model
         }
 
         $query->whereNot($callback);
+    }
+
+    private function domainHasFleetFocusTag(?Domain $domain, string $tagName): bool
+    {
+        if (! $domain instanceof Domain) {
+            return false;
+        }
+
+        $tags = $domain->relationLoaded('tags')
+            ? $domain->tags
+            : $domain->tags()->get();
+
+        return $tags->contains(fn (DomainTag $tag): bool => $tag->name === $tagName);
     }
 
     /**
@@ -545,6 +545,7 @@ class WebProperty extends Model
             'target_platform' => $this->target_platform,
             'owner' => $this->owner,
             'priority' => $this->priority,
+            // Fleet consumers use a stable, explicitly named alias for manual work ordering.
             'fleet_priority' => $this->priority,
             'is_fleet_focus' => $this->isFleetFocus(),
             'notes' => $this->notes,

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -3,6 +3,47 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Fleet Focus
+    |--------------------------------------------------------------------------
+    |
+    | Manual grouping for the current Fleet working set. Membership lives on
+    | the primary/canonical domain tag so it can be managed with the existing
+    | domain tag system, while property priority remains per web property.
+    |
+    */
+    'fleet_focus' => [
+        'tag_name' => env('DOMAIN_MONITOR_FLEET_FOCUS_TAG', 'fleet.live'),
+        'domains' => [
+            'allianceremovals.com.au',
+            'backloading-au.com.au',
+            'backloading-services.com.au',
+            'backloadingremovals.com.au',
+            'beauy.com.au',
+            'cartransport.au',
+            'cartransportaus.com.au',
+            'cartransportwithpersonalitems.com.au',
+            'discountbackloading.com.au',
+            'interstate-car-transport.com.au',
+            'interstate-removals.com.au',
+            'interstatecarcarriers.com.au',
+            'movemycar.com.au',
+            'mover.com.au',
+            'moveroo.com.au',
+            'movingagain.com.au',
+            'movingcars.com.au',
+            'movinginsurance.com.au',
+            'perthinterstateremovalists.com.au',
+            'removalist.net',
+            'removalsinterstate.com.au',
+            'supercheapcartransport.com.au',
+            'transportnondrivablecars.com.au',
+            'vehicle.net.au',
+            'wemove.com.au',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Domain Monitor UI Windows
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2026_04_02_000002_seed_fleet_focus_domain_tag.php
+++ b/database/migrations/2026_04_02_000002_seed_fleet_focus_domain_tag.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    private string $tagName = 'fleet.live';
+
+    private string $tagDescription = 'Fleet-managed live domains used for the dedicated Fleet working set view.';
+
+    public function up(): void
+    {
+        $now = now();
+
+        $tag = DB::table('domain_tags')
+            ->where('name', $this->tagName)
+            ->first();
+
+        if ($tag) {
+            DB::table('domain_tags')
+                ->where('id', $tag->id)
+                ->update([
+                    'priority' => 95,
+                    'color' => '#2563EB',
+                    'description' => $this->tagDescription,
+                    'deleted_at' => null,
+                    'updated_at' => $now,
+                ]);
+        } else {
+            DB::table('domain_tags')->insert([
+                'id' => (string) Str::uuid(),
+                'name' => $this->tagName,
+                'priority' => 95,
+                'color' => '#2563EB',
+                'description' => $this->tagDescription,
+                'created_at' => $now,
+                'updated_at' => $now,
+                'deleted_at' => null,
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $tag = DB::table('domain_tags')
+            ->where('name', $this->tagName)
+            ->first();
+
+        if (! $tag) {
+            return;
+        }
+
+        $hasMemberships = DB::table('domain_tag')
+            ->where('tag_id', $tag->id)
+            ->exists();
+
+        if ($hasMemberships) {
+            return;
+        }
+
+        DB::table('domain_tags')
+            ->where('id', $tag->id)
+            ->where('description', $this->tagDescription)
+            ->delete();
+    }
+};

--- a/resources/views/livewire/web-properties-list.blade.php
+++ b/resources/views/livewire/web-properties-list.blade.php
@@ -2,14 +2,14 @@
     <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
         <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
             <div class="p-5">
-                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Total Properties</dt>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $fleetFocusMode ? 'Fleet Properties' : 'Total Properties' }}</dt>
                 <dd class="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{{ $this->stats['total'] }}</dd>
             </div>
         </div>
         <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
             <div class="p-5">
-                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Multi-Domain</dt>
-                <dd class="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{{ $this->stats['multi_domain'] }}</dd>
+                <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ $fleetFocusMode ? 'Priority Set' : 'Multi-Domain' }}</dt>
+                <dd class="mt-2 text-3xl font-semibold text-gray-900 dark:text-gray-100">{{ $fleetFocusMode ? $this->stats['prioritized'] : $this->stats['multi_domain'] }}</dd>
             </div>
         </div>
         <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
@@ -35,7 +35,7 @@
                         wire:model.live.debounce.300ms="search"
                         type="text"
                         class="mt-1 block w-full"
-                        placeholder="Search property name, slug, domain, or repo..."
+                        placeholder="{{ $fleetFocusMode ? 'Search fleet property, domain, or repo...' : 'Search property name, slug, domain, or repo...' }}"
                     />
                 </div>
 
@@ -64,11 +64,13 @@
             </div>
 
             <div class="mt-4 flex flex-wrap gap-4">
-                <label class="flex items-center">
-                    <input type="checkbox" wire:model.live="reviewQueue"
-                        class="rounded border-gray-300 dark:border-gray-700 text-blue-600 shadow-xs focus:ring-blue-500">
-                    <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">Review Queue</span>
-                </label>
+                @unless($fleetFocusMode)
+                    <label class="flex items-center">
+                        <input type="checkbox" wire:model.live="reviewQueue"
+                            class="rounded border-gray-300 dark:border-gray-700 text-blue-600 shadow-xs focus:ring-blue-500">
+                        <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">Review Queue</span>
+                    </label>
+                @endunless
                 <label class="flex items-center">
                     <input type="checkbox" wire:model.live="multiDomainOnly"
                         class="rounded border-gray-300 dark:border-gray-700 text-blue-600 shadow-xs focus:ring-blue-500">
@@ -85,6 +87,13 @@
                     <span class="ms-2 text-sm text-gray-600 dark:text-gray-400">Missing Analytics Link</span>
                 </label>
             </div>
+
+            @if($fleetFocusMode)
+                <div class="mt-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200">
+                    Fleet membership comes from the primary domain tag <span class="font-semibold">{{ config('domain_monitor.fleet_focus.tag_name') }}</span>.
+                    Use the Fleet Priority column below to set your manual work order for these properties.
+                </div>
+            @endif
 
             <div class="mt-4">
                 <button wire:click="clearFilters"
@@ -120,6 +129,9 @@
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                     <thead class="bg-gray-50 dark:bg-gray-700/50">
                         <tr>
+                            @if($fleetFocusMode)
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Fleet Priority</th>
+                            @endif
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Property</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Primary Domain</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Coverage</th>
@@ -134,6 +146,18 @@
                                 $isReviewCandidate = $property->property_domains_count > 1 || $property->repositories_count === 0 || $property->analytics_sources_count === 0;
                             @endphp
                             <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/25">
+                                @if($fleetFocusMode)
+                                    <td class="px-6 py-4 align-top">
+                                        <input
+                                            type="number"
+                                            wire:change="updatePropertyPriority('{{ $property->id }}', $event.target.value)"
+                                            value="{{ $property->priority ?? '' }}"
+                                            class="w-24 rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                                            min="0"
+                                            placeholder="—"
+                                        />
+                                    </td>
+                                @endif
                                 <td class="px-6 py-4 align-top">
                                     <div class="flex items-start gap-3">
                                         <div class="mt-1">

--- a/resources/views/web-properties/fleet.blade.php
+++ b/resources/views/web-properties/fleet.blade.php
@@ -1,0 +1,26 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center gap-4">
+            <div>
+                <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                    {{ __('Fleet Properties') }}
+                </h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    Review the tagged Fleet working set, keep authoritative controller mappings visible, and manage your own manual property priority order.
+                </p>
+            </div>
+            <a
+                href="{{ route('web-properties.index') }}"
+                class="inline-flex items-center px-4 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md font-semibold text-xs text-gray-700 dark:text-gray-300 uppercase tracking-widest hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+                All Web Properties
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <livewire:web-properties-list :fleet-focus-mode="true" />
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/web-properties/index.blade.php
+++ b/resources/views/web-properties/index.blade.php
@@ -9,6 +9,12 @@
                     Review grouped sites, alias domains, repositories, and analytics bindings before we refine the registry further.
                 </p>
             </div>
+            <a
+                href="{{ route('web-properties.fleet') }}"
+                class="inline-flex items-center px-4 py-2 bg-blue-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-blue-700"
+            >
+                Fleet View
+            </a>
         </div>
     </x-slot>
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Domain;
+use App\Models\DomainTag;
 use App\Models\WebProperty;
 use App\Services\ManualSearchConsoleEvidenceImporter;
 use App\Services\SearchConsoleApiBundleCollector;
@@ -14,6 +16,88 @@ use Illuminate\Support\Facades\Schedule;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Artisan::command('fleet:sync-focus-domains {--dry-run : Only report the changes that would be made}', function () {
+    $tagName = (string) config('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+    /** @var array<int, string> $domainNames */
+    $domainNames = array_values(array_filter(
+        (array) config('domain_monitor.fleet_focus.domains', []),
+        fn (mixed $domain): bool => is_string($domain) && trim($domain) !== ''
+    ));
+    $dryRun = (bool) $this->option('dry-run');
+
+    if ($tagName === '' || $domainNames === []) {
+        $this->warn('Fleet focus tag configuration is empty.');
+
+        return Command::INVALID;
+    }
+
+    $tag = DomainTag::withTrashed()->firstOrCreate(
+        ['name' => $tagName],
+        [
+            'priority' => 95,
+            'color' => '#2563EB',
+            'description' => 'Fleet-managed live domains used for the dedicated Fleet working set view.',
+        ]
+    );
+
+    if ($tag->trashed()) {
+        $tag->restore();
+    }
+
+    $domains = Domain::query()
+        ->whereIn('domain', $domainNames)
+        ->get()
+        ->keyBy('domain');
+
+    $missingDomains = collect($domainNames)
+        ->reject(fn (string $domain) => $domains->has($domain))
+        ->values();
+
+    $attachIds = $domains
+        ->reject(fn (Domain $domain) => $domain->tags()->where('domain_tags.id', $tag->id)->exists())
+        ->pluck('id')
+        ->values();
+
+    if ($dryRun) {
+        $this->info(sprintf(
+            'Would attach [%d] domains to [%s]. Missing [%d] configured domains.',
+            $attachIds->count(),
+            $tagName,
+            $missingDomains->count()
+        ));
+
+        if ($attachIds->isNotEmpty()) {
+            $this->line('Attach: '.implode(', ', $domains->whereIn('id', $attachIds)->keys()->all()));
+        }
+
+        if ($missingDomains->isNotEmpty()) {
+            $this->warn('Missing: '.implode(', ', $missingDomains->all()));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    foreach ($attachIds as $domainId) {
+        $domain = $domains->firstWhere('id', $domainId);
+
+        if ($domain instanceof Domain) {
+            $domain->tags()->syncWithoutDetaching([$tag->id]);
+        }
+    }
+
+    $this->info(sprintf(
+        'Fleet focus sync complete. Attached [%d] domains to [%s].',
+        $attachIds->count(),
+        $tagName
+    ));
+
+    if ($missingDomains->isNotEmpty()) {
+        $this->warn('Configured domains not found: '.implode(', ', $missingDomains->all()));
+    }
+
+    return Command::SUCCESS;
+})->purpose('Attach the configured Fleet focus tag to the current Fleet domain list.');
 
 Artisan::command('analytics:import-search-console-evidence {property : Web property slug} {path : Path to the Google Search Console page indexing export ZIP} {--captured-by= : Optional captured_by value}', function (ManualSearchConsoleEvidenceImporter $importer) {
     $propertyArgument = $this->argument('property');

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         return view('web-properties.index');
     })->name('web-properties.index');
 
+    Route::get('/fleet-properties', function () {
+        return view('web-properties.fleet');
+    })->name('web-properties.fleet');
+
     Route::get('/matomo-coverage', function () {
         return view('matomo-coverage.index');
     })->name('matomo-coverage.index');

--- a/tests/Feature/FleetPropertiesListTest.php
+++ b/tests/Feature/FleetPropertiesListTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\WebPropertiesList;
+use App\Models\Domain;
+use App\Models\DomainTag;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FleetPropertiesListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_fleet_view_only_shows_tagged_properties(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $fleetDomain = Domain::factory()->create([
+            'domain' => 'fleet.example.com',
+            'is_active' => true,
+        ]);
+
+        $otherDomain = Domain::factory()->create([
+            'domain' => 'other.example.com',
+            'is_active' => true,
+        ]);
+
+        $fleetProperty = WebProperty::factory()->create([
+            'slug' => 'fleet-site',
+            'name' => 'Fleet Site',
+            'primary_domain_id' => $fleetDomain->id,
+        ]);
+
+        $otherProperty = WebProperty::factory()->create([
+            'slug' => 'other-site',
+            'name' => 'Other Site',
+            'primary_domain_id' => $otherDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $fleetProperty->id,
+            'domain_id' => $fleetDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $otherProperty->id,
+            'domain_id' => $otherDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $fleetDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->assertSee('Fleet Site')
+            ->assertDontSee('Other Site');
+    }
+
+    public function test_fleet_view_can_update_manual_property_priority(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        $this->actingAs(User::factory()->create());
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $fleetDomain = Domain::factory()->create([
+            'domain' => 'priority.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'priority-site',
+            'name' => 'Priority Site',
+            'primary_domain_id' => $fleetDomain->id,
+            'priority' => null,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $fleetDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $fleetDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->call('updatePropertyPriority', $property->id, '77');
+
+        $this->assertSame(77, $property->fresh()->priority);
+    }
+
+    public function test_fleet_view_rejects_invalid_manual_priority_values(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        $this->actingAs(User::factory()->create());
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $fleetDomain = Domain::factory()->create([
+            'domain' => 'negative-priority.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'negative-priority-site',
+            'name' => 'Negative Priority Site',
+            'primary_domain_id' => $fleetDomain->id,
+            'priority' => 5,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $fleetDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $fleetDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->call('updatePropertyPriority', $property->id, '-3')
+            ->assertHasErrors(['priority']);
+
+        $this->assertSame(5, $property->fresh()->priority);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->call('updatePropertyPriority', $property->id, '300')
+            ->assertHasErrors(['priority']);
+
+        $this->assertSame(5, $property->fresh()->priority);
+    }
+
+    public function test_fleet_view_rejects_non_fleet_property_priority_updates(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        $this->actingAs(User::factory()->create());
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'non-fleet-priority-site',
+            'name' => 'Non Fleet Priority Site',
+            'priority' => 9,
+        ]);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->call('updatePropertyPriority', $property->id, '77')
+            ->assertForbidden();
+
+        $this->assertSame(9, $property->fresh()->priority);
+    }
+
+    public function test_fleet_view_requires_authentication_for_priority_updates(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $fleetDomain = Domain::factory()->create([
+            'domain' => 'auth-required.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'auth-required-site',
+            'name' => 'Auth Required Site',
+            'primary_domain_id' => $fleetDomain->id,
+            'priority' => 5,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $fleetDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $fleetDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->call('updatePropertyPriority', $property->id, '77')
+            ->assertForbidden();
+
+        $this->assertSame(5, $property->fresh()->priority);
+    }
+}

--- a/tests/Feature/FleetPropertiesListTest.php
+++ b/tests/Feature/FleetPropertiesListTest.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Features\SupportLockedProperties\CannotUpdateLockedPropertyException;
 use Livewire\Livewire;
 use Tests\TestCase;
 
@@ -214,5 +215,13 @@ class FleetPropertiesListTest extends TestCase
             ->assertForbidden();
 
         $this->assertSame(5, $property->fresh()->priority);
+    }
+
+    public function test_fleet_view_does_not_allow_client_updates_to_fleet_mode(): void
+    {
+        $this->expectException(CannotUpdateLockedPropertyException::class);
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->set('fleetFocusMode', false);
     }
 }

--- a/tests/Feature/SyncFleetFocusDomainsCommandTest.php
+++ b/tests/Feature/SyncFleetFocusDomainsCommandTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainTag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class SyncFleetFocusDomainsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_syncs_configured_domains_onto_the_fleet_focus_tag(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        config()->set('domain_monitor.fleet_focus.domains', [
+            'fleet-a.example.com',
+            'fleet-b.example.com',
+            'missing.example.com',
+        ]);
+
+        $fleetA = Domain::factory()->create([
+            'domain' => 'fleet-a.example.com',
+            'is_active' => true,
+        ]);
+
+        $fleetB = Domain::factory()->create([
+            'domain' => 'fleet-b.example.com',
+            'is_active' => true,
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:sync-focus-domains'));
+
+        $tag = DomainTag::query()->where('name', 'fleet.live')->firstOrFail();
+
+        $this->assertTrue($fleetA->fresh()->tags->contains('id', $tag->id));
+        $this->assertTrue($fleetB->fresh()->tags->contains('id', $tag->id));
+        $this->assertStringContainsString('Configured domains not found: missing.example.com', Artisan::output());
+    }
+
+    public function test_dry_run_reports_changes_without_attaching_tags(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+        config()->set('domain_monitor.fleet_focus.domains', [
+            'fleet-dry-run.example.com',
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'fleet-dry-run.example.com',
+            'is_active' => true,
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:sync-focus-domains', ['--dry-run' => true]));
+        $this->assertStringContainsString('Would attach [1] domains to [fleet.live].', Artisan::output());
+        $this->assertCount(0, $domain->fresh()->tags);
+    }
+}

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -6,6 +6,7 @@ use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
 use App\Models\DomainAlert;
 use App\Models\DomainCheck;
+use App\Models\DomainTag;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
 use App\Models\SearchConsoleIssueSnapshot;
@@ -36,6 +37,15 @@ class WebPropertyApiTest extends TestCase
             'hosting_provider' => 'Vercel',
         ]);
 
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+                'description' => 'Fleet-managed live domains.',
+            ]
+        );
+
         $property = WebProperty::factory()->create([
             'slug' => 'moveroo-website',
             'name' => 'Moveroo Website',
@@ -59,6 +69,8 @@ class WebPropertyApiTest extends TestCase
             'usage_type' => 'redirect',
             'is_canonical' => false,
         ]);
+
+        $primaryDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
 
         PropertyRepository::create([
             'web_property_id' => $property->id,
@@ -163,6 +175,8 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.control_state', 'controlled')
             ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
+            ->assertJsonPath('web_properties.0.is_fleet_focus', true)
+            ->assertJsonPath('web_properties.0.fleet_priority', $property->priority)
             ->assertJsonPath('web_properties.0.controller_repo', 'moveroo/moveroo-website-astro')
             ->assertJsonPath('web_properties.0.controller_repo_url', 'https://github.com/moveroo/moveroo-website-astro')
             ->assertJsonPath('web_properties.0.controller_local_path', '/Users/jasonhill/Projects/websites/moveroo-website-astro')
@@ -176,6 +190,137 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.api_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_api_captured_at', null)
             ->assertJsonPath('web_properties.0.health_summary.active_alerts_count', 1);
+    }
+
+    public function test_web_properties_summary_can_filter_to_fleet_focus_properties(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $fleetDomain = Domain::factory()->create([
+            'domain' => 'fleet-focus.example.com',
+            'is_active' => true,
+        ]);
+
+        $otherDomain = Domain::factory()->create([
+            'domain' => 'non-fleet.example.com',
+            'is_active' => true,
+        ]);
+
+        $fleetProperty = WebProperty::factory()->create([
+            'slug' => 'fleet-focus-site',
+            'name' => 'Fleet Focus Site',
+            'primary_domain_id' => $fleetDomain->id,
+            'priority' => 42,
+        ]);
+
+        $otherProperty = WebProperty::factory()->create([
+            'slug' => 'non-fleet-site',
+            'name' => 'Non Fleet Site',
+            'primary_domain_id' => $otherDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $fleetProperty->id,
+            'domain_id' => $fleetDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $otherProperty->id,
+            'domain_id' => $otherDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $fleetDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary?fleet_focus=1');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(1, 'web_properties')
+            ->assertJsonPath('web_properties.0.slug', 'fleet-focus-site')
+            ->assertJsonPath('web_properties.0.is_fleet_focus', true)
+            ->assertJsonPath('web_properties.0.fleet_priority', 42);
+
+        $indexResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties?fleet_focus=1');
+
+        $indexResponse
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.slug', 'fleet-focus-site');
+    }
+
+    public function test_web_properties_summary_keeps_fleet_flag_true_for_canonical_tagged_domain_when_primary_domain_drifts(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $stalePrimaryDomain = Domain::factory()->create([
+            'domain' => 'stale-primary.example.com',
+            'is_active' => true,
+        ]);
+
+        $canonicalDomain = Domain::factory()->create([
+            'domain' => 'canonical-fleet.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'canonical-fleet-site',
+            'name' => 'Canonical Fleet Site',
+            'primary_domain_id' => $stalePrimaryDomain->id,
+            'priority' => 21,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $stalePrimaryDomain->id,
+            'usage_type' => 'alias',
+            'is_canonical' => false,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $canonicalDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $canonicalDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary?fleet_focus=1');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(1, 'web_properties')
+            ->assertJsonPath('web_properties.0.slug', 'canonical-fleet-site')
+            ->assertJsonPath('web_properties.0.is_fleet_focus', true)
+            ->assertJsonPath('web_properties.0.fleet_priority', 21);
     }
 
     public function test_web_properties_summary_prefers_any_controller_repo_with_local_path(): void

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -323,6 +323,57 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.fleet_priority', 21);
     }
 
+    public function test_web_properties_summary_keeps_fleet_flag_true_when_primary_domain_tag_has_no_pivot_link(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'primary-only-fleet.example.com',
+            'is_active' => true,
+        ]);
+
+        $canonicalDomain = Domain::factory()->create([
+            'domain' => 'canonical-no-tag.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'primary-only-fleet-site',
+            'name' => 'Primary Only Fleet Site',
+            'primary_domain_id' => $primaryDomain->id,
+            'priority' => 17,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $canonicalDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $primaryDomain->tags()->syncWithoutDetaching([$fleetTag->id]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary?fleet_focus=1');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(1, 'web_properties')
+            ->assertJsonPath('web_properties.0.slug', 'primary-only-fleet-site')
+            ->assertJsonPath('web_properties.0.is_fleet_focus', true)
+            ->assertJsonPath('web_properties.0.fleet_priority', 17);
+    }
+
     public function test_web_properties_summary_prefers_any_controller_repo_with_local_path(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- add a dedicated Fleet focus grouping driven by the fleet.live domain tag
- expose Fleet membership and manual property priority in the property APIs
- add a Fleet-focused web properties view plus a sync command for the configured domain set

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyApiTest.php tests/Feature/FleetPropertiesListTest.php tests/Feature/SyncFleetFocusDomainsCommandTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Http/Controllers/Api/WebPropertyController.php app/Livewire/WebPropertiesList.php routes/console.php tests/Feature/WebPropertyApiTest.php tests/Feature/FleetPropertiesListTest.php tests/Feature/SyncFleetFocusDomainsCommandTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
