### PR TITLE
Expose broken link source evidence in issue feed

### DIFF
--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -2,7 +2,10 @@
 
 namespace App\Services;
 
+use App\Models\Domain;
+use App\Models\DomainCheck;
 use App\Models\WebProperty;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
 
 class DetectedIssueSummaryService
@@ -20,12 +23,16 @@ class DetectedIssueSummaryService
     public function snapshot(): array
     {
         $queueSnapshot = $this->queueService->snapshot();
-        $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems([
+        $queueItems = [
             ...($queueSnapshot['must_fix'] ?? []),
             ...($queueSnapshot['should_fix'] ?? []),
+        ];
+        $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems([
+            ...$queueItems,
         ]);
-        $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence)
-            ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence))
+        $brokenLinksEvidence = $this->brokenLinksEvidenceMapForQueueItems($queueItems);
+        $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence, $brokenLinksEvidence)
+            ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence, $brokenLinksEvidence))
             ->pipe(function (Collection $issues): Collection {
                 $issueIds = $issues
                     ->pluck('issue_id')
@@ -107,6 +114,9 @@ class DetectedIssueSummaryService
         $issueClass = is_string($verification->issue_class) ? $verification->issue_class : 'unclassified';
         $controlId = $this->controlIdForIssueClass($issueClass);
         $configuredRolloutScope = $this->configuredRolloutScopeForControl($controlId);
+        $brokenLinksEvidence = $issueClass === 'seo.broken_links'
+            ? $this->brokenLinksEvidenceForDomainName($verification->domain)
+            : [];
 
         return $this->issueVerificationService->annotateIssue([
             'issue_id' => $issueId,
@@ -138,6 +148,7 @@ class DetectedIssueSummaryService
                 'property_match_confidence' => $propertyName !== null ? 'high' : 'none',
                 'baseline_surface' => $configuredRolloutScope === 'domain_only' ? null : $baselineSurface,
                 'source_domain_id' => null,
+                ...$brokenLinksEvidence,
             ],
         ], $verification);
     }
@@ -145,21 +156,23 @@ class DetectedIssueSummaryService
     /**
      * @param  array<int, array<string, mixed>>  $items
      * @param  array<string, array<string, array<string, mixed>>>  $issueEvidence
+     * @param  array<string, array<string, mixed>>  $brokenLinksEvidence
      * @return Collection<int, array<string, mixed>>
      */
-    private function flattenIssues(array $items, string $severity, array $issueEvidence): Collection
+    private function flattenIssues(array $items, string $severity, array $issueEvidence, array $brokenLinksEvidence): Collection
     {
         return collect($items)
-            ->flatMap(fn (array $item): array => $this->makeIssues($item, $severity, $issueEvidence))
+            ->flatMap(fn (array $item): array => $this->makeIssues($item, $severity, $issueEvidence, $brokenLinksEvidence))
             ->values();
     }
 
     /**
      * @param  array<string, mixed>  $item
      * @param  array<string, array<string, array<string, mixed>>>  $issueEvidence
+     * @param  array<string, array<string, mixed>>  $brokenLinksEvidence
      * @return array<int, array<string, mixed>>
      */
-    private function makeIssues(array $item, string $severity, array $issueEvidence): array
+    private function makeIssues(array $item, string $severity, array $issueEvidence, array $brokenLinksEvidence): array
     {
         $domainId = (string) ($item['id'] ?? '');
         $domain = is_string($item['domain'] ?? null) ? $item['domain'] : null;
@@ -227,6 +240,7 @@ class DetectedIssueSummaryService
                     'property_match_confidence' => is_string($item['property_match_confidence'] ?? null) ? $item['property_match_confidence'] : null,
                     'baseline_surface' => $issueEntry['baseline_surface'],
                     'source_domain_id' => $domainId,
+                    ...($brokenLinksEvidence[$issueId] ?? []),
                     ...($issueEvidence[$evidenceKey][$issueClass] ?? []),
                 ],
             ];
@@ -425,5 +439,207 @@ class DetectedIssueSummaryService
         return is_string($platformProfile)
             ? data_get(config('domain_monitor.priority_queue_standards'), 'platform_profiles.'.$platformProfile.'.baseline_surface')
             : null;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     * @return array<string, array<string, mixed>>
