### PR TITLE
Add Fleet view to main navigation

### DIFF
--- a/app/Livewire/WebPropertiesList.php
+++ b/app/Livewire/WebPropertiesList.php
@@ -15,6 +15,10 @@ class WebPropertiesList extends Component
 {
     use WithPagination;
 
+    private const DEFAULT_PER_PAGE = 20;
+
+    private const FLEET_PER_PAGE = 30;
+
     #[Locked]
     public bool $fleetFocusMode = false;
 
@@ -166,7 +170,9 @@ class WebPropertiesList extends Component
             $query->orderBy('name');
         }
 
-        $properties = $query->paginate(20);
+        $properties = $query->paginate(
+            $this->fleetFocusMode ? self::FLEET_PER_PAGE : self::DEFAULT_PER_PAGE
+        );
 
         return view('livewire.web-properties-list', [
             'properties' => $properties,

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -36,7 +36,7 @@ new class extends Component
                     <x-nav-link :href="route('domains.index')" :active="request()->routeIs('domains.*')" wire:navigate>
                         {{ __('Domains') }}
                     </x-nav-link>
-                    <x-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*')" wire:navigate>
+                    <x-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*') && ! request()->routeIs('web-properties.fleet')" wire:navigate>
                         {{ __('Web Properties') }}
                     </x-nav-link>
                     <x-nav-link :href="route('web-properties.fleet')" :active="request()->routeIs('web-properties.fleet')" wire:navigate>
@@ -121,7 +121,7 @@ new class extends Component
             <x-responsive-nav-link :href="route('domains.index')" :active="request()->routeIs('domains.*')" wire:navigate>
                 {{ __('Domains') }}
             </x-responsive-nav-link>
-            <x-responsive-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*')" wire:navigate>
+            <x-responsive-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*') && ! request()->routeIs('web-properties.fleet')" wire:navigate>
                 {{ __('Web Properties') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('web-properties.fleet')" :active="request()->routeIs('web-properties.fleet')" wire:navigate>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -39,6 +39,9 @@ new class extends Component
                     <x-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*')" wire:navigate>
                         {{ __('Web Properties') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('web-properties.fleet')" :active="request()->routeIs('web-properties.fleet')" wire:navigate>
+                        {{ __('Fleet') }}
+                    </x-nav-link>
                     <x-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                         {{ __('Matomo Coverage') }}
                     </x-nav-link>
@@ -120,6 +123,9 @@ new class extends Component
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('web-properties.index')" :active="request()->routeIs('web-properties.*')" wire:navigate>
                 {{ __('Web Properties') }}
+            </x-responsive-nav-link>
+            <x-responsive-nav-link :href="route('web-properties.fleet')" :active="request()->routeIs('web-properties.fleet')" wire:navigate>
+                {{ __('Fleet') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('matomo-coverage.index')" :active="request()->routeIs('matomo-coverage.*')" wire:navigate>
                 {{ __('Matomo Coverage') }}

--- a/tests/Feature/FleetPropertiesListTest.php
+++ b/tests/Feature/FleetPropertiesListTest.php
@@ -224,4 +224,48 @@ class FleetPropertiesListTest extends TestCase
         Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
             ->set('fleetFocusMode', false);
     }
+
+    public function test_fleet_view_uses_thirty_items_per_page(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $fleetTag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        for ($index = 1; $index <= 31; $index++) {
+            $domain = Domain::factory()->create([
+                'domain' => sprintf('fleet-%02d.example.com', $index),
+                'is_active' => true,
+            ]);
+
+            $property = WebProperty::factory()->create([
+                'slug' => sprintf('fleet-site-%02d', $index),
+                'name' => sprintf('Fleet Site %02d', $index),
+                'primary_domain_id' => $domain->id,
+            ]);
+
+            WebPropertyDomain::create([
+                'web_property_id' => $property->id,
+                'domain_id' => $domain->id,
+                'usage_type' => 'primary',
+                'is_canonical' => true,
+            ]);
+
+            $domain->tags()->syncWithoutDetaching([$fleetTag->id]);
+        }
+
+        Livewire::test(WebPropertiesList::class, ['fleetFocusMode' => true])
+            ->assertSee('Fleet Site 01')
+            ->assertSee('Fleet Site 30')
+            ->assertSee('Showing')
+            ->assertSee('1')
+            ->assertSee('30')
+            ->assertSee('31')
+            ->assertSee('results');
+    }
 }


### PR DESCRIPTION
## Summary
- add a first-class Fleet link to the desktop navigation
- add the same Fleet link to the responsive mobile navigation

## Testing
- ./vendor/bin/phpunit --filter="navigation menu can be rendered|Navigation" tests/Feature/Auth/AuthenticationTest.php
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
