### PR TITLE
[codex] Add target reference links

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -33,6 +33,10 @@ class WebPropertyDetail extends Component
 
     public ?string $targetVehicleBookingUrl = null;
 
+    public ?string $targetMoverooSubdomainUrl = null;
+
+    public ?string $targetContactUsPageUrl = null;
+
     public function mount(): void
     {
         $this->loadProperty();
@@ -67,6 +71,8 @@ class WebPropertyDetail extends Component
         $this->targetHouseholdBookingUrl = $this->property->target_household_booking_url;
         $this->targetVehicleQuoteUrl = $this->property->target_vehicle_quote_url;
         $this->targetVehicleBookingUrl = $this->property->target_vehicle_booking_url;
+        $this->targetMoverooSubdomainUrl = $this->property->target_moveroo_subdomain_url;
+        $this->targetContactUsPageUrl = $this->property->target_contact_us_page_url;
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -116,6 +122,8 @@ class WebPropertyDetail extends Component
             'targetHouseholdBookingUrl' => $this->normalizeTargetUrl($this->targetHouseholdBookingUrl),
             'targetVehicleQuoteUrl' => $this->normalizeTargetUrl($this->targetVehicleQuoteUrl),
             'targetVehicleBookingUrl' => $this->normalizeTargetUrl($this->targetVehicleBookingUrl),
+            'targetMoverooSubdomainUrl' => $this->normalizeTargetUrl($this->targetMoverooSubdomainUrl),
+            'targetContactUsPageUrl' => $this->normalizeTargetUrl($this->targetContactUsPageUrl),
         ];
 
         $this->resetValidation();
@@ -127,6 +135,8 @@ class WebPropertyDetail extends Component
                 'targetHouseholdBookingUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
                 'targetVehicleQuoteUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
                 'targetVehicleBookingUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetMoverooSubdomainUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetContactUsPageUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
             ]
         )->validate();
 
@@ -135,6 +145,8 @@ class WebPropertyDetail extends Component
             'target_household_booking_url' => $validated['targetHouseholdBookingUrl'],
             'target_vehicle_quote_url' => $validated['targetVehicleQuoteUrl'],
             'target_vehicle_booking_url' => $validated['targetVehicleBookingUrl'],
+            'target_moveroo_subdomain_url' => $validated['targetMoverooSubdomainUrl'],
+            'target_contact_us_page_url' => $validated['targetContactUsPageUrl'],
         ]);
 
         $this->loadProperty();

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -34,6 +34,8 @@ use Illuminate\Support\Str;
  * @property string|null $target_household_booking_url
  * @property string|null $target_vehicle_quote_url
  * @property string|null $target_vehicle_booking_url
+ * @property string|null $target_moveroo_subdomain_url
+ * @property string|null $target_contact_us_page_url
  * @property \Illuminate\Support\Carbon|null $conversion_links_scanned_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -70,6 +72,8 @@ class WebProperty extends Model
         'target_household_booking_url',
         'target_vehicle_quote_url',
         'target_vehicle_booking_url',
+        'target_moveroo_subdomain_url',
+        'target_contact_us_page_url',
         'conversion_links_scanned_at',
     ];
 
@@ -580,7 +584,9 @@ class WebProperty extends Model
      *     household_quote: string|null,
      *     household_booking: string|null,
      *     vehicle_quote: string|null,
-     *     vehicle_booking: string|null
+     *     vehicle_booking: string|null,
+     *     moveroo_subdomain: string|null,
+     *     contact_us_page: string|null
      *   },
      *   scanned_at: string|null
      * }
@@ -599,6 +605,8 @@ class WebProperty extends Model
                 'household_booking' => $this->target_household_booking_url,
                 'vehicle_quote' => $this->target_vehicle_quote_url,
                 'vehicle_booking' => $this->target_vehicle_booking_url,
+                'moveroo_subdomain' => $this->target_moveroo_subdomain_url,
+                'contact_us_page' => $this->target_contact_us_page_url,
             ],
             'scanned_at' => $this->conversion_links_scanned_at?->toIso8601String(),
         ];

