### PR TITLE
Add property conversion link tracking

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -3,8 +3,10 @@
 namespace App\Livewire;
 
 use App\Models\WebProperty;
+use App\Services\PropertyConversionLinkScanner;
 use App\Services\SearchConsoleIssueEvidenceService;
 use App\Services\SearchConsoleIssueSnapshotImporter;
+use Illuminate\Support\Facades\Validator;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 
@@ -22,6 +24,14 @@ class WebPropertyDetail extends Component
     public array $searchConsoleIssueSummaries = [];
 
     public mixed $issueDetailArchive = null;
+
+    public ?string $targetHouseholdQuoteUrl = null;
+
+    public ?string $targetHouseholdBookingUrl = null;
+
+    public ?string $targetVehicleQuoteUrl = null;
+
+    public ?string $targetVehicleBookingUrl = null;
 
     public function mount(): void
     {
@@ -52,6 +62,11 @@ class WebPropertyDetail extends Component
 
         $this->searchConsoleIssueSummaries = app(SearchConsoleIssueEvidenceService::class)
             ->propertyIssueSummaries($this->property);
+
+        $this->targetHouseholdQuoteUrl = $this->property->target_household_quote_url;
+        $this->targetHouseholdBookingUrl = $this->property->target_household_booking_url;
+        $this->targetVehicleQuoteUrl = $this->property->target_vehicle_quote_url;
+        $this->targetVehicleBookingUrl = $this->property->target_vehicle_booking_url;
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -83,6 +98,63 @@ class WebPropertyDetail extends Component
             ));
         } catch (\Throwable $exception) {
             session()->flash('error', 'Issue detail import failed: '.$exception->getMessage());
+        }
+    }
+
+    public function saveConversionTargets(): void
+    {
+        if (! $this->property instanceof WebProperty) {
+            session()->flash('error', 'Property not found.');
+
+            return;
+        }
+
+        abort_unless(auth()->check(), 403);
+
+        $validated = Validator::make(
+            [
+                'targetHouseholdQuoteUrl' => $this->targetHouseholdQuoteUrl,
+                'targetHouseholdBookingUrl' => $this->targetHouseholdBookingUrl,
+                'targetVehicleQuoteUrl' => $this->targetVehicleQuoteUrl,
+                'targetVehicleBookingUrl' => $this->targetVehicleBookingUrl,
+            ],
+            [
+                'targetHouseholdQuoteUrl' => ['nullable', 'url', 'max:2048'],
+                'targetHouseholdBookingUrl' => ['nullable', 'url', 'max:2048'],
+                'targetVehicleQuoteUrl' => ['nullable', 'url', 'max:2048'],
+                'targetVehicleBookingUrl' => ['nullable', 'url', 'max:2048'],
+            ]
+        )->validate();
+
+        $this->property->update([
+            'target_household_quote_url' => $validated['targetHouseholdQuoteUrl'],
+            'target_household_booking_url' => $validated['targetHouseholdBookingUrl'],
+            'target_vehicle_quote_url' => $validated['targetVehicleQuoteUrl'],
+            'target_vehicle_booking_url' => $validated['targetVehicleBookingUrl'],
+        ]);
+
+        $this->loadProperty();
+
+        session()->flash('message', 'Target conversion links updated.');
+    }
+
+    public function refreshCurrentConversionLinks(PropertyConversionLinkScanner $scanner): void
+    {
+        if (! $this->property instanceof WebProperty) {
+            session()->flash('error', 'Property not found.');
+
+            return;
+        }
+
+        abort_unless(auth()->check(), 403);
+
+        try {
+            $scanner->persistForProperty($this->property);
+            $this->loadProperty();
+
+            session()->flash('message', 'Current conversion links refreshed from the live site navigation.');
+        } catch (\Throwable $exception) {
+            session()->flash('error', 'Conversion link scan failed: '.$exception->getMessage());
         }
     }
 

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -118,6 +118,8 @@ class WebPropertyDetail extends Component
             'targetVehicleBookingUrl' => $this->normalizeTargetUrl($this->targetVehicleBookingUrl),
         ];
 
+        $this->resetValidation();
+
         $validated = Validator::make(
             $normalizedTargets,
             [

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -109,20 +109,22 @@ class WebPropertyDetail extends Component
             return;
         }
 
-        abort_unless(auth()->check(), 403);
+        $this->authorizePropertyMutation();
+
+        $normalizedTargets = [
+            'targetHouseholdQuoteUrl' => $this->normalizeTargetUrl($this->targetHouseholdQuoteUrl),
+            'targetHouseholdBookingUrl' => $this->normalizeTargetUrl($this->targetHouseholdBookingUrl),
+            'targetVehicleQuoteUrl' => $this->normalizeTargetUrl($this->targetVehicleQuoteUrl),
+            'targetVehicleBookingUrl' => $this->normalizeTargetUrl($this->targetVehicleBookingUrl),
+        ];
 
         $validated = Validator::make(
+            $normalizedTargets,
             [
-                'targetHouseholdQuoteUrl' => $this->targetHouseholdQuoteUrl,
-                'targetHouseholdBookingUrl' => $this->targetHouseholdBookingUrl,
-                'targetVehicleQuoteUrl' => $this->targetVehicleQuoteUrl,
-                'targetVehicleBookingUrl' => $this->targetVehicleBookingUrl,
-            ],
-            [
-                'targetHouseholdQuoteUrl' => ['nullable', 'url', 'max:2048'],
-                'targetHouseholdBookingUrl' => ['nullable', 'url', 'max:2048'],
-                'targetVehicleQuoteUrl' => ['nullable', 'url', 'max:2048'],
-                'targetVehicleBookingUrl' => ['nullable', 'url', 'max:2048'],
+                'targetHouseholdQuoteUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetHouseholdBookingUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetVehicleQuoteUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetVehicleBookingUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
             ]
         )->validate();
 
@@ -146,7 +148,7 @@ class WebPropertyDetail extends Component
             return;
         }
 
