### PR TITLE
Allow selected repo-controlled Fleet properties

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -347,12 +347,35 @@ class WebProperty extends Model
         return [
             'control_state' => 'controlled',
             'execution_surface' => $executionSurface,
-            'fleet_managed' => in_array($executionSurface, [
-                'fleet_wordpress_controlled',
-                'astro_repo_controlled',
-            ], true),
+            'fleet_managed' => $this->isFleetManagedExecutionSurface($executionSurface),
             ...$controllerRepositorySummary,
         ];
+    }
+
+    public function isFleetManagedExecutionSurface(?string $executionSurface): bool
+    {
+        if (! is_string($executionSurface) || $executionSurface === '') {
+            return false;
+        }
+
+        if (in_array($executionSurface, ['fleet_wordpress_controlled', 'astro_repo_controlled'], true)) {
+            return true;
+        }
+
+        if ($executionSurface !== 'repository_controlled') {
+            return false;
+        }
+
+        $domain = $this->primaryDomainName();
+        $configuredAllowlist = config('domain_monitor.fleet_focus.repository_controlled_domains', []);
+        $allowlist = is_array($configuredAllowlist)
+            ? array_values(array_map(
+                static fn (string $value): string => strtolower($value),
+                array_filter($configuredAllowlist, static fn (mixed $value): bool => is_string($value) && $value !== '')
+            ))
+            : [];
+
+        return is_string($domain) && in_array(strtolower($domain), $allowlist, true);
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -596,10 +596,7 @@ class DashboardIssueQueueService
         return [
             'control_state' => 'controlled',
             'execution_surface' => $executionSurface,
-            'fleet_managed' => in_array($executionSurface, [
-                'fleet_wordpress_controlled',
-                'astro_repo_controlled',
-            ], true),
+            'fleet_managed' => $property?->isFleetManagedExecutionSurface($executionSurface) ?? false,
             ...$controllerRepositorySummary,
         ];
     }

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -40,6 +40,9 @@ return [
             'vehicle.net.au',
             'wemove.com.au',
         ],
+        'repository_controlled_domains' => [
+            'transportnondrivablecars.com.au',
+        ],
     ],
 
     /*

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -600,4 +600,81 @@ class DetectedIssueApiTest extends TestCase
         $this->assertNull($issue['execution_surface']);
         $this->assertFalse($issue['fleet_managed']);
     }
+
+    public function test_issues_endpoint_can_mark_allowlisted_repository_controlled_property_as_fleet_managed(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('domain_monitor.fleet_focus.repository_controlled_domains', [
+            'transportnondrivablecars.com.au',
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'transportnondrivablecars.com.au',
+            'is_active' => true,
+            'platform' => 'Custom PHP',
+            'hosting_provider' => 'Synergy Wholesale PTY',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'transportnondrivablecars-com-au',
+            'name' => 'transportnondrivablecars.com.au',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'transportnondrivablecars-com-au-php',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/iamjasonhill/transportnondrivablecars-com-au-php',
+            'local_path' => '/Users/jasonhill/Projects/websites/transportnondrivablecars-com-au-php',
+            'framework' => 'Custom PHP',
+            'is_primary' => true,
+            'is_controller' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'source_provider' => 'matomo',
+            'captured_at' => now(),
+            'matomo_site_id' => '2',
+            'search_console_property_uri' => 'sc-domain:transportnondrivablecars.com.au',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.3,
+            'indexed_pages' => 20,
+            'not_indexed_pages' => 5,
+            'pages_with_redirect' => 3,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => 3]]],
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
+            ->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('property_slug', 'transportnondrivablecars-com-au');
+
+        $this->assertNotNull($issue);
+        $this->assertSame('controlled', $issue['control_state']);
+        $this->assertSame('repository_controlled', $issue['execution_surface']);
+        $this->assertTrue($issue['fleet_managed']);
+        $this->assertSame('transportnondrivablecars-com-au-php', $issue['controller_repo']);
+    }
 }

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -567,6 +567,58 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.fleet_managed', true);
     }
 
+    public function test_web_properties_summary_can_mark_allowlisted_repository_controlled_property_as_fleet_managed(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('domain_monitor.fleet_focus.repository_controlled_domains', [
+            'transportnondrivablecars.com.au',
+        ]);
+
+        $domain = Domain::factory()->create([
+            'domain' => 'transportnondrivablecars.com.au',
+            'platform' => 'Custom PHP',
+            'hosting_provider' => 'Synergy Wholesale PTY',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'transportnondrivablecars-com-au',
+            'name' => 'transportnondrivablecars.com.au',
+            'property_type' => 'website',
+            'status' => 'active',
+            'platform' => 'Custom PHP',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'transportnondrivablecars-com-au-php',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/iamjasonhill/transportnondrivablecars-com-au-php',
+            'local_path' => '/Users/jasonhill/Projects/websites/transportnondrivablecars-com-au-php',
+            'framework' => 'Custom PHP',
+            'is_primary' => true,
+            'is_controller' => true,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'transportnondrivablecars-com-au')
+            ->assertJsonPath('web_properties.0.execution_surface', 'repository_controlled')
+            ->assertJsonPath('web_properties.0.fleet_managed', true)
+            ->assertJsonPath('web_properties.0.controller_repo', 'transportnondrivablecars-com-au-php');
+    }
+
     public function test_web_properties_summary_surfaces_property_level_gsc_issue_detail_coverage(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- treat allowlisted repo-controlled properties as Fleet-managed in both the queue and property summary
- start the allowlist with transportnondrivablecars.com.au while leaving removalist.net outside Fleet ownership
- add regressions for both /api/web-properties-summary and /api/issues

## Testing
- ./vendor/bin/phpunit tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Services/DashboardIssueQueueService.php config/domain_monitor.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