--- a/database/migrations/2026_04_04_085309_add_target_reference_links_to_web_properties_table.php
+++ b/database/migrations/2026_04_04_085309_add_target_reference_links_to_web_properties_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->string('target_moveroo_subdomain_url', 2048)->nullable()->after('target_vehicle_booking_url');
+            $table->string('target_contact_us_page_url', 2048)->nullable()->after('target_moveroo_subdomain_url');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->dropColumn([
+                'target_moveroo_subdomain_url',
+                'target_contact_us_page_url',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -176,7 +176,7 @@
                     <div>
                         <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">Conversion Links</h4>
                         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                            Current URLs are scanned from the live site navigation. Target URLs are the future state Fleet should migrate toward once the new quote and booking surfaces are ready.
+                            Current URLs are scanned from the live site navigation. Target URLs are the admin-maintained source of truth Fleet should migrate toward for quote, booking, and fixed destination links.
                         </p>
                     </div>
 
@@ -258,6 +258,16 @@
                                 <label for="target_vehicle_booking_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Vehicle Booking</label>
                                 <input id="target_vehicle_booking_url" type="url" wire:model="targetVehicleBookingUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetVehicleBookingUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_moveroo_subdomain_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Moveroo Subdomain</label>
+                                <input id="target_moveroo_subdomain_url" type="url" wire:model="targetMoverooSubdomainUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetMoverooSubdomainUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_contact_us_page_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Contact Us Page</label>
+                                <input id="target_contact_us_page_url" type="url" wire:model="targetContactUsPageUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetContactUsPageUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                         </div>
                     </div>

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -59,6 +59,8 @@ class WebPropertyApiTest extends TestCase
             'current_vehicle_quote_url' => 'https://cars.moveroo.com.au/quote/v2',
             'target_household_quote_url' => 'https://quote.moveroo.com.au/household',
             'target_vehicle_quote_url' => 'https://quote.moveroo.com.au/vehicle',
+            'target_moveroo_subdomain_url' => 'https://wemove.moveroo.com.au',
+            'target_contact_us_page_url' => 'https://moveroo.com.au/contact-us',
             'conversion_links_scanned_at' => now(),
         ]);
 
@@ -195,6 +197,8 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.conversion_links.current.vehicle_booking', null)
             ->assertJsonPath('web_properties.0.conversion_links.target.household_quote', 'https://quote.moveroo.com.au/household')
             ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_quote', 'https://quote.moveroo.com.au/vehicle')
+            ->assertJsonPath('web_properties.0.conversion_links.target.moveroo_subdomain', 'https://wemove.moveroo.com.au')
+            ->assertJsonPath('web_properties.0.conversion_links.target.contact_us_page', 'https://moveroo.com.au/contact-us')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -45,6 +45,8 @@ class WebPropertyConversionLinksTest extends TestCase
             ->set('targetHouseholdBookingUrl', 'https://quote.moveroo.com.au/booking')
             ->set('targetVehicleQuoteUrl', 'https://quote.moveroo.com.au/vehicle')
             ->set('targetVehicleBookingUrl', 'https://quote.moveroo.com.au/vehicle-booking')
+            ->set('targetMoverooSubdomainUrl', 'https://wemove.moveroo.com.au')
+            ->set('targetContactUsPageUrl', 'https://moveroo.com.au/contact-us')
             ->call('saveConversionTargets')
             ->assertHasNoErrors();
 
@@ -54,6 +56,8 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://quote.moveroo.com.au/booking', $property->target_household_booking_url);
         $this->assertSame('https://quote.moveroo.com.au/vehicle', $property->target_vehicle_quote_url);
         $this->assertSame('https://quote.moveroo.com.au/vehicle-booking', $property->target_vehicle_booking_url);
+        $this->assertSame('https://wemove.moveroo.com.au', $property->target_moveroo_subdomain_url);
+        $this->assertSame('https://moveroo.com.au/contact-us', $property->target_contact_us_page_url);
     }
 
     public function test_property_detail_can_clear_target_conversion_links(): void
@@ -167,6 +171,7 @@ class WebPropertyConversionLinksTest extends TestCase
             Livewire::actingAs($user)
                 ->test(WebPropertyDetail::class, ['propertySlug' => 'moveroo-website'])
                 ->set('targetHouseholdQuoteUrl', 'https://quote.moveroo.com.au/household')
+                ->set('targetMoverooSubdomainUrl', 'https://wemove.moveroo.com.au')
                 ->call('saveConversionTargets')
                 ->assertForbidden();
         } finally {

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -138,6 +138,8 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('No Matomo snippet detected.');
         $response->assertSee('Conversion Links');
         $response->assertSee('Target Links');
+        $response->assertSee('Moveroo Subdomain');
+        $response->assertSee('Contact Us Page');
         $response->assertSee('Automation Checklist');
         $response->assertSee('Needs Matomo');
     }


### PR DESCRIPTION
## Summary
- add two admin-managed target link fields for `Moveroo Subdomain` and `Contact Us Page`
- surface both fields in the web property Conversion Links target form and persist them through Livewire
- expose the new canonical target links through the web property API contract and cover them in UI/API tests

## Why
These links need to live alongside the existing target conversion URLs as stable, property-level source-of-truth destinations that Fleet-managed systems can reference over time.

## Validation
- `php artisan test tests/Feature/WebPropertyConversionLinksTest.php tests/Feature/WebPropertyUiTest.php tests/Feature/WebPropertyApiTest.php`
- `vendor/bin/pint --dirty`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