-        abort_unless(auth()->check(), 403);
+        $this->authorizePropertyMutation();
 
         try {
             $scanner->persistForProperty($this->property);
@@ -161,5 +163,37 @@ class WebPropertyDetail extends Component
     public function render(): \Illuminate\View\View
     {
         return view('livewire.web-property-detail');
+    }
+
+    private function normalizeTargetUrl(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function authorizePropertyMutation(): void
+    {
+        $user = auth()->user();
+
+        abort_unless($user !== null, 403);
+
+        if (app()->environment(['local', 'testing'])) {
+            return;
+        }
+
+        $allowedEmails = array_filter(array_map(
+            static fn (mixed $email): string => mb_strtolower(trim((string) $email)),
+            (array) config('domain_monitor.property_mutation_emails', config('horizon.allowed_emails', []))
+        ));
+
+        abort_unless(
+            in_array(mb_strtolower((string) $user->email), $allowedEmails, true),
+            403
+        );
     }
 }

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -26,6 +26,15 @@ use Illuminate\Support\Str;
  * @property string|null $owner
  * @property int|null $priority
  * @property string|null $notes
+ * @property string|null $current_household_quote_url
+ * @property string|null $current_household_booking_url
+ * @property string|null $current_vehicle_quote_url
+ * @property string|null $current_vehicle_booking_url
+ * @property string|null $target_household_quote_url
+ * @property string|null $target_household_booking_url
+ * @property string|null $target_vehicle_quote_url
+ * @property string|null $target_vehicle_booking_url
+ * @property \Illuminate\Support\Carbon|null $conversion_links_scanned_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  *
@@ -53,12 +62,22 @@ class WebProperty extends Model
         'owner',
         'priority',
         'notes',
+        'current_household_quote_url',
+        'current_household_booking_url',
+        'current_vehicle_quote_url',
+        'current_vehicle_booking_url',
+        'target_household_quote_url',
+        'target_household_booking_url',
+        'target_vehicle_quote_url',
+        'target_vehicle_booking_url',
+        'conversion_links_scanned_at',
     ];
 
     protected function casts(): array
     {
         return [
             'priority' => 'integer',
+            'conversion_links_scanned_at' => 'datetime',
         ];
     }
 
