### PR TITLE
Guarantee weekly GSC API refresh coverage

### DIFF
--- a/app/Services/SearchConsoleApiEnrichmentRefresher.php
+++ b/app/Services/SearchConsoleApiEnrichmentRefresher.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use RuntimeException;
 
@@ -114,6 +115,19 @@ class SearchConsoleApiEnrichmentRefresher
         ];
     }
 
+    public function recommendedBatchLimit(int $staleDays = 7, int $minimumBatchLimit = 1): int
+    {
+        $eligibleCount = $this->eligibleProperties()->count();
+        $days = max(1, $staleDays);
+        $minimum = max(1, $minimumBatchLimit);
+
+        if ($eligibleCount === 0) {
+            return $minimum;
+        }
+
+        return max($minimum, (int) ceil($eligibleCount / $days));
+    }
+
     /**
      * @return Collection<int, WebProperty>
      */
@@ -121,10 +135,8 @@ class SearchConsoleApiEnrichmentRefresher
     {
         $staleCutoff = now()->subDays(max(1, $staleDays));
 
-        $properties = WebProperty::query()
-            ->where('status', 'active')
-            ->where('property_type', '!=', 'domain_asset')
-            ->whereHas('searchConsoleIssueSnapshots', fn ($query) => $query->where('capture_method', 'gsc_drilldown_zip'))
+        /** @var Collection<int, WebProperty> $properties */
+        $properties = $this->eligibleProperties()
             ->with([
                 'primaryDomain.tags',
                 'analyticsSources.latestSearchConsoleCoverage',
@@ -174,6 +186,17 @@ class SearchConsoleApiEnrichmentRefresher
             ])
             ->take(max(1, $batchLimit))
             ->values();
+    }
+
+    /**
+     * @return Builder<WebProperty>
+     */
+    private function eligibleProperties(): Builder
+    {
+        return WebProperty::query()
+            ->where('status', 'active')
+            ->where('property_type', '!=', 'domain_asset')
+            ->whereHas('searchConsoleIssueSnapshots', fn ($query) => $query->where('capture_method', 'gsc_drilldown_zip'));
     }
 
     private function normalizeCapturedAt(mixed $value): ?\Illuminate\Support\Carbon

--- a/routes/console.php
+++ b/routes/console.php
@@ -448,9 +448,10 @@ Artisan::command('analytics:refresh-search-console-api-enrichment {--capture-met
     $staleDays = is_numeric($staleDaysOption)
         ? (int) $staleDaysOption
         : max(1, (int) config('services.google.search_console.api_refresh_stale_days', 7));
+    $configuredBatchLimit = max(1, (int) config('services.google.search_console.api_refresh_batch_limit', 3));
     $batchLimit = is_numeric($limitOption)
         ? (int) $limitOption
-        : max(1, (int) config('services.google.search_console.api_refresh_batch_limit', 3));
+        : $refresher->recommendedBatchLimit($staleDays, $configuredBatchLimit);
     $captureMethod = is_string($captureMethodOption) && $captureMethodOption !== ''
         ? $captureMethodOption
         : 'gsc_api';

--- a/tests/Feature/RefreshSearchConsoleApiEnrichmentCommandTest.php
+++ b/tests/Feature/RefreshSearchConsoleApiEnrichmentCommandTest.php
@@ -169,6 +169,49 @@ class RefreshSearchConsoleApiEnrichmentCommandTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_it_expands_the_default_batch_limit_to_cover_eligible_properties_within_a_week(): void
+    {
+        config()->set('services.google.search_console.access_token', null);
+        config()->set('services.google.search_console.refresh_token', 'test-refresh-token');
+        config()->set('services.google.search_console.client_id', 'test-client-id');
+        config()->set('services.google.search_console.client_secret', 'test-client-secret');
+        config()->set('services.google.search_console.api_refresh_stale_days', 7);
+        config()->set('services.google.search_console.api_refresh_batch_limit', 3);
+
+        foreach (range(1, 22) as $index) {
+            $property = $this->makeProperty(
+                sprintf('weekly-coverage-%02d', $index),
+                sprintf('weekly-%02d.example.au', $index),
+                (string) (200 + $index),
+            );
+
+            SearchConsoleIssueSnapshot::factory()->create([
+                'domain_id' => $property->primaryDomainModel()?->id,
+                'web_property_id' => $property->id,
+                'issue_class' => 'page_with_redirect_in_sitemap',
+                'capture_method' => 'gsc_drilldown_zip',
+                'affected_url_count' => 1,
+                'sample_urls' => ['https://'.$property->primaryDomainName().'/old-page/'],
+                'examples' => [
+                    ['url' => 'https://'.$property->primaryDomainName().'/old-page/', 'last_crawled' => '2026-03-28'],
+                ],
+                'normalized_payload' => [
+                    'affected_urls' => ['https://'.$property->primaryDomainName().'/old-page/'],
+                ],
+            ]);
+        }
+
+        Http::fake();
+
+        $exitCode = Artisan::call('analytics:refresh-search-console-api-enrichment', [
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Listed 4 of 4 candidate properties', Artisan::output());
+        Http::assertNothingSent();
+    }
+
     public function test_it_rejects_an_invalid_capture_method_before_processing_properties(): void
     {
         Http::fake();


### PR DESCRIPTION
## Summary
- auto-size the default Search Console API refresh batch to cover all eligible properties within the stale window
- keep manual --limit overrides working as before
- add regression coverage proving weekly coverage scales beyond the old fixed batch of 3

## Testing
- ./vendor/bin/phpunit tests/Feature/RefreshSearchConsoleApiEnrichmentCommandTest.php
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleApiEnrichmentRefresher.php routes/console.php tests/Feature/RefreshSearchConsoleApiEnrichmentCommandTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
