### PR TITLE
Add safer production database access helpers

### DIFF
--- a/scripts/_prod-db-common.sh
+++ b/scripts/_prod-db-common.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROD_SSH_USER="${PROD_SSH_USER:-forge}"
+PROD_SSH_HOST="${PROD_SSH_HOST:-170.64.195.27}"
+PROD_APP_ROOT="${PROD_APP_ROOT:-/home/forge/monitor.again.com.au}"
+PROD_APP_ENV_FILE="${PROD_APP_ENV_FILE:-$PROD_APP_ROOT/.env}"
+
+run_remote_prod_psql() {
+    local -a psql_args=("$@")
+    local env_file_b64
+    local psql_args_b64
+
+    env_file_b64="$(printf '%s' "${PROD_APP_ENV_FILE}" | base64 | tr -d '\n')"
+
+    if [ "${#psql_args[@]}" -eq 0 ]; then
+        psql_args_b64=""
+    else
+        psql_args_b64="$(printf '%s\0' "${psql_args[@]}" | base64 | tr -d '\n')"
+    fi
+
+    ssh -o BatchMode=yes "${PROD_SSH_USER}@${PROD_SSH_HOST}" \
+        "PROD_APP_ENV_FILE_B64='${env_file_b64}' PSQL_ARGS_B64='${psql_args_b64}' bash -s" <<'BASH'
+set -euo pipefail
+
+env_file="$(printf '%s' "${PROD_APP_ENV_FILE_B64}" | base64 --decode)"
+
+psql_args=()
+
+if [ -n "${PSQL_ARGS_B64}" ]; then
+    while IFS= read -r -d '' arg; do
+        psql_args+=("$arg")
+    done < <(printf '%s' "${PSQL_ARGS_B64}" | base64 --decode)
+fi
+
+get_env_value_from_file() {
+    local key="$1"
+    local file_path="$2"
+    local line
+    local value
+
+    if [ ! -f "$file_path" ]; then
+        return 0
+    fi
+
+    line="$(grep -m1 -E "^[[:space:]]*${key}=" "$file_path" || true)"
+
+    if [ -z "$line" ]; then
+        return 0
+    fi
+
+    value="${line#*=}"
+    value="$(printf '%s' "$value" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+    if [[ "$value" == \"*\" && "$value" == *\" ]]; then
+        value="${value:1:${#value}-2}"
+        value="${value//\\\"/\"}"
+        value="${value//\\\\/\\}"
+    elif [[ "$value" == \'*\' && "$value" == *\' ]]; then
+        value="${value:1:${#value}-2}"
+    fi
+
+    printf '%s\n' "$value"
+}
+
+if [ ! -f "$env_file" ]; then
+    echo "Error: Production env file not found: $env_file" >&2
+    exit 1
+fi
+
+db_host="$(get_env_value_from_file "DB_HOST" "$env_file")"
+db_port="$(get_env_value_from_file "DB_PORT" "$env_file")"
+db_name="$(get_env_value_from_file "DB_DATABASE" "$env_file")"
+db_user="$(get_env_value_from_file "DB_USERNAME" "$env_file")"
+db_password="$(get_env_value_from_file "DB_PASSWORD" "$env_file")"
+
+if [ -z "$db_name" ] || [ -z "$db_user" ]; then
+    echo "Error: Missing DB_DATABASE or DB_USERNAME in $env_file" >&2
+    exit 1
+fi
+
+export PGPASSWORD="$db_password"
+export PGOPTIONS="${PGOPTIONS:+$PGOPTIONS }-c default_transaction_read_only=on"
+
+exec psql \
+    -h "${db_host:-127.0.0.1}" \
+    -p "${db_port:-5432}" \
+    -U "$db_user" \
+    -d "$db_name" \
+    "${psql_args[@]}"
+BASH
+}

--- a/scripts/_prod-db-common.sh
+++ b/scripts/_prod-db-common.sh
@@ -3,14 +3,28 @@
 set -euo pipefail
 
 PROD_SSH_USER="${PROD_SSH_USER:-forge}"
-PROD_SSH_HOST="${PROD_SSH_HOST:-170.64.195.27}"
-PROD_APP_ROOT="${PROD_APP_ROOT:-/home/forge/monitor.again.com.au}"
-PROD_APP_ENV_FILE="${PROD_APP_ENV_FILE:-$PROD_APP_ROOT/.env}"
+PROD_SSH_HOST="${PROD_SSH_HOST:-}"
+PROD_APP_ROOT="${PROD_APP_ROOT:-}"
+PROD_APP_ENV_FILE="${PROD_APP_ENV_FILE:-}"
 
 run_remote_prod_psql() {
     local -a psql_args=("$@")
     local env_file_b64
     local psql_args_b64
+
+    if [ -z "$PROD_SSH_HOST" ]; then
+        echo "Error: Set PROD_SSH_HOST before using the production DB helpers." >&2
+        exit 1
+    fi
+
+    if [ -z "$PROD_APP_ENV_FILE" ]; then
+        if [ -z "$PROD_APP_ROOT" ]; then
+            echo "Error: Set PROD_APP_ROOT or PROD_APP_ENV_FILE before using the production DB helpers." >&2
+            exit 1
+        fi
+
+        PROD_APP_ENV_FILE="$PROD_APP_ROOT/.env"
+    fi
 
     env_file_b64="$(printf '%s' "${PROD_APP_ENV_FILE}" | base64 | tr -d '\n')"
 

--- a/scripts/prod-db-query.sh
+++ b/scripts/prod-db-query.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./_prod-db-common.sh
+source "${SCRIPT_DIR}/_prod-db-common.sh"
+
+if [ "$#" -eq 0 ] || [ "${1:-}" = "--help" ]; then
+    cat <<'EOF'
+Usage: scripts/prod-db-query.sh "<sql>"
+
+Run a one-off SQL query against the production database via SSH with read-only defaults.
+
+Safety:
+  - This helper is intended for read queries.
+  - Read-only is a default session setting, not a hard database permission boundary.
+  - For truly enforced read-only access, use a dedicated read-only database role.
+
+Optional environment overrides:
+  PROD_SSH_USER
+  PROD_SSH_HOST
+  PROD_APP_ROOT
+  PROD_APP_ENV_FILE
+
+Examples:
+  scripts/prod-db-query.sh "select now();"
+  scripts/prod-db-query.sh "select count(*) from web_properties;"
+EOF
+    exit 0
+fi
+
+query="$1"
+
+normalized_query="$(printf '%s' "$query" | tr '\n' ' ' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+lowercase_query="$(printf '%s' "$normalized_query" | tr '[:upper:]' '[:lower:]')"
+multi_statement_pattern=';[[:space:]]*[^[:space:];]'
+
+if [ -z "$normalized_query" ]; then
+    echo "Error: Query must not be empty." >&2
+    exit 1
+fi
+
+if [[ "$normalized_query" =~ $multi_statement_pattern ]]; then
+    echo "Error: Multiple SQL statements are not allowed." >&2
+    exit 1
+fi
+
+case "$lowercase_query" in
+    select\ *|show\ *|explain\ *|values\ *|table\ *)
+        ;;
+    *)
+        echo "Error: Only clearly read-only SQL is allowed (SELECT, SHOW, EXPLAIN, VALUES, TABLE)." >&2
+        exit 1
+        ;;
+esac
+
+run_remote_prod_psql -X -v ON_ERROR_STOP=1 -P pager=off -c "$query"

--- a/scripts/prod-db-query.sh
+++ b/scripts/prod-db-query.sh
@@ -18,10 +18,12 @@ Safety:
   - Read-only is a default session setting, not a hard database permission boundary.
   - For truly enforced read-only access, use a dedicated read-only database role.
 
+Required environment overrides:
+  PROD_SSH_HOST
+
 Optional environment overrides:
   PROD_SSH_USER
-  PROD_SSH_HOST
-  PROD_APP_ROOT
+  PROD_APP_ROOT (or PROD_APP_ENV_FILE)
   PROD_APP_ENV_FILE
 
 Examples:
@@ -44,6 +46,11 @@ fi
 
 if [[ "$normalized_query" =~ $multi_statement_pattern ]]; then
     echo "Error: Multiple SQL statements are not allowed." >&2
+    exit 1
+fi
+
+if [[ "$lowercase_query" == explain\ * ]] && [[ "$lowercase_query" =~ (^|[[:space:][:punct:]])analyze([[:space:][:punct:]]|$) ]]; then
+    echo "Error: EXPLAIN ANALYZE is not allowed because it executes the underlying statement." >&2
     exit 1
 fi
 

--- a/scripts/prod-db-shell.sh
+++ b/scripts/prod-db-shell.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./_prod-db-common.sh
+source "${SCRIPT_DIR}/_prod-db-common.sh"
+
+if [ "${1:-}" = "--help" ]; then
+    cat <<'EOF'
+Usage: scripts/prod-db-shell.sh
+
+Interactive production DB shell access is intentionally disabled.
+
+Safety:
+  - The current production DB credentials are not a true read-only database role.
+  - Use scripts/prod-db-query.sh for one-off read queries.
+  - Re-enable shell access only after provisioning a dedicated read-only role.
+
+Optional environment overrides:
+  PROD_SSH_USER
+  PROD_SSH_HOST
+  PROD_APP_ROOT
+  PROD_APP_ENV_FILE
+
+Examples:
+  scripts/prod-db-shell.sh
+EOF
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+Interactive production DB shell access is disabled because the current
+application DB credentials are not a true read-only role.
+
+Use:
+  scripts/prod-db-query.sh "select now();"
+
+If you need a real interactive shell, first provision a dedicated read-only
+database user on production and update this helper to use that role.
+EOF
+exit 1

--- a/scripts/prod-db-shell.sh
+++ b/scripts/prod-db-shell.sh
@@ -18,10 +18,12 @@ Safety:
   - Use scripts/prod-db-query.sh for one-off read queries.
   - Re-enable shell access only after provisioning a dedicated read-only role.
 
+Required environment overrides:
+  PROD_SSH_HOST
+
 Optional environment overrides:
   PROD_SSH_USER
-  PROD_SSH_HOST
-  PROD_APP_ROOT
+  PROD_APP_ROOT (or PROD_APP_ENV_FILE)
   PROD_APP_ENV_FILE
 
 Examples:


### PR DESCRIPTION
## Summary
- add SSH-backed helper scripts for one-off production Postgres reads
- centralize remote env loading and `psql` invocation in a shared shell helper
- block interactive shell access until production has a dedicated read-only DB role

## Verification
- `bash -n scripts/_prod-db-common.sh scripts/prod-db-query.sh scripts/prod-db-shell.sh`
- `./scripts/prod-db-query.sh "select current_database() as db, current_user as db_user, current_setting('default_transaction_read_only') as read_only;"`
- `./scripts/prod-db-query.sh "update web_properties set updated_at = now();"`
- `./scripts/prod-db-query.sh $'select 1;\nselect 2;'`
- `./scripts/prod-db-shell.sh`

## Notes
- local-only `SERVER_ACCESS.md` was updated with the correct production app path and usage examples, but it is gitignored and not part of this PR.
- the current helper uses the application DB credentials with read-only session defaults; a true interactive shell should only be re-enabled after provisioning a dedicated read-only DB user.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