@@ -527,6 +546,42 @@ class WebProperty extends Model
     }
 
     /**
+     * @return array{
+     *   current: array{
+     *     household_quote: string|null,
+     *     household_booking: string|null,
+     *     vehicle_quote: string|null,
+     *     vehicle_booking: string|null
+     *   },
+     *   target: array{
+     *     household_quote: string|null,
+     *     household_booking: string|null,
+     *     vehicle_quote: string|null,
+     *     vehicle_booking: string|null
+     *   },
+     *   scanned_at: string|null
+     * }
+     */
+    public function conversionLinkSummary(): array
+    {
+        return [
+            'current' => [
+                'household_quote' => $this->current_household_quote_url,
+                'household_booking' => $this->current_household_booking_url,
+                'vehicle_quote' => $this->current_vehicle_quote_url,
+                'vehicle_booking' => $this->current_vehicle_booking_url,
+            ],
+            'target' => [
+                'household_quote' => $this->target_household_quote_url,
+                'household_booking' => $this->target_household_booking_url,
+                'vehicle_quote' => $this->target_vehicle_quote_url,
+                'vehicle_booking' => $this->target_vehicle_booking_url,
+            ],
+            'scanned_at' => $this->conversion_links_scanned_at?->toIso8601String(),
+        ];
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function brainSummary(): array
@@ -564,6 +619,7 @@ class WebProperty extends Model
             'deployment_provider' => $executionReadiness['deployment_provider'],
             'deployment_project_name' => $executionReadiness['deployment_project_name'],
             'deployment_project_id' => $executionReadiness['deployment_project_id'],
+            'conversion_links' => $this->conversionLinkSummary(),
             'gsc_evidence_summary' => $this->gscEvidenceSummary(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use Illuminate\Http\Client\Factory as HttpFactory;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Str;
+
+class PropertyConversionLinkScanner
+{
+    public function __construct(
+        private readonly HttpFactory $http,
+    ) {}
+
+    /**
+     * @return array{
+     *   current_household_quote_url: string|null,
+     *   current_household_booking_url: string|null,
+     *   current_vehicle_quote_url: string|null,
+     *   current_vehicle_booking_url: string|null,
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     * }
+     */
+    public function scanForProperty(WebProperty $property): array
+    {
+        $homepageUrl = $this->homepageUrlForProperty($property);
+
+        if ($homepageUrl === null) {
+            throw new \RuntimeException('Property does not have a scannable production URL or primary domain.');
+        }
+
+        $response = $this->http
+            ->timeout(15)
+            ->withHeaders([
+                'Accept' => 'text/html,application/xhtml+xml',
+                'User-Agent' => 'DomainMonitorConversionLinkScanner/1.0 (+https://monitor.again.com.au)',
+            ])
+            ->get($homepageUrl);
+
+        if ($response->failed()) {
+            throw new RequestException($response);
+        }
+
+        $anchors = $this->extractAnchors($response->body(), $homepageUrl);
+
+        return [
+            'current_household_quote_url' => $this->pickLink($anchors, 'household_quote'),
+            'current_household_booking_url' => $this->pickLink($anchors, 'household_booking'),
+            'current_vehicle_quote_url' => $this->pickLink($anchors, 'vehicle_quote'),
+            'current_vehicle_booking_url' => $this->pickLink($anchors, 'vehicle_booking'),
+            'conversion_links_scanned_at' => now(),
+        ];
+    }
+
+    /**
+     * @return array<int, array{href: string, text: string, bucket: string|null, score: int}>
+     */
+    public function extractAnchors(string $html, string $baseUrl): array
+    {
+        $dom = new DOMDocument;
+
+        libxml_use_internal_errors(true);
+        $dom->loadHTML($html);
+        libxml_clear_errors();
+
+        $xpath = new DOMXPath($dom);
+        $nodes = $xpath->query('//nav//a[@href] | //header//a[@href]');
+
+        $anchors = [];
+
+        if ($nodes !== false) {
+            /** @var DOMElement $node */
+            foreach ($nodes as $node) {
+                $anchors[] = $node;
+            }
+        }
+
+        if ($anchors === []) {
+            $fallbackNodes = $xpath->query('//body//a[@href]');
+
+            if ($fallbackNodes !== false) {
+                /** @var DOMElement $node */
+                foreach ($fallbackNodes as $node) {
+                    $anchors[] = $node;
+                }
+            }
+        }
+
+        return collect($anchors)
+            ->map(function (DOMElement $anchor) use ($baseUrl): ?array {
+                $href = trim((string) $anchor->getAttribute('href'));
+
+                if ($href === '' || Str::startsWith($href, ['#', 'mailto:', 'tel:', 'javascript:'])) {
+                    return null;
+                }
+
+                $absoluteUrl = $this->normalizeUrl($href, $baseUrl);
+
+                if ($absoluteUrl === null) {
+                    return null;
+                }
+
+                $text = trim(preg_replace('/\s+/', ' ', $anchor->textContent ?? '') ?? '');
+                $classification = $this->classifyAnchor($text, $absoluteUrl);
+
+                return [
+                    'href' => $absoluteUrl,
+                    'text' => $text,
+                    'bucket' => $classification['bucket'],
+                    'score' => $classification['score'],
+                ];
+            })
+            ->filter(fn (?array $anchor): bool => is_array($anchor) && $anchor['bucket'] !== null)
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, array{href: string, text: string, bucket: string|null, score: int}>  $anchors
+     */
+    public function pickLink(array $anchors, string $bucket): ?string
+    {
+        return collect($anchors)
+            ->filter(fn (array $anchor): bool => $anchor['bucket'] === $bucket)
+            ->sortByDesc(fn (array $anchor): int => $anchor['score'])
+            ->pluck('href')
+            ->first();
+    }
+
+    /**
+     * @return array{
+     *   current_household_quote_url: string|null,
+     *   current_household_booking_url: string|null,
+     *   current_vehicle_quote_url: string|null,
+     *   current_vehicle_booking_url: string|null,
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     * }
+     */
+    public function persistForProperty(WebProperty $property): array
+    {
+        $scan = $this->scanForProperty($property);
+
+        $property->forceFill($scan)->save();
+
+        return $scan;
+    }
+
+    private function homepageUrlForProperty(WebProperty $property): ?string
+    {
+        $url = $property->production_url;
+
+        if (is_string($url) && $url !== '') {
+            return rtrim($url, '/');
+        }
+
+        $domain = $property->primaryDomainName();
+
+        if (! is_string($domain) || $domain === '') {
+            return null;
+        }
+
+        return 'https://'.$domain;
+    }
+
+    private function normalizeUrl(string $href, string $baseUrl): ?string
+    {
+        if (Str::startsWith($href, ['http://', 'https://'])) {
+            return $href;
+        }
+
+        $base = parse_url($baseUrl);
+
+        if (! is_array($base) || ! isset($base['scheme'], $base['host'])) {
+            return null;
+        }
+
+        $prefix = $base['scheme'].'://'.$base['host'];
+
+        if (isset($base['port'])) {
+            $prefix .= ':'.$base['port'];
+        }
+
+        if (Str::startsWith($href, '//')) {
+            return $base['scheme'].':'.$href;
+        }
+
+        if (Str::startsWith($href, '/')) {
+            return $prefix.$href;
+        }
+
+        return $prefix.'/'.ltrim($href, '/');
+    }
+
+    /**
+     * @return array{bucket: string|null, score: int}
+     */
+    private function classifyAnchor(string $text, string $href): array
+    {
+        $haystack = Str::lower(trim($text.' '.$href));
+
+        if (! Str::contains($haystack, ['quote', 'book', 'booking'])) {
+            return ['bucket' => null, 'score' => 0];
+        }
+
+        $isBooking = Str::contains($haystack, ['book', 'booking']);
+        $isQuote = Str::contains($haystack, ['quote']);
+        $isVehicle = Str::contains($haystack, ['vehicle', 'car', 'transport']);
+        $isHousehold = Str::contains($haystack, ['move', 'moving', 'removal', 'removalist', 'household', 'furniture', 'backloading']);
+
+        $score = 0;
+        $score += $isBooking ? 40 : 0;
+        $score += $isQuote ? 35 : 0;
+        $score += $isVehicle ? 25 : 0;
+        $score += $isHousehold ? 20 : 0;
+
+        if ($isBooking && $isVehicle) {
+            return ['bucket' => 'vehicle_booking', 'score' => $score];
+        }
+
+        if ($isQuote && $isVehicle) {
+            return ['bucket' => 'vehicle_quote', 'score' => $score];
+        }
+
+        if ($isBooking) {
+            return ['bucket' => 'household_booking', 'score' => $score];
+        }
+
+        if ($isQuote) {
+            return ['bucket' => 'household_quote', 'score' => $score];
+        }
+
+        return ['bucket' => null, 'score' => 0];
+    }
+}

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -68,9 +68,10 @@ class PropertyConversionLinkScanner
     {
         $dom = new DOMDocument;
 
-        libxml_use_internal_errors(true);
+        $previousInternalErrors = libxml_use_internal_errors(true);
         $dom->loadHTML($html);
         libxml_clear_errors();
+        libxml_use_internal_errors($previousInternalErrors);
 
         $xpath = new DOMXPath($dom);
         $nodes = $xpath->query('//nav//a[@href] | //header//a[@href]');

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -138,7 +138,7 @@ class PropertyConversionLinkScanner
         $scan = $this->scanForProperty($property);
         $persistedScan = $this->mergeWithExisting($property, $scan);
 
-        $property->forceFill($persistedScan)->save();
+        $property->fill($persistedScan)->save();
 
         return $persistedScan;
     }

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -138,11 +138,9 @@ class PropertyConversionLinkScanner
     public function persistForProperty(WebProperty $property): array
     {
         $scan = $this->scanForProperty($property);
-        $persistedScan = $this->mergeWithExisting($property, $scan);
+        $property->fill($scan)->save();
 
-        $property->fill($persistedScan)->save();
-
-        return $persistedScan;
+        return $scan;
     }
 
     private function homepageUrlForProperty(WebProperty $property): ?string
@@ -170,38 +168,6 @@ class PropertyConversionLinkScanner
         }
 
         return null;
-    }
-
-    /**
-     * @param  array{
-     *   current_household_quote_url: string|null,
-     *   current_household_booking_url: string|null,
-     *   current_vehicle_quote_url: string|null,
-     *   current_vehicle_booking_url: string|null,
-     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
-     * }  $scan
-     * @return array{
-     *   current_household_quote_url: string|null,
-     *   current_household_booking_url: string|null,
-     *   current_vehicle_quote_url: string|null,
-     *   current_vehicle_booking_url: string|null,
-     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
-     * }
-     */
-    private function mergeWithExisting(WebProperty $property, array $scan): array
-    {
-        foreach ([
-            'current_household_quote_url',
-            'current_household_booking_url',
-            'current_vehicle_quote_url',
-            'current_vehicle_booking_url',
-        ] as $field) {
-            if ($scan[$field] === null && is_string($property->{$field}) && $property->{$field} !== '') {
-                $scan[$field] = $property->{$field};
-            }
-        }
-
-        return $scan;
     }
 
     private function isAllowedScanUrl(string $url, WebProperty $property): bool

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -33,6 +33,10 @@ class PropertyConversionLinkScanner
             throw new \RuntimeException('Property does not have a scannable production URL or primary domain.');
         }
 
