### PR TITLE
Add detected issue verification writeback

### DIFF
--- a/app/Http/Controllers/Api/DetectedIssueVerificationController.php
+++ b/app/Http/Controllers/Api/DetectedIssueVerificationController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\DetectedIssueSummaryService;
+use App\Services\DetectedIssueVerificationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\ValidationException;
+
+class DetectedIssueVerificationController extends Controller
+{
+    public function store(
+        string $issueId,
+        Request $request,
+        DetectedIssueSummaryService $issueSummaryService,
+        DetectedIssueVerificationService $verificationService,
+    ): JsonResponse {
+        $issue = $issueSummaryService->find($issueId);
+
+        if ($issue === null) {
+            return response()->json(['error' => 'Not found'], 404);
+        }
+
+        $validated = $request->validate([
+            'status' => 'required|string|in:verified_fixed_pending_recrawl',
+            'hidden_until' => 'nullable|date|after:now',
+            'verification_notes' => 'nullable|array',
+            'verification_notes.*' => 'string|max:500',
+        ]);
+
+        $hiddenUntil = isset($validated['hidden_until'])
+            ? Carbon::parse((string) $validated['hidden_until'])
+            : null;
+        $maxHiddenUntil = now()->addDays(14);
+
+        if ($hiddenUntil !== null && $hiddenUntil->gt($maxHiddenUntil)) {
+            throw ValidationException::withMessages([
+                'hidden_until' => ['The hidden_until value may not be more than 14 days in the future.'],
+            ]);
+        }
+
+        if ($hiddenUntil === null && $validated['status'] === 'verified_fixed_pending_recrawl') {
+            $hiddenUntil = $maxHiddenUntil;
+        }
+
+        $verification = $verificationService->record($issueId, [
+            'status' => $validated['status'],
+            'hidden_until' => $hiddenUntil?->toIso8601String(),
+            'verification_source' => $this->verificationSource($request),
+            'verification_notes' => $validated['verification_notes'] ?? [],
+        ], $issue);
+
+        return response()->json([
+            'success' => true,
+            'issue_id' => $issueId,
+            'status' => $verification->status,
+            'hidden_until' => $verification->hidden_until?->toIso8601String(),
+            'verification_source' => $verification->verification_source,
+            'verification_notes' => $verification->verification_notes ?? [],
+            'verified_at' => $verification->verified_at->toIso8601String(),
+        ], 201);
+    }
+
+    private function verificationSource(Request $request): string
+    {
+        return match ($request->attributes->get('authenticated_api_client')) {
+            'fleet_control' => 'fleet-control',
+            default => 'external-api',
+        };
+    }
+}

--- a/app/Http/Controllers/Api/IntegrationMetaController.php
+++ b/app/Http/Controllers/Api/IntegrationMetaController.php
@@ -41,6 +41,15 @@ class IntegrationMetaController extends Controller
                     'purpose' => 'detected issue detail',
                 ],
                 [
+                    'path' => '/api/issues/{issue_id}/verification',
+                    'source_system' => 'domain-monitor-issues',
+                    'contract_version' => 1,
+                    'purpose' => 'issue verification writeback for queue suppression and pending recrawl',
+                    'method' => 'POST',
+                    'accepted_tokens' => ['FLEET_CONTROL_API_KEY'],
+                    'optional' => true,
+                ],
+                [
                     'path' => '/api/dashboard/priority-queue',
                     'source_system' => 'domain-monitor-priority-queue',
                     'contract_version' => 2,

--- a/app/Http/Middleware/AuthenticateApiKey.php
+++ b/app/Http/Middleware/AuthenticateApiKey.php
@@ -27,16 +27,16 @@ class AuthenticateApiKey
 
         $token = substr($authHeader, 7); // Remove 'Bearer ' prefix
 
-        // Get allowed API keys from config
-        // These are the keys that external services (Brain, Website Ops) use to authenticate
         $allowedKeys = [
-            config('services.domain_monitor.brain_api_key'),
-            config('services.domain_monitor.ops_api_key'),
-            config('services.domain_monitor.fleet_control_api_key'),
+            'brain' => config('services.domain_monitor.brain_api_key'),
+            'ops' => config('services.domain_monitor.ops_api_key'),
+            'fleet_control' => config('services.domain_monitor.fleet_control_api_key'),
         ];
 
-        // Filter out empty values
-        $allowedKeys = array_filter($allowedKeys);
+        $allowedKeys = array_filter(
+            $allowedKeys,
+            static fn (mixed $allowedKey): bool => is_string($allowedKey) && $allowedKey !== ''
+        );
 
         if (empty($allowedKeys)) {
             Log::warning('API key authentication attempted but no API keys configured');
@@ -47,16 +47,16 @@ class AuthenticateApiKey
             ], 500);
         }
 
