### PR TITLE
Sync suppressed Search Console summaries

### DIFF
--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -15,6 +15,7 @@ class DashboardIssueQueueService
     public function __construct(
         private readonly DetectedIssueIdentityService $issueIdentityService,
         private readonly DetectedIssueVerificationService $issueVerificationService,
+        private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
     ) {}
 
     /**
@@ -59,8 +60,13 @@ class DashboardIssueQueueService
             ->get();
 
         [$mustFixDomains, $shouldFixDomains] = $this->buildIssueQueues($domains);
+        $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems([
+            ...$mustFixDomains->all(),
+            ...$shouldFixDomains->all(),
+        ]);
         [$mustFixDomains, $shouldFixDomains] = $this->applyIssueVerificationQueues(
-            $mustFixDomains->concat($shouldFixDomains)
+            $mustFixDomains->concat($shouldFixDomains),
+            $issueEvidence
         );
 
         $stats['must_fix'] = $mustFixDomains->count();
@@ -80,9 +86,10 @@ class DashboardIssueQueueService
 
     /**
      * @param  Collection<int, array<string, mixed>>  $items
+     * @param  array<string, array<string, array<string, mixed>>>  $issueEvidence
      * @return array{0: Collection<int, array<string, mixed>>, 1: Collection<int, array<string, mixed>>}
      */
-    private function applyIssueVerificationQueues(Collection $items): array
+    private function applyIssueVerificationQueues(Collection $items, array $issueEvidence): array
     {
         if ($items->isEmpty()) {
             return [collect(), collect()];
@@ -113,7 +120,13 @@ class DashboardIssueQueueService
             ?: (strtotime($right['updated_at_iso']) <=> strtotime($left['updated_at_iso']));
 
         foreach ($items as $item) {
-            $filteredItem = $this->filterVerifiedIssueEntries($item, $verificationMap);
+            $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
+            $evidenceKey = $propertySlug ?: (string) ($item['id'] ?? '');
+            $filteredItem = $this->filterVerifiedIssueEntries(
+                $item,
+                $verificationMap,
+                $issueEvidence[$evidenceKey] ?? []
+            );
 
             if ($filteredItem === null) {
                 continue;
@@ -149,10 +162,11 @@ class DashboardIssueQueueService
 
     /**
      * @param  array<string, \App\Models\DetectedIssueVerification>  $verificationMap
+     * @param  array<string, array<string, mixed>>  $propertyIssueEvidence
      * @param  array<string, mixed>  $item
      * @return array<string, mixed>|null
      */
-    private function filterVerifiedIssueEntries(array $item, array $verificationMap): ?array
+    private function filterVerifiedIssueEntries(array $item, array $verificationMap, array $propertyIssueEvidence): ?array
     {
         $domainId = (string) ($item['id'] ?? '');
         $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
@@ -160,13 +174,13 @@ class DashboardIssueQueueService
         $visibleSecondaryRecords = [];
 
         foreach ((array) ($item['primary_issue_records'] ?? []) as $record) {
-            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap)) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence)) {
                 $visiblePrimaryRecords[] = $record;
             }
         }
 
         foreach ((array) ($item['secondary_issue_records'] ?? []) as $record) {
-            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap)) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence)) {
                 $visibleSecondaryRecords[] = $record;
             }
         }
@@ -229,13 +243,15 @@ class DashboardIssueQueueService
      * @param  array<string, mixed>  $record
      * @param  array<string, mixed>  $item
      * @param  array<string, \App\Models\DetectedIssueVerification>  $verificationMap