+     */
+    private function brokenLinksEvidenceMapForQueueItems(array $items): array
+    {
+        $issueToDomainMap = [];
+
+        foreach ($items as $item) {
+            $domain = is_string($item['domain'] ?? null) ? $item['domain'] : null;
+            $domainId = (string) ($item['id'] ?? '');
+            $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+
+            if ($domain === null || $domainId === '') {
+                continue;
+            }
+
+            foreach ((array) ($item['issue_entries'] ?? []) as $entry) {
+                $issueClass = is_string($entry['issue_family'] ?? null) ? $entry['issue_family'] : null;
+
+                if ($issueClass !== 'seo.broken_links') {
+                    continue;
+                }
+
+                $issueId = $this->issueIdentityService->makeIssueId($domainId, $propertySlug, $issueClass);
+                $issueToDomainMap[$issueId] = $domain;
+            }
+        }
+
+        if ($issueToDomainMap === []) {
+            return [];
+        }
+
+        $evidenceByDomain = $this->brokenLinksEvidenceByDomainName(array_values(array_unique(array_values($issueToDomainMap))));
+        $evidenceByIssueId = [];
+
+        foreach ($issueToDomainMap as $issueId => $domainName) {
+            if (isset($evidenceByDomain[$domainName])) {
+                $evidenceByIssueId[$issueId] = $evidenceByDomain[$domainName];
+            }
+        }
+
+        return $evidenceByIssueId;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function brokenLinksEvidenceForDomainName(?string $domainName): array
+    {
+        if (! is_string($domainName) || $domainName === '') {
+            return [];
+        }
+
+        return $this->brokenLinksEvidenceByDomainName([$domainName])[$domainName] ?? [];
+    }
+
+    /**
+     * @param  array<int, string>  $domainNames
+     * @return array<string, array<string, mixed>>
+     */
+    private function brokenLinksEvidenceByDomainName(array $domainNames): array
+    {
+        if ($domainNames === []) {
+            return [];
+        }
+
+        $domains = Domain::query()
+            ->select(['id', 'domain'])
+            ->whereIn('domain', $domainNames)
+            ->get();
+
+        if ($domains->isEmpty()) {
+            return [];
+        }
+
+        /** @var array<string, string> $domainNamesById */
+        $domainNamesById = $domains->pluck('domain', 'id')->all();
+        $checks = $this->latestBrokenLinksChecksForDomainIds(array_keys($domainNamesById));
+        $evidence = [];
+
+        foreach ($checks as $domainId => $check) {
+            $domainName = $domainNamesById[$domainId] ?? null;
+
+            if (! is_string($domainName)) {
+                continue;
+            }
+
+            $normalized = $this->normalizeBrokenLinksEvidence($check->payload);
+
+            if ($normalized !== null) {
+                $evidence[$domainName] = $normalized;
+            }
+        }
+
+        return $evidence;
+    }
+
+    /**
+     * @param  array<int, string>  $domainIds
+     * @return Collection<string, DomainCheck>
+     */
+    private function latestBrokenLinksChecksForDomainIds(array $domainIds): Collection
+    {
+        if ($domainIds === []) {
+            return collect();
+        }
+
+        $latestCheckTimestamps = DomainCheck::query()
+            ->selectRaw('domain_id, MAX(created_at) as latest_created_at')
+            ->where('check_type', 'broken_links')
+            ->whereIn('domain_id', $domainIds)
+            ->groupBy('domain_id');
+
+        /** @var Collection<string, DomainCheck> $checks */
+        $checks = DomainCheck::query()
+            ->from('domain_checks as checks')
+            ->joinSub($latestCheckTimestamps, 'latest_checks', function (JoinClause $join): void {
+                $join->on('checks.domain_id', '=', 'latest_checks.domain_id')
+                    ->on('checks.created_at', '=', 'latest_checks.latest_created_at');
+            })
+            ->where('checks.check_type', 'broken_links')
+            ->get(['checks.id', 'checks.domain_id', 'checks.payload', 'checks.created_at'])
+            ->unique('domain_id')
+            ->keyBy('domain_id');
+
+        return $checks;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @return array<string, mixed>|null
+     */
+    private function normalizeBrokenLinksEvidence(?array $payload): ?array
+    {
+        if (! is_array($payload)) {
+            return null;
+        }
+
+        $payloadBrokenLinks = $payload['broken_links'] ?? null;
+
+        if (! is_array($payloadBrokenLinks)) {
+            return null;
+        }
+
+        $brokenLinks = collect($payloadBrokenLinks)
+            ->filter(fn (mixed $entry): bool => is_array($entry))
+            ->map(function (array $entry): ?array {
+                $url = $this->sanitizeEvidenceUrl($entry['url'] ?? null);
+                $status = is_numeric($entry['status'] ?? null) ? (int) $entry['status'] : null;
+                $foundOn = $this->sanitizeEvidenceUrl($entry['found_on'] ?? null);
+
+                if ($url === null || $status === null || $foundOn === null) {
+                    return null;
+                }
+
+                return [
+                    'url' => $url,
+                    'status' => $status,
+                    'found_on' => $foundOn,
+                ];
+            })
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($brokenLinks === []) {
+            return null;
+        }
+
+        return [
+            'broken_links_count' => count($brokenLinks),
+            'pages_scanned' => is_numeric($payload['pages_scanned'] ?? null)
+                ? (int) $payload['pages_scanned']
+                : null,
+            'broken_links' => $brokenLinks,
+        ];
+    }
+
+    private function sanitizeEvidenceUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        $parts = parse_url($value);
+
+        if ($parts === false || ! isset($parts['scheme'], $parts['host'])) {
+            return preg_replace('/[?#].*$/', '', $value);
+        }
+
+        $sanitized = $parts['scheme'].'://'.$parts['host'];
+
+        if (isset($parts['port'])) {
+            $sanitized .= ':'.$parts['port'];
+        }
+
+        $sanitized .= $parts['path'] ?? '';
+
+        return $sanitized;
     }
 }