-        $isAuthenticated = false;
-        foreach ($allowedKeys as $allowedKey) {
-            if (is_string($allowedKey) && hash_equals($allowedKey, $token)) {
-                $isAuthenticated = true;
+        $authenticatedClient = null;
+        foreach ($allowedKeys as $client => $allowedKey) {
+            if (hash_equals($allowedKey, $token)) {
+                $authenticatedClient = $client;
                 break;
             }
         }
 
         // Check if the provided token matches any allowed key
-        if (! $isAuthenticated) {
+        if ($authenticatedClient === null) {
             Log::warning('Invalid API key authentication attempt', [
                 'ip' => $request->ip(),
                 'path' => $request->path(),
@@ -72,7 +72,10 @@ class AuthenticateApiKey
         Log::debug('API key authentication successful', [
             'ip' => $request->ip(),
             'path' => $request->path(),
+            'client' => $authenticatedClient,
         ]);
+
+        $request->attributes->set('authenticated_api_client', $authenticatedClient);
 
         return $next($request);
     }

--- a/app/Http/Middleware/RequireFleetControlApiKey.php
+++ b/app/Http/Middleware/RequireFleetControlApiKey.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireFleetControlApiKey
+{
+    /**
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->attributes->get('authenticated_api_client') !== 'fleet_control') {
+            return response()->json([
+                'error' => 'Forbidden',
+                'message' => 'Fleet control authentication is required for this action',
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/DetectedIssueVerification.php
+++ b/app/Models/DetectedIssueVerification.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+/**
+ * @property string $id
+ * @property string $issue_id
+ * @property string|null $property_slug
+ * @property string|null $domain
+ * @property string|null $issue_class
+ * @property string $status
+ * @property \Illuminate\Support\Carbon|null $hidden_until
+ * @property string|null $verification_source
+ * @property array<int, string>|null $verification_notes
+ * @property \Illuminate\Support\Carbon $verified_at
+ */
+class DetectedIssueVerification extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'issue_id',
+        'property_slug',
+        'domain',
+        'issue_class',
+        'status',
+        'hidden_until',
+        'verification_source',
+        'verification_notes',
+        'verified_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'hidden_until' => 'datetime',
+            'verification_notes' => 'array',
+            'verified_at' => 'datetime',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $verification): void {
+            if (empty($verification->id)) {
+                $verification->id = Str::uuid()->toString();
+            }
+        });
+    }
+}

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -12,6 +12,11 @@ use Illuminate\Support\Str;
 
 class DashboardIssueQueueService
 {
+    public function __construct(
+        private readonly DetectedIssueIdentityService $issueIdentityService,
+        private readonly DetectedIssueVerificationService $issueVerificationService,
+    ) {}
+
     /**
      * @return array<string, mixed>
      */
@@ -54,6 +59,9 @@ class DashboardIssueQueueService
             ->get();
 
         [$mustFixDomains, $shouldFixDomains] = $this->buildIssueQueues($domains);
+        [$mustFixDomains, $shouldFixDomains] = $this->applyIssueVerificationQueues(
+            $mustFixDomains->concat($shouldFixDomains)
+        );
 
         $stats['must_fix'] = $mustFixDomains->count();
         $stats['should_fix'] = $shouldFixDomains->count();
@@ -68,6 +76,209 @@ class DashboardIssueQueueService
             'should_fix' => $shouldFixDomains->all(),
             'derived' => $this->buildDerivedSummary($mustFixDomains, $shouldFixDomains),
         ];
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $items
+     * @return array{0: Collection<int, array<string, mixed>>, 1: Collection<int, array<string, mixed>>}
+     */
+    private function applyIssueVerificationQueues(Collection $items): array
+    {
+        if ($items->isEmpty()) {
+            return [collect(), collect()];
+        }
+
+        $issueIds = [];
+
+        foreach ($items as $item) {
+            $domainId = (string) ($item['id'] ?? '');
+            $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+
+            foreach ((array) ($item['issue_entries'] ?? []) as $entry) {
+                $issueFamily = is_string($entry['issue_family'] ?? null) ? $entry['issue_family'] : null;
+
+                if ($issueFamily === null) {
+                    continue;
+                }
+
+                $issueIds[] = $this->issueIdentityService->makeIssueId($domainId, $propertySlug, $issueFamily);
+            }
+        }
+
+        $verificationMap = $this->issueVerificationService->latestMapForIssueIds($issueIds);
+        $mustFix = collect();
+        $shouldFix = collect();
+        $sorter = fn (array $left, array $right): int => ($right['primary_reason_count'] <=> $left['primary_reason_count'])
+            ?: ($right['secondary_reason_count'] <=> $left['secondary_reason_count'])
+            ?: (strtotime($right['updated_at_iso']) <=> strtotime($left['updated_at_iso']));
+
+        foreach ($items as $item) {
+            $filteredItem = $this->filterVerifiedIssueEntries($item, $verificationMap);
+
+            if ($filteredItem === null) {
+                continue;
+            }
+
+            $queueBucket = is_string($filteredItem['queue_bucket'] ?? null) ? $filteredItem['queue_bucket'] : 'must_fix';
+            unset($filteredItem['queue_bucket']);
+
+            if ($queueBucket === 'must_fix') {
+                if ((int) $filteredItem['primary_reason_count'] > 0) {
+                    $mustFix->push($filteredItem);
+
+                    continue;
+                }
+
+                if ((int) $filteredItem['secondary_reason_count'] > 0) {
+                    $shouldFix->push($filteredItem);
+                }
+
+                continue;
+            }
+
+            if ((int) $filteredItem['primary_reason_count'] > 0 || (int) $filteredItem['secondary_reason_count'] > 0) {
+                $shouldFix->push($filteredItem);
+            }
+        }
+
+        return [
+            $mustFix->sort($sorter)->values(),
+            $shouldFix->sort($sorter)->values(),
+        ];
+    }
+
+    /**
+     * @param  array<string, \App\Models\DetectedIssueVerification>  $verificationMap
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>|null
+     */
+    private function filterVerifiedIssueEntries(array $item, array $verificationMap): ?array
+    {
+        $domainId = (string) ($item['id'] ?? '');
+        $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+        $visiblePrimaryRecords = [];
+        $visibleSecondaryRecords = [];
+
+        foreach ((array) ($item['primary_issue_records'] ?? []) as $record) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap)) {
+                $visiblePrimaryRecords[] = $record;
+            }
+        }
+
+        foreach ((array) ($item['secondary_issue_records'] ?? []) as $record) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap)) {
+                $visibleSecondaryRecords[] = $record;
+            }
+        }
+
+        $visibleRecordKeys = array_flip(array_map(
+            fn (array $record): string => $this->issueRecordKey($record),
+            array_merge($visiblePrimaryRecords, $visibleSecondaryRecords)
+        ));
+        $visibleEntries = array_values(array_filter(
+            (array) ($item['issue_entries'] ?? []),
+            fn (array $entry): bool => isset($visibleRecordKeys[$this->issueRecordKey($entry)])
+        ));
+
+        if ($visibleEntries === []) {
+            return null;
+        }
+
+        if ($visiblePrimaryRecords === [] && $visibleSecondaryRecords === []) {
+            return null;
+        }
+
+        $canonicalIssue = $visibleEntries[0] ?? null;
+
+        $item['primary_issue_records'] = $visiblePrimaryRecords;
+        $item['secondary_issue_records'] = $visibleSecondaryRecords;
+        $item['issue_entries'] = $visibleEntries;
+        $item['primary_reasons'] = array_map(
+            static fn (array $record): string => $record['reason'],
+            $visiblePrimaryRecords
+        );
+        $item['secondary_reasons'] = array_map(
+            static fn (array $record): string => $record['reason'],
+            $visibleSecondaryRecords
+        );
+        $item['primary_reason_count'] = count($visiblePrimaryRecords);
+        $item['secondary_reason_count'] = count($visibleSecondaryRecords);
+        $item['issue_family'] = is_array($canonicalIssue) ? $canonicalIssue['issue_family'] : null;
+        $item['control_id'] = is_array($canonicalIssue) ? $canonicalIssue['control_id'] : null;
+        $item['rollout_scope'] = is_array($canonicalIssue) ? $canonicalIssue['rollout_scope'] : 'domain_only';
+        $item['baseline_surface'] = is_array($canonicalIssue) ? $canonicalIssue['baseline_surface'] : null;
+        $item['issue_families'] = array_unique(array_map(
+            static fn (array $entry): string => $entry['issue_family'],
+            $visibleEntries
+        ));
+        $item['primary_issue_families'] = array_unique(array_map(
+            static fn (array $record): string => $record['issue_family'],
+            $visiblePrimaryRecords
+        ));
+        $item['secondary_issue_families'] = array_unique(array_map(
+            static fn (array $record): string => $record['issue_family'],
+            $visibleSecondaryRecords
+        ));
+        $item['is_standard_gap'] = ($item['rollout_scope'] ?? 'domain_only') === 'fleet';
+        unset($item['baseline_captured_at']);
+
+        return $item;
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     * @param  array<string, mixed>  $item
+     * @param  array<string, \App\Models\DetectedIssueVerification>  $verificationMap
+     */
+    private function shouldKeepVerifiedRecord(
+        array $record,
+        array $item,
+        string $domainId,
+        ?string $propertySlug,
+        array $verificationMap
+    ): bool {
+        $issueFamily = is_string($record['issue_family'] ?? null) ? $record['issue_family'] : null;
+
+        if ($issueFamily === null) {
+            return false;
+        }
+
+        $issueId = $this->issueIdentityService->makeIssueId($domainId, $propertySlug, $issueFamily);
+        $verification = $verificationMap[$issueId] ?? null;
+        $issue = [
+            'issue_id' => $issueId,
+            'detected_at' => is_string($item['updated_at_iso'] ?? null) ? $item['updated_at_iso'] : null,
+            'evidence' => [
+                'captured_at' => $this->queueIssueObservedAt($item, $issueFamily),
+            ],
+        ];
+
+        return ! ($verification instanceof \App\Models\DetectedIssueVerification
+            && $this->issueVerificationService->isCurrentlySuppressed($issue, $verification));
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    private function issueRecordKey(array $record): string
+    {
+        $issueFamily = is_string($record['issue_family'] ?? null) ? $record['issue_family'] : null;
+        $reason = is_string($record['reason'] ?? null) ? $record['reason'] : '';
+        $severity = is_string($record['severity'] ?? null) ? $record['severity'] : '';
+
+        return sprintf('%s|%s|%s', $issueFamily, $severity, $reason);
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function queueIssueObservedAt(array $item, string $issueFamily): ?string
+    {
+        if (array_key_exists($issueFamily, config('domain_monitor.search_console_issue_catalog', []))) {
+            return is_string($item['baseline_captured_at'] ?? null) ? $item['baseline_captured_at'] : null;
+        }
+
+        return is_string($item['updated_at_iso'] ?? null) ? $item['updated_at_iso'] : null;
     }
 
     /**
@@ -97,6 +308,7 @@ class DashboardIssueQueueService
                     $domain,
                     $property,
                     $coverageStatus,
+                    'must_fix',
                     $mustFixReasons,
                     $shouldFixReasons,
                     $mustFixIssueRecords,
@@ -111,6 +323,7 @@ class DashboardIssueQueueService
                     $domain,
                     $property,
                     $coverageStatus,
+                    'should_fix',
                     $shouldFixReasons,
                     [],
                     $shouldFixIssueRecords,
@@ -331,11 +544,14 @@ class DashboardIssueQueueService
         Domain $domain,
         ?WebProperty $property,
         string $coverageStatus,
+        string $queueBucket,
         array $primaryReasons,
         array $secondaryReasons = [],
         array $primaryIssueRecords = [],
         array $secondaryIssueRecords = []
     ): array {
+        $baseline = $property?->latestPropertySeoBaselineRecord();
+
         return $this->enrichQueueItem($domain, $property, [
             'id' => $domain->id,
             'domain' => $domain->domain,
@@ -351,11 +567,13 @@ class DashboardIssueQueueService
             'secondary_reason_count' => count($secondaryReasons),
             'primary_issue_records' => $primaryIssueRecords,
             'secondary_issue_records' => $secondaryIssueRecords,
+            'queue_bucket' => $queueBucket,
             'coverage_required' => $this->requiresControlCoverage($domain, $property),
             'coverage_status' => $coverageStatus,
             'coverage_gap' => in_array($coverageStatus, ['missing_property', 'missing_repository', 'missing_local_path'], true),
             'updated_at_human' => $domain->updated_at?->diffForHumans(),
             'updated_at_iso' => $domain->updated_at?->toIso8601String() ?? now()->toIso8601String(),
+            'baseline_captured_at' => $baseline?->captured_at?->toIso8601String(),
         ]);
     }
 

--- a/app/Services/DetectedIssueIdentityService.php
+++ b/app/Services/DetectedIssueIdentityService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+class DetectedIssueIdentityService
+{
+    public function makeIssueId(string $domainId, ?string $propertySlug, string $issueClass): string
+    {
+        $issueIdentity = [
+            'source_domain_id' => $domainId,
+            'property_slug' => $propertySlug,
+            'issue_class' => $issueClass,
+        ];
+
+        return sprintf(
+            'dm:%s:%s',
+            $domainId !== '' ? $domainId : 'unknown',
+            substr(sha1(json_encode($issueIdentity, JSON_THROW_ON_ERROR)), 0, 16)
+        );
+    }
+}

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\WebProperty;
 use Illuminate\Support\Collection;
 
 class DetectedIssueSummaryService
@@ -9,6 +10,8 @@ class DetectedIssueSummaryService
     public function __construct(
         private readonly DashboardIssueQueueService $queueService,
         private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
+        private readonly DetectedIssueIdentityService $issueIdentityService,
+        private readonly DetectedIssueVerificationService $issueVerificationService,
     ) {}
 
     /**
@@ -23,6 +26,19 @@ class DetectedIssueSummaryService
         ]);
         $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence)
             ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence))
+            ->pipe(function (Collection $issues): Collection {
+                $issueIds = $issues
+                    ->pluck('issue_id')
+                    ->filter(fn (mixed $issueId): bool => is_string($issueId) && $issueId !== '')
+                    ->values()
+                    ->all();
+                $verificationMap = $this->issueVerificationService->latestMapForIssueIds($issueIds);
+
+                return $issues->map(fn (array $issue): array => $this->issueVerificationService->annotateIssue(
+                    $issue,
+                    $verificationMap[$issue['issue_id']] ?? null
+                ));
+            })
             ->values();
         $mustFix = $issues->where('severity', 'must_fix')->values();
         $shouldFix = $issues->where('severity', 'should_fix')->values();
@@ -53,7 +69,75 @@ class DetectedIssueSummaryService
         /** @var array<string, mixed>|null $issue */
         $issue = collect($issues)->firstWhere('issue_id', $issueId);
 
-        return $issue;
+        if (is_array($issue)) {
+            return $issue;
+        }
+
+        return $this->issueFromStoredVerification($issueId);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function issueFromStoredVerification(string $issueId): ?array
+    {
+        $verification = $this->issueVerificationService->latestForIssueId($issueId);
+
+        if ($verification === null) {
+            return null;
+        }
+
+        $propertyName = null;
+        $platformProfile = null;
+        $baselineSurface = null;
+
+        if (is_string($verification->property_slug) && $verification->property_slug !== '') {
+            $property = WebProperty::query()
+                ->select(['slug', 'name', 'property_type'])
+                ->where('slug', $verification->property_slug)
+                ->first();
+
+            if ($property instanceof WebProperty) {
+                $propertyName = $property->name;
+            }
+        }
+
+        $issueClass = is_string($verification->issue_class) ? $verification->issue_class : 'unclassified';
+        $controlId = $this->controlIdForIssueClass($issueClass);
+        $configuredRolloutScope = $this->configuredRolloutScopeForControl($controlId);
+
+        return $this->issueVerificationService->annotateIssue([
+            'issue_id' => $issueId,
+            'property_slug' => $verification->property_slug,
+            'property_name' => $propertyName,
+            'domain' => $verification->domain,
+            'issue_class' => $issueClass,
+            'severity' => $this->defaultSeverityForIssueClass($issueClass),
+            'detector' => 'domain_monitor.priority_queue',
+            'status' => 'open',
+            'detected_at' => $verification->verified_at->toIso8601String(),
+            'rollout_scope' => $configuredRolloutScope ?? 'domain_only',
+            'control_id' => $controlId,
+            'platform_profile' => $platformProfile,
+            'host_profile' => null,
+            'control_profile' => null,
+            'control_state' => null,
+            'execution_surface' => null,
+            'fleet_managed' => false,
+            'controller_repo' => null,
+            'controller_repo_url' => null,
+            'evidence' => [
+                'primary_reasons' => [],
+                'secondary_reasons' => [],
+                'related_issue_classes' => [$issueClass],
+                'coverage_required' => false,
+                'coverage_status' => null,
+                'coverage_gap' => false,
+                'property_match_confidence' => $propertyName !== null ? 'high' : 'none',
+                'baseline_surface' => $configuredRolloutScope === 'domain_only' ? null : $baselineSurface,
+                'source_domain_id' => null,
+            ],
+        ], $verification);
     }
 
     /**
@@ -96,15 +180,13 @@ class DetectedIssueSummaryService
 
         foreach ($issueEntries as $issueEntry) {
             $issueClass = $issueEntry['issue_class'];
-            $issueIdentity = [
-                'source_domain_id' => $domainId,
-                'property_slug' => $propertySlug,
-                'issue_class' => $issueClass,
-            ];
             $issueId = sprintf(
-                'dm:%s:%s',
-                $domainId !== '' ? $domainId : 'unknown',
-                substr(sha1(json_encode($issueIdentity, JSON_THROW_ON_ERROR)), 0, 16)
+                '%s',
+                $this->issueIdentityService->makeIssueId(
+                    $domainId,
+                    $propertySlug,
+                    $issueClass
+                )
             );
 
             $issues[] = [

--- a/app/Services/DetectedIssueVerificationService.php
+++ b/app/Services/DetectedIssueVerificationService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\DetectedIssueVerification;
+use Illuminate\Support\Carbon;
+
+class DetectedIssueVerificationService
+{
+    /**
+     * @param  array<int, string>  $issueIds
+     * @return array<string, DetectedIssueVerification>
+     */
+    public function latestMapForIssueIds(array $issueIds): array
+    {
+        $normalizedIssueIds = array_values(array_unique(array_filter(
+            $issueIds,
+            static fn (string $issueId): bool => $issueId !== ''
+        )));
+
+        if ($normalizedIssueIds === []) {
+            return [];
+        }
+
+        $latest = [];
+
+        DetectedIssueVerification::query()
+            ->whereIn('issue_id', $normalizedIssueIds)
+            ->orderByDesc('verified_at')
+            ->orderByDesc('created_at')
+            ->get()
+            ->each(function (DetectedIssueVerification $verification) use (&$latest): void {
+                $latest[$verification->issue_id] ??= $verification;
+            });
+
+        return $latest;
+    }
+
+    public function latestForIssueId(string $issueId): ?DetectedIssueVerification
+    {
+        if ($issueId === '') {
+            return null;
+        }
+
+        return $this->latestMapForIssueIds([$issueId])[$issueId] ?? null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issue
+     * @return array<string, mixed>
+     */
+    public function annotateIssue(array $issue, ?DetectedIssueVerification $verification = null): array
+    {
+        $verification ??= $this->latestForIssueId((string) ($issue['issue_id'] ?? ''));
+        $isSuppressed = $verification instanceof DetectedIssueVerification
+            ? $this->isCurrentlySuppressed($issue, $verification)
+            : false;
+
+        $issue['status'] = $isSuppressed
+            ? $verification->status
+            : 'open';
+        $issue['hidden_until'] = $isSuppressed && $verification->hidden_until instanceof Carbon
+            ? $verification->hidden_until->toIso8601String()
+            : null;
+        $issue['verification'] = $verification instanceof DetectedIssueVerification
+            ? [
+                'status' => $verification->status,
+                'hidden_until' => $verification->hidden_until?->toIso8601String(),
+                'verification_source' => $verification->verification_source,
+                'verification_notes' => $verification->verification_notes ?? [],
+                'verified_at' => $verification->verified_at->toIso8601String(),
+                'is_currently_suppressed' => $isSuppressed,
+            ]
+            : null;
+
+        return $issue;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issue
+     */
+    public function isCurrentlySuppressed(array $issue, DetectedIssueVerification $verification): bool
+    {
+        if ($verification->status !== 'verified_fixed_pending_recrawl') {
+            return false;
+        }
+
+        if (! $verification->hidden_until instanceof Carbon || ! $verification->hidden_until->isFuture()) {
+            return false;
+        }
+
+        $observedAt = $this->latestObservedAt($issue);
+
+        if ($observedAt instanceof Carbon && $observedAt->gt($verification->verified_at)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array{status:string, hidden_until?:\Illuminate\Support\Carbon|string|null, verification_source?:string|null, verification_notes?:array<int, string>|null, verified_at?:\Illuminate\Support\Carbon|string|null}  $attributes
+     * @param  array<string, mixed>  $issueContext
+     */
+    public function record(string $issueId, array $attributes, array $issueContext = []): DetectedIssueVerification
+    {
+        return DetectedIssueVerification::create([
+            'issue_id' => $issueId,
+            'property_slug' => is_string($issueContext['property_slug'] ?? null) ? $issueContext['property_slug'] : null,
+            'domain' => is_string($issueContext['domain'] ?? null) ? $issueContext['domain'] : null,
+            'issue_class' => is_string($issueContext['issue_class'] ?? null) ? $issueContext['issue_class'] : null,
+            'status' => (string) $attributes['status'],
+            'hidden_until' => $attributes['hidden_until'] ?? null,
+            'verification_source' => is_string($attributes['verification_source'] ?? null) ? $attributes['verification_source'] : null,
+            'verification_notes' => is_array($attributes['verification_notes'] ?? null) ? array_values(array_filter($attributes['verification_notes'], 'is_string')) : null,
+            'verified_at' => $attributes['verified_at'] ?? now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $issue
+     */
+    private function latestObservedAt(array $issue): ?Carbon
+    {
+        $timestamps = [
+            data_get($issue, 'evidence.captured_at'),
+            data_get($issue, 'evidence.api_captured_at'),
+            $issue['detected_at'] ?? null,
+        ];
+
+        return collect($timestamps)
+            ->filter(fn (mixed $value): bool => is_string($value) && $value !== '')
+            ->map(function (string $value): ?Carbon {
+                try {
+                    return Carbon::parse($value);
+                } catch (\Throwable) {
+                    return null;
+                }
+            })
+            ->filter()
+            ->sortByDesc(fn (Carbon $date): int => $date->getTimestamp())
+            ->first();
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
             'api-key' => \App\Http\Middleware\AuthenticateApiKey::class,
+            'fleet-control-api-key' => \App\Http\Middleware\RequireFleetControlApiKey::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/database/migrations/2026_04_03_020000_create_detected_issue_verifications_table.php
+++ b/database/migrations/2026_04_03_020000_create_detected_issue_verifications_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('detected_issue_verifications')) {
+            Schema::create('detected_issue_verifications', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('issue_id')->index();
+                $table->string('property_slug')->nullable()->index();
+                $table->string('domain')->nullable()->index();
+                $table->string('issue_class', 100)->nullable()->index();
+                $table->string('status', 60);
+                $table->timestamp('hidden_until')->nullable()->index();
+                $table->string('verification_source')->nullable();
+                $table->json('verification_notes')->nullable();
+                $table->timestamp('verified_at')->index();
+                $table->timestamps();
+
+                $table->index(['issue_id', 'verified_at'], 'detected_issue_verification_issue_verified_idx');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('detected_issue_verifications');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\DashboardPriorityQueueController;
 use App\Http\Controllers\Api\DeploymentController;
 use App\Http\Controllers\Api\DetectedIssueController;
+use App\Http\Controllers\Api\DetectedIssueVerificationController;
 use App\Http\Controllers\Api\DomainController;
 use App\Http\Controllers\Api\IntegrationMetaController;
 use App\Http\Controllers\Api\TagController;
@@ -38,6 +39,8 @@ Route::middleware(['api-key'])->group(function () {
     Route::get('/dashboard/priority-queue', DashboardPriorityQueueController::class);
     Route::get('/issues', [DetectedIssueController::class, 'index']);
     Route::get('/issues/{issueId}', [DetectedIssueController::class, 'show']);
+    Route::post('/issues/{issueId}/verification', [DetectedIssueVerificationController::class, 'store'])
+        ->middleware('fleet-control-api-key');
 
     // Tags
     Route::get('/tags', [TagController::class, 'index']);

--- a/tests/Feature/DetectedIssueVerificationApiTest.php
+++ b/tests/Feature/DetectedIssueVerificationApiTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DetectedIssueVerification;
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyRepository;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DetectedIssueVerificationApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_can_mark_an_issue_as_verified_fixed_pending_recrawl_and_hide_it_from_active_feeds(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeSearchConsoleProperty('pending-recrawl.example.com', now()->subHour(), 3);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('property_slug', $property->slug);
+
+        $this->assertNotNull($issue);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/issues/'.urlencode($issue['issue_id']).'/verification', [
+            'status' => 'verified_fixed_pending_recrawl',
+            'verification_notes' => [
+                'Live redirect now resolves correctly',
+                'Legacy URL no longer present in sitemap',
+            ],
+        ])->assertCreated()
+            ->assertJsonPath('issue_id', $issue['issue_id'])
+            ->assertJsonPath('status', 'verified_fixed_pending_recrawl')
+            ->assertJsonPath('verification_source', 'fleet-control')
+            ->assertJsonPath('verification_notes.0', 'Live redirect now resolves correctly');
+
+        $this->assertDatabaseCount('detected_issue_verifications', 1);
+
+        $issuesAfterVerification = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertCount(0, $issuesAfterVerification);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue')
+            ->assertOk()
+            ->assertJsonPath('stats.must_fix', 0)
+            ->assertJsonPath('stats.should_fix', 0);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($issue['issue_id']))
+            ->assertOk()
+            ->assertJsonPath('issue_id', $issue['issue_id'])
+            ->assertJsonPath('status', 'verified_fixed_pending_recrawl')
+            ->assertJsonPath('verification.verification_source', 'fleet-control');
+    }
+
+    public function test_verified_pending_recrawl_issue_resurfaces_when_newer_search_console_capture_exists(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeSearchConsoleProperty('recrawl-fresh.example.com', now(), 2);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('property_slug', $property->slug);
+
+        $this->assertNotNull($issue);
+
+        DetectedIssueVerification::create([
+            'issue_id' => $issue['issue_id'],
+            'property_slug' => $property->slug,
+            'domain' => $property->primaryDomainName(),
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDays(14),
+            'verification_source' => 'fleet-control',
+            'verification_notes' => ['Waiting for recrawl'],
+            'verified_at' => now()->subDay(),
+        ]);
+
+        $issuesAfterVerification = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertCount(1, $issuesAfterVerification);
+        $this->assertSame($issue['issue_id'], $issuesAfterVerification[0]['issue_id']);
+        $this->assertSame('open', $issuesAfterVerification[0]['status']);
+        $this->assertIsArray($issuesAfterVerification[0]['verification'] ?? null);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue')
+            ->assertOk()
+            ->assertJsonPath('stats.must_fix', 1)
+            ->assertJsonPath('must_fix.0.domain', 'recrawl-fresh.example.com');
+    }
+
+    public function test_verification_writeback_requires_fleet_control_authentication(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeSearchConsoleProperty('fleet-auth.example.com', now()->subHour(), 1);
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+        $issue = collect($issues)->firstWhere('property_slug', $property->slug);
+
+        $this->assertNotNull($issue);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->postJson('/api/issues/'.urlencode($issue['issue_id']).'/verification', [
+            'status' => 'verified_fixed_pending_recrawl',
+        ])->assertForbidden();
+    }
+
+    public function test_hidden_until_cannot_exceed_fourteen_day_recrawl_window(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeSearchConsoleProperty('grace-window.example.com', now()->subHour(), 1);
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+        $issue = collect($issues)->firstWhere('property_slug', $property->slug);
+
+        $this->assertNotNull($issue);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/issues/'.urlencode($issue['issue_id']).'/verification', [
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDays(21)->toIso8601String(),
+        ])->assertStatus(422)
+            ->assertJsonValidationErrors(['hidden_until']);
+    }
+
+    public function test_verified_primary_issue_downgrades_queue_item_to_should_fix_when_secondary_reason_remains(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeSearchConsoleProperty('downgrade-queue.example.com', now()->subHour(), 2);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'check_type' => 'broken_links',
+            'status' => 'warn',
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+        $issue = collect($issues)->firstWhere('property_slug', $property->slug);
+
+        $this->assertNotNull($issue);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/issues/'.urlencode($issue['issue_id']).'/verification', [
+            'status' => 'verified_fixed_pending_recrawl',
+        ])->assertCreated();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue')
+            ->assertOk()
+            ->assertJsonPath('stats.must_fix', 0)
+            ->assertJsonPath('stats.should_fix', 1)
+            ->assertJsonPath('should_fix.0.domain', 'downgrade-queue.example.com')
+            ->assertJsonPath('should_fix.0.primary_reason_count', 0)
+            ->assertJsonPath('should_fix.0.secondary_reason_count', 1)
+            ->assertJsonPath('should_fix.0.secondary_reasons.0', 'Broken links need review');
+    }
+
+    private function makeSearchConsoleProperty(string $domainName, \Illuminate\Support\Carbon $capturedAt, int $pagesWithRedirect): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Synergy Wholesale PTY',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $domainName,
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => '_wp-house',
+            'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+            'is_controller' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => $capturedAt,
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '999',
+            'search_console_property_uri' => 'sc-domain:'.$domainName,
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 10,
+            'impressions' => 100,
+            'ctr' => 0.1,
+            'average_position' => 12.3,
+            'indexed_pages' => 20,
+            'not_indexed_pages' => 5,
+            'pages_with_redirect' => $pagesWithRedirect,
+            'raw_payload' => ['issues' => [['label' => 'Page with redirect', 'count' => $pagesWithRedirect]]],
+        ]);
+
+        return $property;
+    }
+}

--- a/tests/Feature/IntegrationMetaApiTest.php
+++ b/tests/Feature/IntegrationMetaApiTest.php
@@ -28,6 +28,7 @@ class IntegrationMetaApiTest extends TestCase
             ->assertJsonPath('auth.accepted_tokens.2', 'FLEET_CONTROL_API_KEY')
             ->assertJsonPath('feeds.0.path', '/api/web-properties-summary')
             ->assertJsonPath('feeds.1.path', '/api/issues')
-            ->assertJsonPath('feeds.3.contract_version', 2);
+            ->assertJsonPath('feeds.3.path', '/api/issues/{issue_id}/verification')
+            ->assertJsonPath('feeds.4.contract_version', 2);
     }
 }


### PR DESCRIPTION
## Summary
- add a verified-fixed-pending-recrawl writeback flow for detected issues
- suppress verified issues from active issue and priority-queue feeds until the grace window ends or a newer capture resurfaces them
- keep suppressed issues addressable by issue id and restrict writeback to Fleet control auth

## Testing
- ./vendor/bin/phpunit tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/DetectedIssueVerificationApiTest.php tests/Feature/IntegrationMetaApiTest.php
- ./vendor/bin/phpstan analyse app/Http/Middleware/AuthenticateApiKey.php app/Http/Middleware/RequireFleetControlApiKey.php app/Http/Controllers/Api/DetectedIssueController.php app/Http/Controllers/Api/DetectedIssueVerificationController.php app/Http/Controllers/Api/IntegrationMetaController.php app/Models/DetectedIssueVerification.php app/Services/DetectedIssueIdentityService.php app/Services/DetectedIssueVerificationService.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php routes/api.php tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/DetectedIssueVerificationApiTest.php tests/Feature/IntegrationMetaApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