+     * @param  array<string, array<string, mixed>>  $propertyIssueEvidence
      */
     private function shouldKeepVerifiedRecord(
         array $record,
         array $item,
         string $domainId,
         ?string $propertySlug,
-        array $verificationMap
+        array $verificationMap,
+        array $propertyIssueEvidence
     ): bool {
         $issueFamily = is_string($record['issue_family'] ?? null) ? $record['issue_family'] : null;
 
@@ -245,12 +261,11 @@ class DashboardIssueQueueService
 
         $issueId = $this->issueIdentityService->makeIssueId($domainId, $propertySlug, $issueFamily);
         $verification = $verificationMap[$issueId] ?? null;
+        $issueEvidenceForRecord = $this->queueIssueEvidence($item, $issueFamily, $propertyIssueEvidence[$issueFamily] ?? []);
         $issue = [
             'issue_id' => $issueId,
-            'detected_at' => is_string($item['updated_at_iso'] ?? null) ? $item['updated_at_iso'] : null,
-            'evidence' => [
-                'captured_at' => $this->queueIssueObservedAt($item, $issueFamily),
-            ],
+            'detected_at' => $this->queueIssueDetectedAt($item, $issueFamily, $issueEvidenceForRecord),
+            'evidence' => $issueEvidenceForRecord,
         ];
 
         return ! ($verification instanceof \App\Models\DetectedIssueVerification
@@ -271,14 +286,49 @@ class DashboardIssueQueueService
 
     /**
      * @param  array<string, mixed>  $item
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, string>
      */
-    private function queueIssueObservedAt(array $item, string $issueFamily): ?string
+    private function queueIssueEvidence(array $item, string $issueFamily, array $issueEvidence): array
     {
         if (array_key_exists($issueFamily, config('domain_monitor.search_console_issue_catalog', []))) {
-            return is_string($item['baseline_captured_at'] ?? null) ? $item['baseline_captured_at'] : null;
+            $evidence = [];
+
+            if (is_string($issueEvidence['captured_at'] ?? null) && $issueEvidence['captured_at'] !== '') {
+                $evidence['captured_at'] = $issueEvidence['captured_at'];
+            } elseif (is_string($item['baseline_captured_at'] ?? null) && $item['baseline_captured_at'] !== '') {
+                $evidence['captured_at'] = $item['baseline_captured_at'];
+            }
+
+            if (is_string($issueEvidence['api_captured_at'] ?? null) && $issueEvidence['api_captured_at'] !== '') {
+                $evidence['api_captured_at'] = $issueEvidence['api_captured_at'];
+            }
+
+            return $evidence;
         }
 
-        return is_string($item['updated_at_iso'] ?? null) ? $item['updated_at_iso'] : null;
+        return is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
+            ? ['captured_at' => $item['updated_at_iso']]
+            : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @param  array<string, mixed>  $issueEvidence
+     */
+    private function queueIssueDetectedAt(array $item, string $issueFamily, array $issueEvidence): ?string
+    {
+        if (array_key_exists($issueFamily, config('domain_monitor.search_console_issue_catalog', []))) {
+            foreach (['api_captured_at', 'captured_at'] as $key) {
+                if (is_string($issueEvidence[$key] ?? null) && $issueEvidence[$key] !== '') {
+                    return $issueEvidence[$key];
+                }
+            }
+        }
+
+        return is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
+            ? $item['updated_at_iso']
+            : null;
     }
 
     /**

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -178,9 +178,6 @@ class DetectedIssueSummaryService
         $domain = is_string($item['domain'] ?? null) ? $item['domain'] : null;
         $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
         $evidenceKey = $propertySlug ?: $domainId;
-        $detectedAt = is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== ''
-            ? $item['updated_at_iso']
-            : now()->toIso8601String();
         $queueIssueEntries = $this->normalizedIssueEntries($item, $severity);
         $issueEntries = array_merge(
             $queueIssueEntries,
@@ -213,7 +210,7 @@ class DetectedIssueSummaryService
                 'severity' => $issueEntry['severity'],
                 'detector' => 'domain_monitor.priority_queue',
                 'status' => 'open',
-                'detected_at' => $detectedAt,
+                'detected_at' => $this->issueDetectedAt($issueClass, $item, $issueEvidence[$evidenceKey][$issueClass] ?? []),
                 'rollout_scope' => $issueEntry['rollout_scope'],
                 'control_id' => $issueEntry['control_id'],
                 'platform_profile' => is_string($item['platform_profile'] ?? null) ? $item['platform_profile'] : null,
@@ -439,6 +436,27 @@ class DetectedIssueSummaryService
         return is_string($platformProfile)
             ? data_get(config('domain_monitor.priority_queue_standards'), 'platform_profiles.'.$platformProfile.'.baseline_surface')
             : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @param  array<string, mixed>  $issueEvidence
+     */
+    private function issueDetectedAt(string $issueClass, array $item, array $issueEvidence): string
+    {
+        if (array_key_exists($issueClass, config('domain_monitor.search_console_issue_catalog', []))) {
+            foreach (['api_captured_at', 'captured_at'] as $key) {
+                if (is_string($issueEvidence[$key] ?? null) && $issueEvidence[$key] !== '') {
+                    return $issueEvidence[$key];
+                }
+            }
+        }
+
+        if (is_string($item['updated_at_iso'] ?? null) && $item['updated_at_iso'] !== '') {
+            return $item['updated_at_iso'];
+        }
+
+        return now()->toIso8601String();
     }
 
     /**

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -9,6 +9,11 @@ use Illuminate\Support\Collection;
 
 class SearchConsoleIssueEvidenceService
 {
+    public function __construct(
+        private readonly DetectedIssueIdentityService $issueIdentityService,
+        private readonly DetectedIssueVerificationService $issueVerificationService,
+    ) {}
+
     /**
      * @param  array<int, array<string, mixed>>  $items
      * @return array<string, array<string, array<string, mixed>>>
@@ -55,15 +60,51 @@ class SearchConsoleIssueEvidenceService
         $propertyEvidence = $context['evidence'][$property->slug] ?? [];
         $baseline = $property->latestPropertySeoBaselineRecord();
         $snapshots = $context['snapshots'][$property->id] ?? [];
+        $issueDomainId = $this->issueDomainIdForProperty($property);
+        $issueIds = [];
+
+        foreach (array_keys($propertyEvidence) as $issueClass) {
+            if ($issueClass === '' || ! is_string($issueDomainId) || $issueDomainId === '') {
+                continue;
+            }
+
+            $issueIds[$issueClass] = $this->issueIdentityService->makeIssueId(
+                $issueDomainId,
+                $property->slug,
+                $issueClass
+            );
+        }
+
+        $verificationMap = $this->issueVerificationService->latestMapForIssueIds(array_values($issueIds));
 
         return collect($propertyEvidence)
-            ->map(function (array $evidence, string $issueClass) use ($baseline, $snapshots): array {
+            ->map(function (array $evidence, string $issueClass) use ($baseline, $snapshots, $property, $issueIds, $verificationMap): ?array {
                 $catalogEntry = config('domain_monitor.search_console_issue_catalog.'.$issueClass, []);
                 $detailSnapshot = $snapshots[$issueClass]['detail'] ?? null;
                 $apiSnapshot = $snapshots[$issueClass]['api'] ?? null;
                 $count = is_numeric($evidence['affected_url_count'] ?? null) ? (int) $evidence['affected_url_count'] : null;
                 $examples = is_array($evidence['examples'] ?? null) ? $evidence['examples'] : [];
                 $summaryCount = $count ?? $baseline?->issueCount($issueClass);
+
+                $issueId = $issueIds[$issueClass] ?? null;
+                $verification = is_string($issueId) ? ($verificationMap[$issueId] ?? null) : null;
+                $issueContext = [
+                    'issue_id' => $issueId,
+                    'property_slug' => $property->slug,
+                    'domain' => $property->primaryDomainName(),
+                    'issue_class' => $issueClass,
+                    'detected_at' => $evidence['captured_at'] ?? null,
+                    'evidence' => array_filter([
+                        'captured_at' => is_string($evidence['captured_at'] ?? null) ? $evidence['captured_at'] : null,
+                        'api_captured_at' => is_string($evidence['api_captured_at'] ?? null) ? $evidence['api_captured_at'] : null,
+                    ]),
+                ];
+
+                if (is_string($issueId)
+                    && $verification instanceof \App\Models\DetectedIssueVerification
+                    && $this->issueVerificationService->isCurrentlySuppressed($issueContext, $verification)) {
+                    return null;
+                }
 
                 return [
                     'issue_class' => $issueClass,
@@ -81,9 +122,30 @@ class SearchConsoleIssueEvidenceService
                     'api_snapshot_id' => $apiSnapshot?->id,
                 ];
             })
+            ->filter(fn (mixed $summary): bool => is_array($summary))
             ->sortByDesc(fn (array $summary): int => (int) ($summary['affected_url_count'] ?? 0))
             ->values()
             ->all();
+    }
+
+    private function issueDomainIdForProperty(WebProperty $property): ?string
+    {
+        $candidates = [
+            $property->primary_domain_id,
+            $property->primaryDomain?->id,
+            $property->propertyDomains
+                ->firstWhere('is_canonical', true)?->domain_id,
+            $property->propertyDomains
+                ->firstWhere('usage_type', 'primary')?->domain_id,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_string($candidate) && $candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/DetectedIssueVerificationApiTest.php
+++ b/tests/Feature/DetectedIssueVerificationApiTest.php
@@ -303,6 +303,111 @@ class DetectedIssueVerificationApiTest extends TestCase
             ->assertJsonPath('should_fix.0.secondary_reasons.0', 'Broken links need review');
     }
 
+    public function test_dashboard_priority_queue_hides_suppressed_search_console_reasons_using_issue_capture_timestamps(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeSearchConsoleProperty('queue-sync.example.com', now(), 6);
+
+        DomainSeoBaseline::query()
+            ->where('web_property_id', $property->id)
+            ->update([
+                'blocked_by_robots' => 1,
+                'raw_payload' => [
+                    'issues' => [
+                        ['label' => 'Page with redirect', 'count' => 6],
+                        ['label' => 'Blocked by robots.txt', 'count' => 1],
+                    ],
+                ],
+            ]);
+
+        DomainCheck::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'check_type' => 'security_headers',
+            'status' => 'warn',
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:queue-sync.example.com',
+            'captured_at' => now()->subDays(2),
+            'captured_by' => 'test',
+            'affected_url_count' => 6,
+            'sample_urls' => [
+                'https://queue-sync.example.com/',
+            ],
+            'examples' => [
+                ['url' => 'https://queue-sync.example.com/', 'last_crawled' => now()->subDays(3)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://queue-sync.example.com/',
+                ],
+            ],
+            'raw_payload' => ['source' => 'drilldown'],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:queue-sync.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://queue-sync.example.com/wp-admin/',
+            ],
+            'examples' => [
+                ['url' => 'https://queue-sync.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://queue-sync.example.com/wp-admin/',
+                ],
+            ],
+            'raw_payload' => ['source' => 'drilldown'],
+        ]);
+
+        $issueId = app(\App\Services\DetectedIssueIdentityService::class)
+            ->makeIssueId($property->primary_domain_id, $property->slug, 'page_with_redirect_in_sitemap');
+
+        DetectedIssueVerification::create([
+            'issue_id' => $issueId,
+            'property_slug' => $property->slug,
+            'domain' => $property->primaryDomainName(),
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDays(14),
+            'verification_source' => 'fleet-control',
+            'verification_notes' => ['Verified live'],
+            'verified_at' => now()->subDay(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue')
+            ->assertOk();
+
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+        /** @var array<string, mixed>|null $queueItem */
+        $queueItem = collect($mustFixPayload)
+            ->first(fn (array $item): bool => ($item['domain'] ?? null) === 'queue-sync.example.com');
+
+        $this->assertIsArray($queueItem);
+        $this->assertSame(['Search Console reports blocked by robots.txt (1 URLs)'], $queueItem['primary_reasons']);
+        $this->assertSame(['Security headers need review'], $queueItem['secondary_reasons']);
+    }
+
     public function test_suppressed_supplemental_issue_is_hidden_from_collection_feed_but_still_available_by_issue_id(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\AnalyticsInstallAudit;
+use App\Models\DetectedIssueVerification;
 use App\Models\Domain;
 use App\Models\DomainSeoBaseline;
 use App\Models\PropertyAnalyticsSource;
@@ -300,5 +301,179 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('https://checklist.example.au/');
         $response->assertSee('https://checklist.example.au/new-page/');
         $response->assertDontSee('1970-01-01');
+    }
+
+    public function test_web_property_detail_hides_suppressed_search_console_issue_summaries(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'suppressed-summary.example.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'suppressed-summary-site',
+            'name' => 'Suppressed Summary Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:suppressed-summary.example.au',
+            'captured_at' => now()->subDays(2),
+            'captured_by' => 'test',
+            'affected_url_count' => 17,
+            'sample_urls' => ['https://suppressed-summary.example.au/'],
+            'examples' => [
+                ['url' => 'https://suppressed-summary.example.au/', 'last_crawled' => now()->subDays(3)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://suppressed-summary.example.au/'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:suppressed-summary.example.au',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://suppressed-summary.example.au/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://suppressed-summary.example.au/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://suppressed-summary.example.au/wp-admin/'],
+            ],
+        ]);
+
+        $issueId = app(\App\Services\DetectedIssueIdentityService::class)
+            ->makeIssueId($domain->id, $property->slug, 'page_with_redirect_in_sitemap');
+
+        DetectedIssueVerification::create([
+            'issue_id' => $issueId,
+            'property_slug' => $property->slug,
+            'domain' => $domain->domain,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDays(14),
+            'verification_source' => 'fleet-control',
+            'verification_notes' => ['Verified live'],
+            'verified_at' => now()->subDay(),
+        ]);
+
+        $response = $this->actingAs($user)->get('/web-properties/suppressed-summary-site');
+
+        $response->assertOk();
+        $response->assertDontSee('Page with redirect');
+        $response->assertDontSee('17 affected URLs');
+        $response->assertSee('Blocked by robots.txt');
+        $response->assertSee('1 affected URLs');
+    }
+
+    public function test_web_property_detail_hides_suppressed_search_console_issue_summaries_when_primary_domain_id_is_missing(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'suppressed-summary-fallback.example.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'suppressed-summary-fallback-site',
+            'name' => 'Suppressed Summary Fallback Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => null,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:suppressed-summary-fallback.example.au',
+            'captured_at' => now()->subDays(2),
+            'captured_by' => 'test',
+            'affected_url_count' => 4,
+            'sample_urls' => ['https://suppressed-summary-fallback.example.au/'],
+            'examples' => [
+                ['url' => 'https://suppressed-summary-fallback.example.au/', 'last_crawled' => now()->subDays(3)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://suppressed-summary-fallback.example.au/'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:suppressed-summary-fallback.example.au',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://suppressed-summary-fallback.example.au/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://suppressed-summary-fallback.example.au/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://suppressed-summary-fallback.example.au/wp-admin/'],
+            ],
+        ]);
+
+        $issueId = app(\App\Services\DetectedIssueIdentityService::class)
+            ->makeIssueId($domain->id, $property->slug, 'page_with_redirect_in_sitemap');
+
+        DetectedIssueVerification::create([
+            'issue_id' => $issueId,
+            'property_slug' => $property->slug,
+            'domain' => $domain->domain,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDays(14),
+            'verification_source' => 'fleet-control',
+            'verification_notes' => ['Verified live'],
+            'verified_at' => now()->subDay(),
+        ]);
+
+        $response = $this->actingAs($user)->get('/web-properties/suppressed-summary-fallback-site');
+
+        $response->assertOk();
+        $response->assertDontSee('Page with redirect');
+        $response->assertDontSee('4 affected URLs');
+        $response->assertSee('Blocked by robots.txt');
+        $response->assertSee('1 affected URLs');
     }
 }


### PR DESCRIPTION
## Summary
- align dashboard/property Search Console summaries with the active issue suppression rules used by 
- use recrawl-aware Search Console evidence timestamps when deciding whether a verified issue should stay hidden
- hide suppressed Search Console snippets on the property detail view and cover the primary-domain fallback edge case

## Testing
- ./vendor/bin/phpunit tests/Feature/DetectedIssueVerificationApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/WebPropertyUiTest.php tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php app/Services/SearchConsoleIssueEvidenceService.php tests/Feature/DetectedIssueVerificationApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/WebPropertyUiTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
