### PR TITLE
[codex] Expose target links to fleet inspections

### DIFF
--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -44,7 +44,7 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties:id,slug,name,property_type,status',
+                'webProperties:id,slug,name,property_type,status,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,conversion_links_scanned_at',
                 'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
             ])
@@ -766,6 +766,7 @@ class DashboardIssueQueueService
         $item['deployment_provider'] = $executionReadiness['deployment_provider'];
         $item['deployment_project_name'] = $executionReadiness['deployment_project_name'];
         $item['deployment_project_id'] = $executionReadiness['deployment_project_id'];
+        $item['conversion_links'] = $property?->conversionLinkSummary();
 
         return $item;
     }

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -97,17 +97,34 @@ class DetectedIssueSummaryService
         }
 
         $propertyName = null;
+        $conversionLinks = null;
         $platformProfile = null;
         $baselineSurface = null;
 
         if (is_string($verification->property_slug) && $verification->property_slug !== '') {
             $property = WebProperty::query()
-                ->select(['slug', 'name', 'property_type'])
+                ->select([
+                    'slug',
+                    'name',
+                    'property_type',
+                    'current_household_quote_url',
+                    'current_household_booking_url',
+                    'current_vehicle_quote_url',
+                    'current_vehicle_booking_url',
+                    'target_household_quote_url',
+                    'target_household_booking_url',
+                    'target_vehicle_quote_url',
+                    'target_vehicle_booking_url',
+                    'target_moveroo_subdomain_url',
+                    'target_contact_us_page_url',
+                    'conversion_links_scanned_at',
+                ])
                 ->where('slug', $verification->property_slug)
                 ->first();
 
             if ($property instanceof WebProperty) {
                 $propertyName = $property->name;
+                $conversionLinks = $property->conversionLinkSummary();
             }
         }
 
@@ -138,6 +155,7 @@ class DetectedIssueSummaryService
             'fleet_managed' => false,
             'controller_repo' => null,
             'controller_repo_url' => null,