+        if (! $this->isAllowedScanUrl($homepageUrl, $property)) {
+            throw new \RuntimeException('Property homepage URL is not allowed for conversion-link scanning.');
+        }
+
         $response = $this->http
             ->timeout(15)
             ->withHeaders([
@@ -76,17 +80,6 @@ class PropertyConversionLinkScanner
             /** @var DOMElement $node */
             foreach ($nodes as $node) {
                 $anchors[] = $node;
-            }
-        }
-
-        if ($anchors === []) {
-            $fallbackNodes = $xpath->query('//body//a[@href]');
-
-            if ($fallbackNodes !== false) {
-                /** @var DOMElement $node */
-                foreach ($fallbackNodes as $node) {
-                    $anchors[] = $node;
-                }
             }
         }
 
@@ -143,27 +136,129 @@ class PropertyConversionLinkScanner
     public function persistForProperty(WebProperty $property): array
     {
         $scan = $this->scanForProperty($property);
+        $persistedScan = $this->mergeWithExisting($property, $scan);
 
-        $property->forceFill($scan)->save();
+        $property->forceFill($persistedScan)->save();
 
-        return $scan;
+        return $persistedScan;
     }
 
     private function homepageUrlForProperty(WebProperty $property): ?string
     {
+        $domain = $property->primaryDomainName();
+
+        if (is_string($domain) && $domain !== '') {
+            return 'https://'.$domain;
+        }
+
         $url = $property->production_url;
 
         if (is_string($url) && $url !== '') {
-            return rtrim($url, '/');
+            $parts = parse_url($url);
+
+            if (is_array($parts) && isset($parts['scheme'], $parts['host'])) {
+                $homepageUrl = $parts['scheme'].'://'.$parts['host'];
+
+                if (isset($parts['port'])) {
+                    $homepageUrl .= ':'.$parts['port'];
+                }
+
+                return $homepageUrl;
+            }
         }
 
-        $domain = $property->primaryDomainName();
+        return null;
+    }
 
-        if (! is_string($domain) || $domain === '') {
-            return null;
+    /**
+     * @param  array{
+     *   current_household_quote_url: string|null,
+     *   current_household_booking_url: string|null,
+     *   current_vehicle_quote_url: string|null,
+     *   current_vehicle_booking_url: string|null,
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     * }  $scan
+     * @return array{
+     *   current_household_quote_url: string|null,
+     *   current_household_booking_url: string|null,
+     *   current_vehicle_quote_url: string|null,
+     *   current_vehicle_booking_url: string|null,
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     * }
+     */
+    private function mergeWithExisting(WebProperty $property, array $scan): array
+    {
+        foreach ([
+            'current_household_quote_url',
+            'current_household_booking_url',
+            'current_vehicle_quote_url',
+            'current_vehicle_booking_url',
+        ] as $field) {
+            if ($scan[$field] === null && is_string($property->{$field}) && $property->{$field} !== '') {
+                $scan[$field] = $property->{$field};
+            }
         }
 
-        return 'https://'.$domain;
+        return $scan;
+    }
+
+    private function isAllowedScanUrl(string $url, WebProperty $property): bool
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+
+        $scheme = Str::lower((string) $parts['scheme']);
+        $host = Str::lower((string) $parts['host']);
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return filter_var(
+                $host,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ) !== false;
+        }
+
+        if (! str_contains($host, '.') || Str::endsWith($host, ['.local', '.internal'])) {
+            return false;
+        }
+
+        return in_array($host, $this->allowedHostsForProperty($property), true);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function allowedHostsForProperty(WebProperty $property): array
+    {
+        $hosts = [];
+
+        $primaryDomain = $property->primaryDomainName();
+        if (is_string($primaryDomain) && $primaryDomain !== '') {
+            $hosts[] = Str::lower($primaryDomain);
+        }
+
+        foreach ($property->orderedDomainLinks() as $link) {
+            if (is_string($link->domain?->domain) && $link->domain->domain !== '') {
+                $hosts[] = Str::lower($link->domain->domain);
+            }
+        }
+
+        if (is_string($property->production_url) && $property->production_url !== '') {
+            $productionHost = parse_url($property->production_url, PHP_URL_HOST);
+
+            if (is_string($productionHost) && $productionHost !== '') {
+                $hosts[] = Str::lower($productionHost);
+            }
+        }
+
+        return array_values(array_unique($hosts));
     }
 
     private function normalizeUrl(string $href, string $baseUrl): ?string

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -297,14 +297,14 @@ class PropertyConversionLinkScanner
     {
         $haystack = Str::lower(trim($text.' '.$href));
 
-        if (! Str::contains($haystack, ['quote', 'book', 'booking'])) {
+        if (! $this->containsWholeWord($haystack, ['quote', 'book', 'booking'])) {
             return ['bucket' => null, 'score' => 0];
         }
 
-        $isBooking = Str::contains($haystack, ['book', 'booking']);
-        $isQuote = Str::contains($haystack, ['quote']);
-        $isVehicle = Str::contains($haystack, ['vehicle', 'car', 'transport']);
-        $isHousehold = Str::contains($haystack, ['move', 'moving', 'removal', 'removalist', 'household', 'furniture', 'backloading']);
+        $isBooking = $this->containsWholeWord($haystack, ['book', 'booking']);
+        $isQuote = $this->containsWholeWord($haystack, ['quote']);
+        $isVehicle = $this->containsWholeWord($haystack, ['vehicle', 'car', 'transport']);
+        $isHousehold = $this->containsWholeWord($haystack, ['move', 'moving', 'removal', 'removalist', 'household', 'furniture', 'backloading']);
 
         $score = 0;
         $score += $isBooking ? 40 : 0;
@@ -329,5 +329,23 @@ class PropertyConversionLinkScanner
         }
 
         return ['bucket' => null, 'score' => 0];
+    }
+
+    /**
+     * @param  array<int, string>  $terms
+     */
+    private function containsWholeWord(string $haystack, array $terms): bool
+    {
+        foreach ($terms as $term) {
+            if ($term === '') {
+                continue;
+            }
+
+            if (preg_match('/(?<![a-z0-9])'.preg_quote(Str::lower($term), '/').'(?![a-z0-9])/i', $haystack) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -7,7 +7,6 @@ use DOMDocument;
 use DOMElement;
 use DOMXPath;
 use Illuminate\Http\Client\Factory as HttpFactory;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Str;
 
 class PropertyConversionLinkScanner
@@ -46,8 +45,11 @@ class PropertyConversionLinkScanner
             ])
             ->get($homepageUrl);
 
-        if ($response->failed()) {
-            throw new RequestException($response);
+        if (! $response->successful()) {
+            throw new \RuntimeException(sprintf(
+                'Homepage URL returned non-success HTTP status [%d].',
+                $response->status()
+            ));
         }
 
         $anchors = $this->extractAnchors($response->body(), $homepageUrl);

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -39,6 +39,7 @@ class PropertyConversionLinkScanner
 
         $response = $this->http
             ->timeout(15)
+            ->withoutRedirecting()
             ->withHeaders([
                 'Accept' => 'text/html,application/xhtml+xml',
                 'User-Agent' => 'DomainMonitorConversionLinkScanner/1.0 (+https://monitor.again.com.au)',

--- a/database/migrations/2026_04_02_080000_add_conversion_link_fields_to_web_properties_table.php
+++ b/database/migrations/2026_04_02_080000_add_conversion_link_fields_to_web_properties_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->string('current_household_quote_url')->nullable()->after('notes');
+            $table->string('current_household_booking_url')->nullable()->after('current_household_quote_url');
+            $table->string('current_vehicle_quote_url')->nullable()->after('current_household_booking_url');
+            $table->string('current_vehicle_booking_url')->nullable()->after('current_vehicle_quote_url');
+            $table->string('target_household_quote_url')->nullable()->after('current_vehicle_booking_url');
+            $table->string('target_household_booking_url')->nullable()->after('target_household_quote_url');
+            $table->string('target_vehicle_quote_url')->nullable()->after('target_household_booking_url');
+            $table->string('target_vehicle_booking_url')->nullable()->after('target_vehicle_quote_url');
+            $table->timestamp('conversion_links_scanned_at')->nullable()->after('target_vehicle_booking_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->dropColumn([
+                'current_household_quote_url',
+                'current_household_booking_url',
+                'current_vehicle_quote_url',
+                'current_vehicle_booking_url',
+                'target_household_quote_url',
+                'target_household_booking_url',
+                'target_vehicle_quote_url',
+                'target_vehicle_booking_url',
+                'conversion_links_scanned_at',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_04_02_080000_add_conversion_link_fields_to_web_properties_table.php
+++ b/database/migrations/2026_04_02_080000_add_conversion_link_fields_to_web_properties_table.php
@@ -9,14 +9,14 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('web_properties', function (Blueprint $table): void {
-            $table->string('current_household_quote_url')->nullable()->after('notes');
-            $table->string('current_household_booking_url')->nullable()->after('current_household_quote_url');
-            $table->string('current_vehicle_quote_url')->nullable()->after('current_household_booking_url');
-            $table->string('current_vehicle_booking_url')->nullable()->after('current_vehicle_quote_url');
-            $table->string('target_household_quote_url')->nullable()->after('current_vehicle_booking_url');
-            $table->string('target_household_booking_url')->nullable()->after('target_household_quote_url');
-            $table->string('target_vehicle_quote_url')->nullable()->after('target_household_booking_url');
-            $table->string('target_vehicle_booking_url')->nullable()->after('target_vehicle_quote_url');
+            $table->string('current_household_quote_url', 2048)->nullable()->after('notes');
+            $table->string('current_household_booking_url', 2048)->nullable()->after('current_household_quote_url');
+            $table->string('current_vehicle_quote_url', 2048)->nullable()->after('current_household_booking_url');
+            $table->string('current_vehicle_booking_url', 2048)->nullable()->after('current_vehicle_quote_url');
+            $table->string('target_household_quote_url', 2048)->nullable()->after('current_vehicle_booking_url');
+            $table->string('target_household_booking_url', 2048)->nullable()->after('target_household_quote_url');
+            $table->string('target_vehicle_quote_url', 2048)->nullable()->after('target_household_booking_url');
+            $table->string('target_vehicle_booking_url', 2048)->nullable()->after('target_vehicle_quote_url');
             $table->timestamp('conversion_links_scanned_at')->nullable()->after('target_vehicle_booking_url');
         });
     }

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -6,6 +6,7 @@
             $repositories = $property->repositories;
             $analyticsSources = $property->analyticsSources;
             $tags = collect($property->tagSummaries());
+            $conversionLinks = $property->conversionLinkSummary();
             $automationCoverage = $property->automationCoverageSummary();
             $automationChecks = [
                 [
@@ -164,6 +165,101 @@
                                 </span>
                             @endforeach
                         @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+            <div class="p-6">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">Conversion Links</h4>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            Current URLs are scanned from the live site navigation. Target URLs are the future state Fleet should migrate toward once the new quote and booking surfaces are ready.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <div class="text-xs text-gray-500 dark:text-gray-400">
+                            @if($conversionLinks['scanned_at'])
+                                Last scanned {{ \Illuminate\Support\Carbon::parse($conversionLinks['scanned_at'])->format('Y-m-d H:i') }}
+                            @else
+                                Not scanned yet
+                            @endif
+                        </div>
+                        <button
+                            type="button"
+                            wire:click="refreshCurrentConversionLinks"
+                            wire:loading.attr="disabled"
+                            wire:target="refreshCurrentConversionLinks"
+                            class="inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-white"
+                        >
+                            Refresh Current Links
+                        </button>
+                    </div>
+                </div>
+
+                <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+                    <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                        <h5 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Current Live Links</h5>
+                        <div class="mt-4 space-y-4 text-sm">
+                            @foreach([
+                                'Household Quote' => $conversionLinks['current']['household_quote'],
+                                'Household Booking' => $conversionLinks['current']['household_booking'],
+                                'Vehicle Quote' => $conversionLinks['current']['vehicle_quote'],
+                                'Vehicle Booking' => $conversionLinks['current']['vehicle_booking'],
+                            ] as $label => $url)
+                                <div>
+                                    <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $label }}</div>
+                                    @if($url)
+                                        <a href="{{ $url }}" target="_blank" rel="noopener noreferrer" class="mt-1 block break-all font-medium text-blue-600 hover:underline dark:text-blue-400">
+                                            {{ $url }}
+                                        </a>
+                                    @else
+                                        <div class="mt-1 text-gray-500 dark:text-gray-400">Not detected</div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+
+                    <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                        <div class="flex items-center justify-between gap-3">
+                            <h5 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Target Links</h5>
+                            <button
+                                type="button"
+                                wire:click="saveConversionTargets"
+                                wire:loading.attr="disabled"
+                                wire:target="saveConversionTargets"
+                                class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                Save Targets
+                            </button>
+                        </div>
+
+                        <div class="mt-4 grid grid-cols-1 gap-4">
+                            <div>
+                                <label for="target_household_quote_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Household Quote</label>
+                                <input id="target_household_quote_url" type="url" wire:model.defer="targetHouseholdQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetHouseholdQuoteUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_household_booking_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Household Booking</label>
+                                <input id="target_household_booking_url" type="url" wire:model.defer="targetHouseholdBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetHouseholdBookingUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_vehicle_quote_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vehicle Quote</label>
+                                <input id="target_vehicle_quote_url" type="url" wire:model.defer="targetVehicleQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetVehicleQuoteUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_vehicle_booking_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vehicle Booking</label>
+                                <input id="target_vehicle_booking_url" type="url" wire:model.defer="targetVehicleBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetVehicleBookingUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -241,22 +241,22 @@
                         <div class="mt-4 grid grid-cols-1 gap-4">
                             <div>
                                 <label for="target_household_quote_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Household Quote</label>
-                                <input id="target_household_quote_url" type="url" wire:model.defer="targetHouseholdQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                <input id="target_household_quote_url" type="url" wire:model="targetHouseholdQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetHouseholdQuoteUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                             <div>
                                 <label for="target_household_booking_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Household Booking</label>
-                                <input id="target_household_booking_url" type="url" wire:model.defer="targetHouseholdBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                <input id="target_household_booking_url" type="url" wire:model="targetHouseholdBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetHouseholdBookingUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                             <div>
                                 <label for="target_vehicle_quote_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vehicle Quote</label>
-                                <input id="target_vehicle_quote_url" type="url" wire:model.defer="targetVehicleQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                <input id="target_vehicle_quote_url" type="url" wire:model="targetVehicleQuoteUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetVehicleQuoteUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                             <div>
                                 <label for="target_vehicle_booking_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vehicle Booking</label>
-                                <input id="target_vehicle_booking_url" type="url" wire:model.defer="targetVehicleBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                <input id="target_vehicle_booking_url" type="url" wire:model="targetVehicleBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetVehicleBookingUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                         </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,6 +4,7 @@ use App\Models\Domain;
 use App\Models\DomainTag;
 use App\Models\WebProperty;
 use App\Services\ManualSearchConsoleEvidenceImporter;
+use App\Services\PropertyConversionLinkScanner;
 use App\Services\SearchConsoleApiBundleCollector;
 use App\Services\SearchConsoleApiBundleImporter;
 use App\Services\SearchConsoleApiEnrichmentRefresher;
@@ -98,6 +99,65 @@ Artisan::command('fleet:sync-focus-domains {--dry-run : Only report the changes 
 
     return Command::SUCCESS;
 })->purpose('Attach the configured Fleet focus tag to the current Fleet domain list.');
+
+Artisan::command('fleet:scan-conversion-links {propertySlug? : Optional web property slug} {--dry-run : Report the links without persisting them}', function (PropertyConversionLinkScanner $scanner) {
+    $propertySlug = $this->argument('propertySlug');
+    $dryRun = (bool) $this->option('dry-run');
+
+    $query = WebProperty::query()
+        ->with(['primaryDomain', 'propertyDomains.domain']);
+
+    if (is_string($propertySlug) && $propertySlug !== '') {
+        $query->where('slug', $propertySlug);
+    } else {
+        $query->fleetFocus();
+    }
+
+    $properties = $query
+        ->orderBy('name')
+        ->get();
+
+    if ($properties->isEmpty()) {
+        $this->warn('No web properties matched the conversion-link scan scope.');
+
+        return Command::INVALID;
+    }
+
+    $scanned = 0;
+    $failed = 0;
+
+    foreach ($properties as $property) {
+        try {
+            $scan = $scanner->scanForProperty($property);
+
+            if (! $dryRun) {
+                $property->forceFill($scan)->save();
+            }
+
+            $this->info(sprintf(
+                '[%s] household quote=%s | household booking=%s | vehicle quote=%s | vehicle booking=%s',
+                $property->slug,
+                $scan['current_household_quote_url'] ?? 'n/a',
+                $scan['current_household_booking_url'] ?? 'n/a',
+                $scan['current_vehicle_quote_url'] ?? 'n/a',
+                $scan['current_vehicle_booking_url'] ?? 'n/a'
+            ));
+            $scanned++;
+        } catch (\Throwable $exception) {
+            $this->warn(sprintf('[%s] scan failed: %s', $property->slug, $exception->getMessage()));
+            $failed++;
+        }
+    }
+
+    $this->line(sprintf(
+        'Conversion link scan complete. Scanned [%d], failed [%d]%s.',
+        $scanned,
+        $failed,
+        $dryRun ? ' (dry run)' : ''
+    ));
+
+    return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+})->purpose('Scan live homepage navigation for current quote and booking links on Fleet properties.');
 
 Artisan::command('analytics:import-search-console-evidence {property : Web property slug} {path : Path to the Google Search Console page indexing export ZIP} {--captured-by= : Optional captured_by value}', function (ManualSearchConsoleEvidenceImporter $importer) {
     $propertyArgument = $this->argument('property');

--- a/routes/console.php
+++ b/routes/console.php
@@ -128,11 +128,9 @@ Artisan::command('fleet:scan-conversion-links {propertySlug? : Optional web prop
 
     foreach ($properties as $property) {
         try {
-            $scan = $scanner->scanForProperty($property);
-
-            if (! $dryRun) {
-                $property->forceFill($scan)->save();
-            }
+            $scan = $dryRun
+                ? $scanner->scanForProperty($property)
+                : $scanner->persistForProperty($property);
 
             $this->info(sprintf(
                 '[%s] household quote=%s | household booking=%s | vehicle quote=%s | vehicle booking=%s',

--- a/tests/Feature/FleetPropertiesListTest.php
+++ b/tests/Feature/FleetPropertiesListTest.php
@@ -247,6 +247,7 @@ class FleetPropertiesListTest extends TestCase
                 'slug' => sprintf('fleet-site-%02d', $index),
                 'name' => sprintf('Fleet Site %02d', $index),
                 'primary_domain_id' => $domain->id,
+                'priority' => null,
             ]);
 
             WebPropertyDomain::create([

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -54,6 +54,12 @@ class WebPropertyApiTest extends TestCase
             'platform' => 'Astro',
             'primary_domain_id' => $primaryDomain->id,
             'production_url' => 'https://moveroo.com.au',
+            'current_household_quote_url' => 'https://removalists.moveroo.com.au/quote/household',
+            'current_household_booking_url' => 'https://removalists.moveroo.com.au/booking/create',
+            'current_vehicle_quote_url' => 'https://cars.moveroo.com.au/quote/v2',
+            'target_household_quote_url' => 'https://quote.moveroo.com.au/household',
+            'target_vehicle_quote_url' => 'https://quote.moveroo.com.au/vehicle',
+            'conversion_links_scanned_at' => now(),
         ]);
 
         WebPropertyDomain::create([
@@ -183,6 +189,12 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.deployment_provider', 'vercel')
             ->assertJsonPath('web_properties.0.deployment_project_name', 'moveroo-website')
             ->assertJsonPath('web_properties.0.deployment_project_id', 'prj_moveroo123')
+            ->assertJsonPath('web_properties.0.conversion_links.current.household_quote', 'https://removalists.moveroo.com.au/quote/household')
+            ->assertJsonPath('web_properties.0.conversion_links.current.household_booking', 'https://removalists.moveroo.com.au/booking/create')
+            ->assertJsonPath('web_properties.0.conversion_links.current.vehicle_quote', 'https://cars.moveroo.com.au/quote/v2')
+            ->assertJsonPath('web_properties.0.conversion_links.current.vehicle_booking', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.household_quote', 'https://quote.moveroo.com.au/household')
+            ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_quote', 'https://quote.moveroo.com.au/vehicle')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\WebPropertyDetail;
+use App\Models\Domain;
+use App\Models\DomainTag;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class WebPropertyConversionLinksTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_property_detail_can_save_target_conversion_links(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'moveroo-website'])
+            ->set('targetHouseholdQuoteUrl', 'https://quote.moveroo.com.au/household')
+            ->set('targetHouseholdBookingUrl', 'https://quote.moveroo.com.au/booking')
+            ->set('targetVehicleQuoteUrl', 'https://quote.moveroo.com.au/vehicle')
+            ->set('targetVehicleBookingUrl', 'https://quote.moveroo.com.au/vehicle-booking')
+            ->call('saveConversionTargets')
+            ->assertHasNoErrors();
+
+        $property->refresh();
+
+        $this->assertSame('https://quote.moveroo.com.au/household', $property->target_household_quote_url);
+        $this->assertSame('https://quote.moveroo.com.au/booking', $property->target_household_booking_url);
+        $this->assertSame('https://quote.moveroo.com.au/vehicle', $property->target_vehicle_quote_url);
+        $this->assertSame('https://quote.moveroo.com.au/vehicle-booking', $property->target_vehicle_booking_url);
+    }
+
+    public function test_property_detail_can_refresh_current_conversion_links_from_live_navigation(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://moveroo.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://moveroo.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://removalists.moveroo.com.au/quote/household">Moving Quote</a>
+                            <a href="https://cars.moveroo.com.au/quote/v2">Vehicle Transport Quote</a>
+                            <a href="https://removalists.moveroo.com.au/booking/create">Book Your Move</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'moveroo-website'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertHasNoErrors();
+
+        $property->refresh();
+
+        $this->assertSame('https://removalists.moveroo.com.au/quote/household', $property->current_household_quote_url);
+        $this->assertSame('https://removalists.moveroo.com.au/booking/create', $property->current_household_booking_url);
+        $this->assertSame('https://cars.moveroo.com.au/quote/v2', $property->current_vehicle_quote_url);
+        $this->assertNull($property->current_vehicle_booking_url);
+        $this->assertNotNull($property->conversion_links_scanned_at);
+    }
+
+    public function test_fleet_scan_conversion_links_command_persists_detected_links(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'wemove.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'wemove-com-au',
+            'name' => 'wemove.com.au',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://wemove.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://wemove.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <nav>
+                            <a href="https://wemove.moveroo.com.au/">Quote Page</a>
+                            <a href="https://wemove.moveroo.com.au/bookings">Book Removalists</a>
+                            <a href="https://vehicles.moveroo.com.au">Car Transport Quote</a>
+                        </nav>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:scan-conversion-links'));
+
+        $property->refresh();
+
+        $this->assertSame('https://wemove.moveroo.com.au/', $property->current_household_quote_url);
+        $this->assertSame('https://wemove.moveroo.com.au/bookings', $property->current_household_booking_url);
+        $this->assertSame('https://vehicles.moveroo.com.au', $property->current_vehicle_quote_url);
+        $this->assertNull($property->current_vehicle_booking_url);
+    }
+}

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -340,6 +340,55 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertNull($property->current_vehicle_quote_url);
     }
 
+    public function test_fleet_scan_conversion_links_does_not_clear_existing_values_when_homepage_redirects(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://moveroo.com.au',
+            'current_household_quote_url' => 'https://removalists.moveroo.com.au/quote/household',
+            'current_household_booking_url' => 'https://removalists.moveroo.com.au/booking/create',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://moveroo.com.au' => Http::response('', 302, [
+                'Location' => 'https://www.moveroo.com.au',
+            ]),
+        ]);
+
+        $this->assertSame(1, Artisan::call('fleet:scan-conversion-links', ['propertySlug' => 'moveroo-website']));
+
+        $property->refresh();
+
+        $this->assertSame('https://removalists.moveroo.com.au/quote/household', $property->current_household_quote_url);
+        $this->assertSame('https://removalists.moveroo.com.au/booking/create', $property->current_household_booking_url);
+    }
+
     public function test_fleet_scan_conversion_links_does_not_treat_facebook_as_a_booking_link(): void
     {
         config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -56,6 +56,37 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://quote.moveroo.com.au/vehicle-booking', $property->target_vehicle_booking_url);
     }
 
+    public function test_property_detail_can_clear_target_conversion_links(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+            'target_household_quote_url' => 'https://quote.moveroo.com.au/household',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'moveroo-website'])
+            ->set('targetHouseholdQuoteUrl', '   ')
+            ->call('saveConversionTargets')
+            ->assertHasNoErrors();
+
+        $this->assertNull($property->fresh()->target_household_quote_url);
+    }
+
     public function test_property_detail_can_refresh_current_conversion_links_from_live_navigation(): void
     {
         $user = User::factory()->create();
@@ -104,6 +135,43 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://cars.moveroo.com.au/quote/v2', $property->current_vehicle_quote_url);
         $this->assertNull($property->current_vehicle_booking_url);
         $this->assertNotNull($property->conversion_links_scanned_at);
+    }
+
+    public function test_property_detail_rejects_mutations_for_unauthorized_users_outside_local_env(): void
+    {
+        $originalEnvironment = $this->app['env'];
+        $this->app['env'] = 'production';
+
+        config()->set('domain_monitor.property_mutation_emails', ['allowed@example.com']);
+
+        $user = User::factory()->create(['email' => 'blocked@example.com']);
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        try {
+            Livewire::actingAs($user)
+                ->test(WebPropertyDetail::class, ['propertySlug' => 'moveroo-website'])
+                ->set('targetHouseholdQuoteUrl', 'https://quote.moveroo.com.au/household')
+                ->call('saveConversionTargets')
+                ->assertForbidden();
+        } finally {
+            $this->app['env'] = $originalEnvironment;
+        }
     }
 
     public function test_fleet_scan_conversion_links_command_persists_detected_links(): void
@@ -161,5 +229,114 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://wemove.moveroo.com.au/bookings', $property->current_household_booking_url);
         $this->assertSame('https://vehicles.moveroo.com.au', $property->current_vehicle_quote_url);
         $this->assertNull($property->current_vehicle_booking_url);
+    }
+
+    public function test_fleet_scan_conversion_links_prefers_primary_domain_over_non_root_production_url(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'backloadingremovals.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloadingremovals-com-au',
+            'name' => 'backloadingremovals.com.au',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://mymovehub.backloadingremovals.com.au/booking/create',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://backloadingremovals.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymovehub.backloadingremovals.com.au/quote/household">Moving Furniture &amp; boxes</a>
+                            <a href="https://mymovehub.backloadingremovals.com.au/booking/create">Book Your Move</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://mymovehub.backloadingremovals.com.au/booking/create' => Http::response('<html><body>No nav</body></html>'),
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:scan-conversion-links', ['propertySlug' => 'backloadingremovals-com-au']));
+
+        $property->refresh();
+
+        $this->assertSame('https://mymovehub.backloadingremovals.com.au/quote/household', $property->current_household_quote_url);
+        $this->assertSame('https://mymovehub.backloadingremovals.com.au/booking/create', $property->current_household_booking_url);
+    }
+
+    public function test_fleet_scan_conversion_links_keeps_previous_values_when_a_bucket_is_missing(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moving-again',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://movingagain.com.au',
+            'current_vehicle_quote_url' => 'https://cartransport.movingagain.com.au/quote',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://movingagain.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://removalistquotes.movingagain.com.au/quote/household">Get a Quote</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:scan-conversion-links', ['propertySlug' => 'moving-again']));
+
+        $property->refresh();
+
+        $this->assertSame('https://removalistquotes.movingagain.com.au/quote/household', $property->current_household_quote_url);
+        $this->assertSame('https://cartransport.movingagain.com.au/quote', $property->current_vehicle_quote_url);
     }
 }

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -339,4 +339,58 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://removalistquotes.movingagain.com.au/quote/household', $property->current_household_quote_url);
         $this->assertSame('https://cartransport.movingagain.com.au/quote', $property->current_vehicle_quote_url);
     }