--- a/tests/Feature/BrokenLinkHealthCheckServiceTest.php
+++ b/tests/Feature/BrokenLinkHealthCheckServiceTest.php
@@ -34,6 +34,7 @@ class BrokenLinkHealthCheckServiceTest extends TestCase
         $this->assertFalse($result['is_valid']);
         $this->assertSame(1, $result['broken_links_count']);
         $this->assertSame('https://example.com/bad', $result['broken_links'][0]['url']);
+        $this->assertSame('https://example.com', $result['broken_links'][0]['found_on']);
     }
 
     public function test_it_marks_broken_link_check_as_unverified_when_crawl_fails(): void

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -455,6 +455,128 @@ class DetectedIssueApiTest extends TestCase
         $this->assertCount(2, $issues->pluck('issue_id')->unique());
     }
 
+    public function test_issues_endpoint_includes_broken_link_source_pages(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'broken-links.example.com',
+            'is_active' => true,
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'broken-links-site',
+            'name' => 'Broken Links Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/broken-links-site',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/broken-links-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/broken-links-site',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => 'broken-links-site',
+            'deployment_project_id' => 'prj_brokenlinks123',
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $domain->id,
+            'check_type' => 'broken_links',
+            'status' => 'warn',
+            'created_at' => now()->subHour(),
+            'payload' => [
+                'broken_links_count' => 1,
+                'pages_scanned' => 4,
+                'broken_links' => [
+                    [
+                        'url' => 'https://broken-links.example.com/old-result/',
+                        'status' => 404,
+                        'found_on' => 'https://broken-links.example.com/old-page/',
+                    ],
+                ],
+            ],
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $domain->id,
+            'check_type' => 'broken_links',
+            'status' => 'fail',
+            'created_at' => now(),
+            'payload' => [
+                'broken_links_count' => 2,
+                'pages_scanned' => 12,
+                'broken_links' => [
+                    [
+                        'url' => 'https://broken-links.example.com/missing-page/?token=secret',
+                        'status' => 404,
+                        'found_on' => 'https://broken-links.example.com/services/?preview=1',
+                    ],
+                    [
+                        'url' => 'https://broken-links.example.com/old-booking/?session=abc',
+                        'status' => 410,
+                        'found_on' => 'https://broken-links.example.com/contact/',
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->assertJsonPath('stats.open', 1)
+            ->json('issues');
+
+        /** @var array<string, mixed>|null $brokenLinksIssue */
+        $brokenLinksIssue = collect($issues)->firstWhere('issue_class', 'seo.broken_links');
+
+        $this->assertIsArray($brokenLinksIssue);
+        $this->assertSame('broken-links-site', $brokenLinksIssue['property_slug']);
+        $this->assertSame(2, data_get($brokenLinksIssue, 'evidence.broken_links_count'));
+        $this->assertSame(12, data_get($brokenLinksIssue, 'evidence.pages_scanned'));
+        $this->assertSame(
+            'https://broken-links.example.com/missing-page/',
+            data_get($brokenLinksIssue, 'evidence.broken_links.0.url')
+        );
+        $this->assertSame(
+            404,
+            data_get($brokenLinksIssue, 'evidence.broken_links.0.status')
+        );
+        $this->assertSame(
+            'https://broken-links.example.com/services/',
+            data_get($brokenLinksIssue, 'evidence.broken_links.0.found_on')
+        );
+
+        $detailResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode((string) $brokenLinksIssue['issue_id']))
+            ->assertOk()
+            ->assertJsonPath('evidence.broken_links.1.url', 'https://broken-links.example.com/old-booking/')
+            ->assertJsonPath('evidence.broken_links.1.found_on', 'https://broken-links.example.com/contact/');
+
+        $this->assertSame(
+            ['https://broken-links.example.com/missing-page/', 'https://broken-links.example.com/old-booking/'],
+            array_column($detailResponse->json('evidence.broken_links') ?? [], 'url')
+        );
+    }
+
     public function test_issues_endpoint_reports_uncontrolled_when_no_controller_path_exists(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/DetectedIssueVerificationApiTest.php
+++ b/tests/Feature/DetectedIssueVerificationApiTest.php
@@ -75,6 +75,97 @@ class DetectedIssueVerificationApiTest extends TestCase
             ->assertJsonPath('verification.verification_source', 'fleet-control');
     }
 
+    public function test_suppressed_broken_link_issue_detail_keeps_source_page_evidence(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'suppressed-broken-links.example.com',
+            'is_active' => true,
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'suppressed-broken-links-site',
+            'name' => 'Suppressed Broken Links Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'moveroo/suppressed-broken-links-site',
+            'repo_provider' => 'github',
+            'repo_url' => 'https://github.com/moveroo/suppressed-broken-links-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/suppressed-broken-links-site',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => true,
+            'deployment_provider' => 'vercel',
+            'deployment_project_name' => 'suppressed-broken-links-site',
+            'deployment_project_id' => 'prj_suppressedbrokenlinks123',
+        ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $domain->id,
+            'check_type' => 'broken_links',
+            'status' => 'warn',
+            'payload' => [
+                'broken_links_count' => 1,
+                'pages_scanned' => 3,
+                'broken_links' => [
+                    [
+                        'url' => 'https://suppressed-broken-links.example.com/missing/?token=abc',
+                        'status' => 404,
+                        'found_on' => 'https://suppressed-broken-links.example.com/start-here/?preview=1',
+                    ],
+                ],
+            ],
+        ]);
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $issue = collect($issues)->firstWhere('issue_class', 'seo.broken_links');
+
+        $this->assertNotNull($issue);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/issues/'.urlencode($issue['issue_id']).'/verification', [
+            'status' => 'verified_fixed_pending_recrawl',
+            'verification_notes' => ['Verified and awaiting recrawl'],
+        ])->assertCreated();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->assertJsonCount(0, 'issues');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($issue['issue_id']))
+            ->assertOk()
+            ->assertJsonPath('status', 'verified_fixed_pending_recrawl')
+            ->assertJsonPath('evidence.broken_links.0.url', 'https://suppressed-broken-links.example.com/missing/')
+            ->assertJsonPath('evidence.broken_links.0.found_on', 'https://suppressed-broken-links.example.com/start-here/');
+    }
+
     public function test_verified_pending_recrawl_issue_resurfaces_when_newer_search_console_capture_exists(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- expose broken link evidence on `/api/issues` so Fleet can see the broken URL, HTTP status, and source page
- sanitize surfaced broken-link URLs and keep that detail out of the dashboard queue payload
- preserve broken-link evidence on issue detail even after Fleet suppresses an issue pending recrawl

## Testing
- `./vendor/bin/phpunit tests/Feature/BrokenLinkHealthCheckServiceTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/DetectedIssueVerificationApiTest.php`
- `./vendor/bin/phpstan analyse app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/BrokenLinkHealthCheckServiceTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/DetectedIssueVerificationApiTest.php --memory-limit=2G`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