+            'conversion_links' => $conversionLinks,
             'evidence' => [
                 'primary_reasons' => [],
                 'secondary_reasons' => [],
@@ -221,6 +239,7 @@ class DetectedIssueSummaryService
                 'fleet_managed' => (bool) ($item['fleet_managed'] ?? false),
                 'controller_repo' => is_string($item['controller_repo'] ?? null) ? $item['controller_repo'] : null,
                 'controller_repo_url' => is_string($item['controller_repo_url'] ?? null) ? $item['controller_repo_url'] : null,
+                'conversion_links' => is_array($item['conversion_links'] ?? null) ? $item['conversion_links'] : null,
                 'evidence' => [
                     'primary_reasons' => [$issueEntry['reason']],
                     'secondary_reasons' => array_values(array_filter(

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -33,6 +33,9 @@ class DashboardPriorityQueueApiTest extends TestCase
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $mustFixDomain->id,
+            'target_household_quote_url' => 'https://quote.must-fix.example.com/household',
+            'target_moveroo_subdomain_url' => 'https://must-fix.moveroo.com.au',
+            'target_contact_us_page_url' => 'https://must-fix.example.com/contact-us',
         ]);
 
         WebPropertyDomain::create([
@@ -218,6 +221,9 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('must_fix.0.issue_family', 'health.http')
             ->assertJsonPath('must_fix.0.control_id', 'transport.http_health')
             ->assertJsonPath('must_fix.0.platform_profile', 'wordpress_legacy_unmanaged')
+            ->assertJsonPath('must_fix.0.conversion_links.target.household_quote', 'https://quote.must-fix.example.com/household')
+            ->assertJsonPath('must_fix.0.conversion_links.target.moveroo_subdomain', 'https://must-fix.moveroo.com.au')
+            ->assertJsonPath('must_fix.0.conversion_links.target.contact_us_page', 'https://must-fix.example.com/contact-us')
             ->assertJsonPath('must_fix.0.rollout_scope', 'domain_only')
             ->assertJsonPath('must_fix.0.is_standard_gap', false);
 

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -33,6 +33,9 @@ class DetectedIssueApiTest extends TestCase
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $redirectDomain->id,
+            'target_household_quote_url' => 'https://quote.redirect-issue.example.com/household',
+            'target_moveroo_subdomain_url' => 'https://redirect-issue.moveroo.com.au',
+            'target_contact_us_page_url' => 'https://redirect-issue.example.com/contact-us',
         ]);
 
         WebPropertyDomain::create([
@@ -303,6 +306,9 @@ class DetectedIssueApiTest extends TestCase
         $this->assertTrue($redirectIssue['fleet_managed']);
         $this->assertSame('_wp-house', $redirectIssue['controller_repo']);
         $this->assertNull($redirectIssue['controller_repo_url']);
+        $this->assertSame('https://quote.redirect-issue.example.com/household', data_get($redirectIssue, 'conversion_links.target.household_quote'));
+        $this->assertSame('https://redirect-issue.moveroo.com.au', data_get($redirectIssue, 'conversion_links.target.moveroo_subdomain'));
+        $this->assertSame('https://redirect-issue.example.com/contact-us', data_get($redirectIssue, 'conversion_links.target.contact_us_page'));
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
         $this->assertSame(
             ['https://redirect-issue.example.com/', 'http://redirect-issue.example.com/'],
@@ -350,6 +356,8 @@ class DetectedIssueApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('issue_id', $redirectIssue['issue_id'])
             ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
+            ->assertJsonPath('conversion_links.target.moveroo_subdomain', 'https://redirect-issue.moveroo.com.au')
+            ->assertJsonPath('conversion_links.target.contact_us_page', 'https://redirect-issue.example.com/contact-us')
             ->assertJsonPath('evidence.source_domain_id', $redirectDomain->id)
             ->assertJsonPath('evidence.examples.0.url', 'https://redirect-issue.example.com/');
     }

--- a/tests/Feature/DetectedIssueVerificationApiTest.php
+++ b/tests/Feature/DetectedIssueVerificationApiTest.php
@@ -93,6 +93,8 @@ class DetectedIssueVerificationApiTest extends TestCase
             'property_type' => 'marketing_site',
             'status' => 'active',
             'primary_domain_id' => $domain->id,
+            'target_moveroo_subdomain_url' => 'https://suppressed-broken-links.moveroo.com.au',
+            'target_contact_us_page_url' => 'https://suppressed-broken-links.example.com/contact-us',
         ]);
 
         WebPropertyDomain::create([
@@ -162,6 +164,8 @@ class DetectedIssueVerificationApiTest extends TestCase
         ])->getJson('/api/issues/'.urlencode($issue['issue_id']))
             ->assertOk()
             ->assertJsonPath('status', 'verified_fixed_pending_recrawl')
+            ->assertJsonPath('conversion_links.target.moveroo_subdomain', 'https://suppressed-broken-links.moveroo.com.au')
+            ->assertJsonPath('conversion_links.target.contact_us_page', 'https://suppressed-broken-links.example.com/contact-us')
             ->assertJsonPath('evidence.broken_links.0.url', 'https://suppressed-broken-links.example.com/missing/')
             ->assertJsonPath('evidence.broken_links.0.found_on', 'https://suppressed-broken-links.example.com/start-here/');
     }


### PR DESCRIPTION
## Summary
- expose property-level `conversion_links` on Fleet-facing inspection payloads in `/api/dashboard/priority-queue`
- carry the same `conversion_links` context through `/api/issues` and `/api/issues/{issue_id}`
- add API coverage to lock in the new queue and issue contract fields

## Why
Fleet inspections need direct access to the target links without doing a second property lookup, so the inspection-facing feeds now include the same conversion link summary that the web property feed already exposes.

## Validation
- `php artisan test tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php`
- `vendor/bin/pint --dirty`
- `php artisan test`
- pre-PR review-swarm pass on the branch diff (no material findings)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