+
+    public function test_fleet_scan_conversion_links_does_not_treat_facebook_as_a_booking_link(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-website',
+            'name' => 'Moveroo Website',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://moveroo.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://moveroo.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://facebook.com/moveroo">Facebook</a>
+                            <a href="https://removalists.moveroo.com.au/quote/household">Moving Quote</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:scan-conversion-links', ['propertySlug' => 'moveroo-website']));
+
+        $property->refresh();
+
+        $this->assertSame('https://removalists.moveroo.com.au/quote/household', $property->current_household_quote_url);
+        $this->assertNull($property->current_household_booking_url);
+    }
 }

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -286,7 +286,7 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://mymovehub.backloadingremovals.com.au/booking/create', $property->current_household_booking_url);
     }
 
-    public function test_fleet_scan_conversion_links_keeps_previous_values_when_a_bucket_is_missing(): void
+    public function test_fleet_scan_conversion_links_clears_previous_values_when_a_bucket_is_missing(): void
     {
         config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
 
@@ -337,7 +337,7 @@ class WebPropertyConversionLinksTest extends TestCase
         $property->refresh();
 
         $this->assertSame('https://removalistquotes.movingagain.com.au/quote/household', $property->current_household_quote_url);
-        $this->assertSame('https://cartransport.movingagain.com.au/quote', $property->current_vehicle_quote_url);
+        $this->assertNull($property->current_vehicle_quote_url);
     }
 
     public function test_fleet_scan_conversion_links_does_not_treat_facebook_as_a_booking_link(): void

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -135,6 +135,8 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('Car transport by Moving Again');
         $response->assertSee('not detected');
         $response->assertSee('No Matomo snippet detected.');
+        $response->assertSee('Conversion Links');
+        $response->assertSee('Target Links');
         $response->assertSee('Automation Checklist');
         $response->assertSee('Needs Matomo');
     }


### PR DESCRIPTION
## Summary
- add current and target conversion-link fields to web properties and expose them through the property summary API
- add a live scanner service and `fleet:scan-conversion-links` command to detect current nav/header quote and booking links
- add a conversion-links section to the property detail page with current live links plus editable future target links

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyConversionLinksTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Livewire/WebPropertyDetail.php app/Services/PropertyConversionLinkScanner.php routes/console.php tests/Feature/WebPropertyConversionLinksTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
