### PR TITLE
Add Fleet property context refresh flow

### DIFF
--- a/app/Console/Commands/RefreshFleetContextCommand.php
+++ b/app/Console/Commands/RefreshFleetContextCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\FleetPropertyContextRefreshService;
+use Illuminate\Console\Command;
+
+class RefreshFleetContextCommand extends Command
+{
+    protected $signature = 'domains:refresh-fleet-context
+                            {--property= : Web property slug to refresh}
+                            {--force-search-console-api-enrichment : Force Search Console API enrichment refresh even if current enrichment is fresh}
+                            {--stale-days= : Override the Search Console enrichment staleness threshold in days}';
+
+    protected $description = 'Refresh the Fleet assessment context for a single web property';
+
+    public function handle(FleetPropertyContextRefreshService $service): int
+    {
+        $propertySlug = $this->option('property');
+
+        if (! is_string($propertySlug) || trim($propertySlug) === '') {
+            $this->error('Please provide --property=<slug>.');
+
+            return self::INVALID;
+        }
+
+        $staleDays = $this->validatedStaleDays();
+
+        if ($this->option('stale-days') !== null && $staleDays === null) {
+            $this->error('The --stale-days option must be an integer between 1 and 30.');
+
+            return self::INVALID;
+        }
+
+        try {
+            $summary = $service->refresh(
+                trim($propertySlug),
+                (bool) $this->option('force-search-console-api-enrichment'),
+                $staleDays,
+            );
+        } catch (\RuntimeException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->line((string) json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $summary['success'] ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function validatedStaleDays(): ?int
+    {
+        $value = $this->option('stale-days');
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) === false) {
+            return null;
+        }
+
+        $days = (int) $value;
+
+        if ($days < 1 || $days > 30) {
+            return null;
+        }
+
+        return $days;
+    }
+}

--- a/app/Http/Controllers/Api/WebPropertyFleetContextRefreshController.php
+++ b/app/Http/Controllers/Api/WebPropertyFleetContextRefreshController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\RefreshFleetPropertyContextRequest;
 use App\Services\FleetPropertyContextRefreshService;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 
 class WebPropertyFleetContextRefreshController extends Controller
@@ -20,7 +21,7 @@ class WebPropertyFleetContextRefreshController extends Controller
                 (bool) $request->boolean('force_search_console_api_enrichment'),
                 $request->integer('search_console_stale_days') ?: null,
             );
-        } catch (\RuntimeException $exception) {
+        } catch (ModelNotFoundException $exception) {
             return response()->json([
                 'success' => false,
                 'error' => 'Web property not found.',

--- a/app/Http/Controllers/Api/WebPropertyFleetContextRefreshController.php
+++ b/app/Http/Controllers/Api/WebPropertyFleetContextRefreshController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\RefreshFleetPropertyContextRequest;
+use App\Services\FleetPropertyContextRefreshService;
+use Illuminate\Http\JsonResponse;
+
+class WebPropertyFleetContextRefreshController extends Controller
+{
+    public function __invoke(
+        RefreshFleetPropertyContextRequest $request,
+        string $slug,
+        FleetPropertyContextRefreshService $service
+    ): JsonResponse {
+        try {
+            $summary = $service->refresh(
+                $slug,
+                (bool) $request->boolean('force_search_console_api_enrichment'),
+                $request->integer('search_console_stale_days') ?: null,
+            );
+        } catch (\RuntimeException $exception) {
+            return response()->json([
+                'success' => false,
+                'error' => 'Web property not found.',
+            ], 404);
+        }
+
+        return response()->json($summary, $summary['success'] ? 200 : 207);
+    }
+}

--- a/app/Http/Requests/RefreshFleetPropertyContextRequest.php
+++ b/app/Http/Requests/RefreshFleetPropertyContextRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class RefreshFleetPropertyContextRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'force_search_console_api_enrichment' => ['sometimes', 'boolean'],
+            'search_console_stale_days' => ['sometimes', 'integer', 'min:1', 'max:30'],
+        ];
+    }
+}

--- a/app/Http/Requests/RefreshFleetPropertyContextRequest.php
+++ b/app/Http/Requests/RefreshFleetPropertyContextRequest.php
@@ -24,4 +24,17 @@ class RefreshFleetPropertyContextRequest extends FormRequest
             'search_console_stale_days' => ['sometimes', 'integer', 'min:1', 'max:30'],
         ];
     }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'force_search_console_api_enrichment.boolean' => 'The force Search Console refresh flag must be true or false.',
+            'search_console_stale_days.integer' => 'The Search Console stale-days override must be a whole number.',
+            'search_console_stale_days.min' => 'The Search Console stale-days override must be at least 1 day.',
+            'search_console_stale_days.max' => 'The Search Console stale-days override may not be greater than 30 days.',
+        ];
+    }
 }

--- a/app/Services/DomainHealthCheckRunner.php
+++ b/app/Services/DomainHealthCheckRunner.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use Throwable;
+
+class DomainHealthCheckRunner
+{
+    public function __construct(
+        private readonly SecurityHeadersHealthCheck $securityHeadersHealthCheck,
+        private readonly SeoHealthCheck $seoHealthCheck,
+        private readonly BrokenLinkHealthCheck $brokenLinkHealthCheck,
+    ) {}
+
+    /**
+     * @return array{
+     *   status: 'refreshed'|'skipped'|'failed',
+     *   checked_at: string|null,
+     *   reason: string|null
+     * }
+     */
+    public function run(Domain $domain, string $type): array
+    {
+        if (! in_array($type, ['security_headers', 'seo', 'broken_links'], true)) {
+            throw new InvalidArgumentException("Unsupported Fleet health check type [{$type}].");
+        }
+
+        $domain->loadMissing('platform');
+
+        $skipReason = $domain->monitoringSkipReason($type);
+        if ($skipReason !== null) {
+            return [
+                'status' => 'skipped',
+                'checked_at' => $this->latestCheckTimestamp($domain, $type),
+                'reason' => $skipReason,
+            ];
+        }
+
+        try {
+            $startedAt = now();
+
+            if ($type === 'security_headers') {
+                $result = $this->securityHeadersHealthCheck->check($domain->domain);
+                $status = $this->determineWarnStatus($result);
+            } elseif ($type === 'seo') {
+                $result = $this->seoHealthCheck->check($domain->domain);
+                $status = $this->determineWarnStatus($result);
+            } else {
+                $result = $this->brokenLinkHealthCheck->check($domain->domain);
+                $status = $this->determineBrokenLinksStatus($result);
+            }
+
+            $payload = $result['payload'];
+            $duration = isset($payload['duration_ms']) && is_numeric($payload['duration_ms'])
+                ? (int) $payload['duration_ms']
+                : 0;
+
+            /** @var DomainCheck $check */
+            $check = $domain->checks()->create([
+                'check_type' => $type,
+                'status' => $status,
+                'response_code' => null,
+                'started_at' => $startedAt,
+                'finished_at' => now(),
+                'duration_ms' => $duration,
+                'error_message' => is_string($result['error_message'] ?? null) ? $result['error_message'] : null,
+                'payload' => $payload,
+                'retry_count' => 0,
+            ]);
+
+            $domain->forceFill(['last_checked_at' => now()])->save();
+
+            return [
+                'status' => 'refreshed',
+                'checked_at' => $check->finished_at?->toIso8601String(),
+                'reason' => null,
+            ];
+        } catch (Throwable $exception) {
+            Log::warning('Fleet property health check refresh failed', [
+                'domain_id' => $domain->id,
+                'domain' => $domain->domain,
+                'check_type' => $type,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'checked_at' => $this->latestCheckTimestamp($domain, $type),
+                'reason' => 'health_check_refresh_failed',
+            ];
+        }
+    }
+
+    private function latestCheckTimestamp(Domain $domain, string $type): ?string
+    {
+        $latestCheck = $domain->checks()
+            ->where('check_type', $type)
+            ->latest('finished_at')
+            ->first();
+
+        return $latestCheck?->finished_at?->toIso8601String();
+    }
+
+    /**
+     * @param  array{is_valid: bool, verified?: bool}  $result
+     */
+    private function determineWarnStatus(array $result): string
+    {
+        if (($result['verified'] ?? false) !== true) {
+            return 'unknown';
+        }
+
+        return $result['is_valid'] ? 'ok' : 'warn';
+    }
+
+    /**
+     * @param  array{is_valid: bool, verified?: bool}  $result
+     */
+    private function determineBrokenLinksStatus(array $result): string
+    {
+        if (($result['verified'] ?? false) !== true) {
+            return 'unknown';
+        }
+
+        return $result['is_valid'] ? 'ok' : 'fail';
+    }
+}

--- a/app/Services/FleetPropertyContextRefreshService.php
+++ b/app/Services/FleetPropertyContextRefreshService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Domain;
 use App\Models\WebProperty;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Log;
 
 class FleetPropertyContextRefreshService
@@ -74,7 +75,7 @@ class FleetPropertyContextRefreshService
             ->first();
 
         if (! $property instanceof WebProperty) {
-            throw new \RuntimeException("Web property [{$slug}] was not found.");
+            throw (new ModelNotFoundException)->setModel(WebProperty::class, [$slug]);
         }
 
         return $this->hydrateProperty($property);

--- a/app/Services/FleetPropertyContextRefreshService.php
+++ b/app/Services/FleetPropertyContextRefreshService.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\WebProperty;
+use Illuminate\Support\Facades\Log;
+
+class FleetPropertyContextRefreshService
+{
+    public function __construct(
+        private readonly PropertyConversionLinkScanner $conversionLinkScanner,
+        private readonly DomainHealthCheckRunner $domainHealthCheckRunner,
+        private readonly SearchConsoleApiEnrichmentRefresher $searchConsoleApiEnrichmentRefresher,
+    ) {}
+
+    /**
+     * @return array{
+     *   success: bool,
+     *   property_slug: string,
+     *   primary_domain: string|null,
+     *   refreshed: array<string, array<string, mixed>>
+     * }
+     */
+    public function refresh(WebProperty|string $property, bool $forceSearchConsoleApiEnrichment = false, ?int $searchConsoleStaleDays = null): array
+    {
+        $property = $property instanceof WebProperty
+            ? $this->hydrateProperty($property)
+            : $this->findPropertyOrFail($property);
+
+        $eligibility = $property->coverageEligibility();
+
+        if (! $eligibility['eligible']) {
+            return $this->ineligiblePropertySummary($property, (string) $eligibility['reason']);
+        }
+
+        $primaryDomain = $this->refreshableDomain($property);
+
+        $conversionLinks = $this->refreshConversionLinks($property);
+        $brokenLinks = $this->refreshHealthCheck($primaryDomain, 'broken_links');
+        $securityHeaders = $this->refreshHealthCheck($primaryDomain, 'security_headers');
+        $seo = $this->refreshHealthCheck($primaryDomain, 'seo');
+        $searchConsole = $this->searchConsoleApiEnrichmentRefresher->refreshProperty(
+            $property,
+            $searchConsoleStaleDays ?? max(1, (int) config('services.google.search_console.api_refresh_stale_days', 7)),
+            capturedBy: 'fleet_context_refresh',
+            force: $forceSearchConsoleApiEnrichment,
+        );
+
+        $steps = [
+            'conversion_links' => $conversionLinks,
+            'broken_links' => $brokenLinks,
+            'security_headers' => $securityHeaders,
+            'seo' => $seo,
+            'search_console_api_enrichment' => $searchConsole,
+        ];
+
+        $success = collect($steps)->every(
+            fn (array $step): bool => $step['status'] !== 'failed'
+        );
+
+        return [
+            'success' => $success,
+            'property_slug' => $property->slug,
+            'primary_domain' => $primaryDomain?->domain,
+            'refreshed' => $steps,
+        ];
+    }
+
+    private function findPropertyOrFail(string $slug): WebProperty
+    {
+        $property = WebProperty::query()
+            ->where('slug', $slug)
+            ->first();
+
+        if (! $property instanceof WebProperty) {
+            throw new \RuntimeException("Web property [{$slug}] was not found.");
+        }
+
+        return $this->hydrateProperty($property);
+    }
+
+    private function hydrateProperty(WebProperty $property): WebProperty
+    {
+        $property->loadMissing([
+            'propertyDomains.domain.platform',
+            'propertyDomains.domain.tags',
+            'analyticsSources.latestSearchConsoleCoverage',
+            'latestSeoBaselineForProperty',
+        ]);
+
+        return $property;
+    }
+
+    /**
+     * @return array{status:'refreshed'|'failed',scanned_at:string|null,reason:string|null}
+     */
+    private function refreshConversionLinks(WebProperty $property): array
+    {
+        try {
+            $scan = $this->conversionLinkScanner->persistForProperty($property);
+
+            return [
+                'status' => 'refreshed',
+                'scanned_at' => $scan['conversion_links_scanned_at']->toIso8601String(),
+                'reason' => null,
+            ];
+        } catch (\Throwable $exception) {
+            Log::warning('Fleet property conversion link refresh failed', [
+                'web_property_id' => $property->id,
+                'property_slug' => $property->slug,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'scanned_at' => $property->fresh()?->conversion_links_scanned_at?->toIso8601String(),
+                'reason' => 'conversion_links_refresh_failed',
+            ];
+        }
+    }
+
+    /**
+     * @return array{status:'refreshed'|'skipped'|'failed',checked_at:string|null,reason:string|null}
+     */
+    private function refreshHealthCheck(?\App\Models\Domain $domain, string $type): array
+    {
+        if (! $domain instanceof \App\Models\Domain) {
+            return [
+                'status' => 'skipped',
+                'checked_at' => null,
+                'reason' => 'Property does not have a primary domain.',
+            ];
+        }
+
+        return $this->domainHealthCheckRunner->run($domain, $type);
+    }
+
+    private function refreshableDomain(WebProperty $property): ?Domain
+    {
+        $canonicalLink = $property->canonicalDomainLink();
+
+        if ($canonicalLink !== null) {
+            return $canonicalLink->domain;
+        }
+
+        return $property->primaryDomainModel();
+    }
+
+    /**
+     * @return array{
+     *   success: bool,
+     *   property_slug: string,
+     *   primary_domain: string|null,
+     *   refreshed: array{
+     *     conversion_links: array{status:'skipped',scanned_at:null,reason:string},
+     *     broken_links: array{status:'skipped',checked_at:null,reason:string},
+     *     security_headers: array{status:'skipped',checked_at:null,reason:string},
+     *     seo: array{status:'skipped',checked_at:null,reason:string},
+     *     search_console_api_enrichment: array{status:'skipped',captured_at:null,reason:'ineligible',message:string}
+     *   }
+     * }
+     */
+    private function ineligiblePropertySummary(WebProperty $property, string $reason): array
+    {
+        $domain = $this->refreshableDomain($property);
+
+        return [
+            'success' => true,
+            'property_slug' => $property->slug,
+            'primary_domain' => $domain ? $domain->domain : null,
+            'refreshed' => [
+                'conversion_links' => [
+                    'status' => 'skipped',
+                    'scanned_at' => null,
+                    'reason' => $reason,
+                ],
+                'broken_links' => [
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => $reason,
+                ],
+                'security_headers' => [
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => $reason,
+                ],
+                'seo' => [
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => $reason,
+                ],
+                'search_console_api_enrichment' => [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'ineligible',
+                    'message' => 'Property is not eligible for Fleet context refresh.',
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Services/SearchConsoleApiEnrichmentRefresher.php
+++ b/app/Services/SearchConsoleApiEnrichmentRefresher.php
@@ -334,7 +334,7 @@ class SearchConsoleApiEnrichmentRefresher
     /**
      * @return array{
      *   eligible: bool,
-     *   reason: 'missing'|'ineligible',
+     *   reason: 'missing'|'ineligible'|null,
      *   message: string
      * }
      */
@@ -370,7 +370,7 @@ class SearchConsoleApiEnrichmentRefresher
 
         return [
             'eligible' => true,
-            'reason' => 'missing',
+            'reason' => null,
             'message' => '',
         ];
     }

--- a/app/Services/SearchConsoleApiEnrichmentRefresher.php
+++ b/app/Services/SearchConsoleApiEnrichmentRefresher.php
@@ -5,7 +5,9 @@ namespace App\Services;
 use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use RuntimeException;
 
 class SearchConsoleApiEnrichmentRefresher
@@ -13,6 +15,7 @@ class SearchConsoleApiEnrichmentRefresher
     public function __construct(
         private readonly SearchConsoleApiBundleCollector $collector,
         private readonly SearchConsoleApiBundleImporter $importer,
+        private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
     ) {}
 
     /**
@@ -129,6 +132,108 @@ class SearchConsoleApiEnrichmentRefresher
     }
 
     /**
+     * @return array{
+     *   status: 'refreshed'|'skipped'|'failed',
+     *   captured_at: string|null,
+     *   reason: 'fresh'|'stale'|'missing'|'explicit'|'ineligible',
+     *   message: string|null
+     * }
+     */
+    public function refreshProperty(
+        WebProperty $property,
+        int $staleDays = 7,
+        int $days = 28,
+        ?int $urlLimit = null,
+        ?int $rowLimit = null,
+        string $captureMethod = 'gsc_api',
+        ?string $capturedBy = null,
+        bool $force = false,
+    ): array {
+        $latestApiCapturedAt = $this->latestApiCapturedAtForProperty($property);
+        $reason = $this->refreshReason($latestApiCapturedAt, $staleDays, $force);
+
+        if (! $force && $reason === 'fresh') {
+            return [
+                'status' => 'skipped',
+                'captured_at' => $latestApiCapturedAt?->toIso8601String(),
+                'reason' => 'fresh',
+                'message' => null,
+            ];
+        }
+
+        $guard = $this->refreshPropertyGuard($property);
+
+        if (! $guard['eligible']) {
+            return [
+                'status' => 'skipped',
+                'captured_at' => $latestApiCapturedAt?->toIso8601String(),
+                'reason' => $guard['reason'],
+                'message' => $guard['message'],
+            ];
+        }
+
+        try {
+            $bundle = $this->collector->collectBundleForProperty(
+                $property,
+                $days,
+                $urlLimit,
+                $rowLimit,
+            );
+
+            $temporaryPath = tempnam(sys_get_temp_dir(), 'gsc-refresh-bundle-');
+
+            if (! is_string($temporaryPath)) {
+                throw new RuntimeException('Unable to create a temporary Search Console API bundle file.');
+            }
+
+            try {
+                $encodedBundle = json_encode($bundle, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+                $bytesWritten = file_put_contents($temporaryPath, $encodedBundle);
+
+                if ($bytesWritten === false) {
+                    throw new RuntimeException('Unable to write the temporary Search Console API bundle file.');
+                }
+
+                $imported = $this->importer->importBundleForProperty(
+                    $property,
+                    $temporaryPath,
+                    $captureMethod,
+                    $capturedBy ?: 'scheduled_api_enrichment_refresh'
+                );
+            } finally {
+                @unlink($temporaryPath);
+            }
+
+            /** @var Carbon|null $capturedAt */
+            $capturedAt = collect($imported['snapshots'])
+                ->map(fn (SearchConsoleIssueSnapshot $snapshot): ?Carbon => $this->normalizeCapturedAt($snapshot->captured_at))
+                ->filter()
+                ->max();
+
+            return [
+                'status' => 'refreshed',
+                'captured_at' => $capturedAt?->toIso8601String() ?? $this->latestApiCapturedAtForProperty($property)?->toIso8601String(),
+                'reason' => $reason,
+                'message' => null,
+            ];
+        } catch (\Throwable $exception) {
+            Log::warning('Fleet property Search Console API enrichment refresh failed', [
+                'web_property_id' => $property->id,
+                'property_slug' => $property->slug,
+                'reason' => $reason,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'captured_at' => $latestApiCapturedAt?->toIso8601String(),
+                'reason' => $reason,
+                'message' => 'Search Console API enrichment refresh failed.',
+            ];
+        }
+    }
+
+    /**
      * @return Collection<int, WebProperty>
      */
     public function candidateProperties(int $staleDays = 7, int $batchLimit = 3): Collection
@@ -214,5 +319,84 @@ class SearchConsoleApiEnrichmentRefresher
         }
 
         return null;
+    }
+
+    public function latestApiCapturedAtForProperty(WebProperty $property): ?Carbon
+    {
+        return $this->normalizeCapturedAt(
+            SearchConsoleIssueSnapshot::query()
+                ->where('web_property_id', $property->id)
+                ->where('capture_method', '!=', 'gsc_drilldown_zip')
+                ->max('captured_at')
+        );
+    }
+
+    /**
+     * @return array{
+     *   eligible: bool,
+     *   reason: 'missing'|'ineligible',
+     *   message: string
+     * }
+     */
+    private function refreshPropertyGuard(WebProperty $property): array
+    {
+        $eligibility = $property->coverageEligibility();
+
+        if (! $eligibility['eligible']) {
+            return [
+                'eligible' => false,
+                'reason' => 'ineligible',
+                'message' => 'Property is not eligible for Search Console API enrichment refresh.',
+            ];
+        }
+
+        $searchConsolePropertyUri = $property->searchConsolePropertyUri();
+
+        if (! is_string($searchConsolePropertyUri) || $searchConsolePropertyUri === '') {
+            return [
+                'eligible' => false,
+                'reason' => 'missing',
+                'message' => 'No Search Console property mapping is available for refresh.',
+            ];
+        }
+
+        if (! $this->hasCurrentDrilldownIssueEvidence($property)) {
+            return [
+                'eligible' => false,
+                'reason' => 'missing',
+                'message' => 'No Search Console issue detail evidence is available for enrichment.',
+            ];
+        }
+
+        return [
+            'eligible' => true,
+            'reason' => 'missing',
+            'message' => '',
+        ];
+    }
+
+    private function hasCurrentDrilldownIssueEvidence(WebProperty $property): bool
+    {
+        return collect($this->issueEvidenceService->propertyIssueSummaries($property))
+            ->contains(function (array $summary): bool {
+                return ($summary['detail_snapshot_id'] ?? null) !== null
+                    || ($summary['source_capture_method'] ?? null) === 'gsc_drilldown_zip';
+            });
+    }
+
+    /**
+     * @return 'explicit'|'fresh'|'missing'|'stale'
+     */
+    private function refreshReason(?Carbon $latestApiCapturedAt, int $staleDays, bool $force): string
+    {
+        if ($force) {
+            return 'explicit';
+        }
+
+        if (! $latestApiCapturedAt instanceof Carbon) {
+            return 'missing';
+        }
+
+        return $latestApiCapturedAt->lt(now()->subDays(max(1, $staleDays))) ? 'stale' : 'fresh';
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\DomainController;
 use App\Http\Controllers\Api\IntegrationMetaController;
 use App\Http\Controllers\Api\TagController;
 use App\Http\Controllers\Api\WebPropertyController;
+use App\Http\Controllers\Api\WebPropertyFleetContextRefreshController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -35,6 +36,8 @@ Route::middleware(['api-key'])->group(function () {
     Route::get('/web-properties', [WebPropertyController::class, 'index']);
     Route::get('/web-properties-summary', [WebPropertyController::class, 'summary']);
     Route::get('/web-properties/{slug}', [WebPropertyController::class, 'show']);
+    Route::post('/web-properties/{slug}/refresh-fleet-context', WebPropertyFleetContextRefreshController::class)
+        ->middleware('fleet-control-api-key');
     Route::get('/web-properties/{slug}/health-summary', [WebPropertyController::class, 'healthSummary']);
     Route::get('/dashboard/priority-queue', DashboardPriorityQueueController::class);
     Route::get('/issues', [DetectedIssueController::class, 'index']);

--- a/tests/Feature/FleetPropertyContextRefreshTest.php
+++ b/tests/Feature/FleetPropertyContextRefreshTest.php
@@ -1,0 +1,770 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DetectedIssueVerification;
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use App\Models\DomainTag;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleCoverageStatus;
+use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use App\Services\DetectedIssueIdentityService;
+use App\Services\DomainHealthCheckRunner;
+use App\Services\FleetPropertyContextRefreshService;
+use App\Services\PropertyConversionLinkScanner;
+use App\Services\SearchConsoleApiEnrichmentRefresher;
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class FleetPropertyContextRefreshTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_property_refresh_command_updates_conversion_link_timestamps(): void
+    {
+        $property = $this->makeProperty('refresh-links-site', 'refresh-links.example.com');
+
+        Http::fake([
+            'https://refresh-links.example.com' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://refresh-links.example.com/quote/household">Moving Quote</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => [
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => "Skipped {$type} in conversion link test.",
+                ]);
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        $this->artisan('domains:refresh-fleet-context', [
+            '--property' => 'refresh-links-site',
+        ])->assertSuccessful();
+
+        $property->refresh();
+
+        $this->assertSame('https://refresh-links.example.com/quote/household', $property->current_household_quote_url);
+        $this->assertNotNull($property->conversion_links_scanned_at);
+    }
+
+    public function test_property_refresh_command_updates_supported_health_check_results(): void
+    {
+        $property = $this->makeProperty('refresh-health-site', 'refresh-health.example.com');
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        Http::fake([
+            'https://refresh-health.example.com' => Http::response(
+                '<html><body><a href="/missing-page">Missing page</a></body></html>',
+                200,
+                [
+                    'Content-Type' => 'text/html; charset=UTF-8',
+                    'Strict-Transport-Security' => 'max-age=600',
+                    'X-Frame-Options' => 'SAMEORIGIN',
+                    'X-Content-Type-Options' => 'nosniff',
+                ]
+            ),
+            'https://refresh-health.example.com/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
+            'https://refresh-health.example.com/sitemap.xml' => Http::response('', 404),
+            'https://refresh-health.example.com/sitemap_index.xml' => Http::response('<xml></xml>', 200),
+            'https://refresh-health.example.com/missing-page' => Http::response('', 404),
+        ]);
+
+        $this->artisan('domains:refresh-fleet-context', [
+            '--property' => 'refresh-health-site',
+        ])->assertSuccessful();
+
+        $domainId = $property->primary_domain_id;
+
+        $this->assertSame('fail', DomainCheck::query()->where('domain_id', $domainId)->where('check_type', 'broken_links')->latest('finished_at')->first()?->status);
+        $this->assertSame('warn', DomainCheck::query()->where('domain_id', $domainId)->where('check_type', 'security_headers')->latest('finished_at')->first()?->status);
+        $this->assertSame('ok', DomainCheck::query()->where('domain_id', $domainId)->where('check_type', 'seo')->latest('finished_at')->first()?->status);
+    }
+
+    public function test_search_console_refresh_is_skipped_when_fresh(): void
+    {
+        Storage::fake('local');
+
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('fresh-gsc-site', 'fresh-gsc.example.com', withSearchConsoleCoverage: true);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_api',
+            'captured_at' => now()->subDay(),
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturn([
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => 'Skipped in Search Console freshness test.',
+                ]);
+        });
+
+        Http::fake();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/fresh-gsc-site/refresh-fleet-context');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('refreshed.search_console_api_enrichment.status', 'skipped')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'fresh');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_search_console_refresh_is_skipped_for_manually_excluded_properties(): void
+    {
+        Storage::fake('local');
+
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('excluded-gsc-site', 'excluded-gsc.example.com', withSearchConsoleCoverage: true);
+
+        $manualExclusionTag = DomainTag::firstOrCreate(['name' => 'coverage.excluded']);
+        $property->primaryDomainModel()?->tags()->syncWithoutDetaching([$manualExclusionTag->id]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+        ]);
+
+        Http::fake();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/excluded-gsc-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('refreshed.conversion_links.status', 'skipped')
+            ->assertJsonPath('refreshed.conversion_links.reason', 'primary domain is manually excluded from fleet coverage')
+            ->assertJsonPath('refreshed.broken_links.status', 'skipped')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.status', 'skipped')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'ineligible')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.message', 'Property is not eligible for Fleet context refresh.');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_search_console_refresh_runs_when_stale(): void
+    {
+        Storage::fake('local');
+
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+        config()->set('services.google.search_console.access_token', null);
+        config()->set('services.google.search_console.refresh_token', 'test-refresh-token');
+        config()->set('services.google.search_console.client_id', 'test-client-id');
+        config()->set('services.google.search_console.client_secret', 'test-client-secret');
+        config()->set('services.google.search_console.language_code', 'en-AU');
+        config()->set('services.google.search_console.inspection_request_delay_micros', 0);
+
+        $property = $this->makeProperty('stale-gsc-site', 'stale-gsc.example.com', withSearchConsoleCoverage: true);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://stale-gsc.example.com/old-page/'],
+            'examples' => [
+                ['url' => 'https://stale-gsc.example.com/old-page/', 'last_crawled' => '2026-03-28'],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://stale-gsc.example.com/old-page/'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_api',
+            'captured_at' => now()->subDays(10),
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturn([
+                    'status' => 'skipped',
+                    'checked_at' => null,
+                    'reason' => 'Skipped in Search Console stale test.',
+                ]);
+        });
+
+        Http::fake([
+            'https://oauth2.googleapis.com/token' => Http::response([
+                'access_token' => 'refreshed-access-token',
+                'expires_in' => 3600,
+                'token_type' => 'Bearer',
+            ], 200),
+            'https://www.googleapis.com/webmasters/v3/sites/*/sitemaps' => Http::response([
+                'sitemap' => [
+                    [
+                        'path' => 'https://stale-gsc.example.com/sitemap_index.xml',
+                        'warnings' => '0',
+                        'errors' => '0',
+                    ],
+                ],
+            ], 200),
+            'https://www.googleapis.com/webmasters/v3/sites/*/searchAnalytics/query' => Http::response([
+                'rows' => [
+                    [
+                        'keys' => ['https://stale-gsc.example.com/old-page/'],
+                        'clicks' => 5,
+                        'impressions' => 50,
+                        'ctr' => 0.1,
+                        'position' => 8.2,
+                    ],
+                ],
+            ], 200),
+            'https://searchconsole.googleapis.com/v1/urlInspection/index:inspect' => Http::response([
+                'inspectionResult' => [
+                    'indexStatusResult' => [
+                        'coverageState' => 'Page with redirect',
+                        'robotsTxtState' => 'ALLOWED',
+                        'indexingState' => 'INDEXING_ALLOWED',
+                        'pageFetchState' => 'SUCCESSFUL',
+                        'lastCrawlTime' => '2026-04-01T00:00:00Z',
+                        'googleCanonical' => 'https://stale-gsc.example.com/new-page/',
+                        'userCanonical' => 'https://stale-gsc.example.com/old-page/',
+                        'referringUrls' => ['https://stale-gsc.example.com/sitemap_index.xml'],
+                        'sitemap' => ['https://stale-gsc.example.com/sitemap_index.xml'],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/stale-gsc-site/refresh-fleet-context');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('refreshed.search_console_api_enrichment.status', 'refreshed')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'stale');
+
+        $this->assertSame(
+            2,
+            SearchConsoleIssueSnapshot::query()
+                ->where('web_property_id', $property->id)
+                ->where('capture_method', 'gsc_api')
+                ->count()
+        );
+    }
+
+    public function test_active_api_outputs_reflect_refreshed_state_after_endpoint_runs(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('api-refresh-site', 'api-refresh.example.com');
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        Http::fake([
+            'https://api-refresh.example.com' => Http::response(
+                <<<'HTML'
+                    <html>
+                        <body>
+                            <header>
+                                <a href="https://api-refresh.example.com/quote/household">Moving Quote</a>
+                            </header>
+                            <main>
+                                <a href="/missing-page">Missing page</a>
+                            </main>
+                        </body>
+                    </html>
+                HTML,
+                200,
+                [
+                    'Content-Type' => 'text/html; charset=UTF-8',
+                    'Strict-Transport-Security' => 'max-age=600',
+                    'X-Frame-Options' => 'SAMEORIGIN',
+                    'X-Content-Type-Options' => 'nosniff',
+                ]
+            ),
+            'https://api-refresh.example.com/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
+            'https://api-refresh.example.com/sitemap.xml' => Http::response('', 404),
+            'https://api-refresh.example.com/sitemap_index.xml' => Http::response('<xml></xml>', 200),
+            'https://api-refresh.example.com/missing-page' => Http::response('', 404),
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/api-refresh-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('refreshed.conversion_links.status', 'refreshed')
+            ->assertJsonPath('refreshed.broken_links.status', 'refreshed');
+
+        $propertyResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties/api-refresh-site')
+            ->assertOk()
+            ->assertJsonPath('data.slug', 'api-refresh-site')
+            ->assertJsonPath('data.conversion_links.current.household_quote', 'https://api-refresh.example.com/quote/household')
+            ->assertJsonPath('data.health_summary.checks.broken_links', 'fail');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary')
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'api-refresh-site')
+            ->assertJsonPath('web_properties.0.conversion_links.current.household_quote', 'https://api-refresh.example.com/quote/household');
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        /** @var array<string, mixed>|null $brokenLinksIssue */
+        $brokenLinksIssue = collect($issues)->firstWhere('issue_class', 'seo.broken_links');
+
+        $this->assertIsArray($brokenLinksIssue);
+        $this->assertSame('api-refresh-site', $brokenLinksIssue['property_slug']);
+
+        $issueDetailResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode((string) $brokenLinksIssue['issue_id']))
+            ->assertOk()
+            ->assertJsonPath('issue_class', 'seo.broken_links')
+            ->assertJsonPath('property_slug', 'api-refresh-site');
+
+        $this->assertContains(
+            'https://api-refresh.example.com/missing-page',
+            array_column($issueDetailResponse->json('evidence.broken_links') ?? [], 'url')
+        );
+    }
+
+    public function test_search_console_refresh_is_skipped_when_current_issue_evidence_is_suppressed(): void
+    {
+        Storage::fake('local');
+
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('suppressed-gsc-site', 'suppressed-gsc.example.com', withSearchConsoleCoverage: true);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primaryDomainModel()?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+        ]);
+
+        $issueId = app(DetectedIssueIdentityService::class)->makeIssueId(
+            (string) $property->primaryDomainModel()?->id,
+            $property->slug,
+            'page_with_redirect_in_sitemap'
+        );
+
+        DetectedIssueVerification::create([
+            'issue_id' => $issueId,
+            'property_slug' => $property->slug,
+            'domain' => $property->primaryDomainName(),
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'status' => 'verified_fixed_pending_recrawl',
+            'hidden_until' => now()->addDay(),
+            'verified_at' => now(),
+            'evidence' => [
+                'captured_at' => now()->subDay()->toIso8601String(),
+            ],
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => $this->skippedHealthResult($type));
+        });
+
+        Http::fake();
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/suppressed-gsc-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('refreshed.search_console_api_enrichment.status', 'skipped')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'missing')
+            ->assertJsonPath('refreshed.search_console_api_enrichment.message', 'No Search Console issue detail evidence is available for enrichment.');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_health_checks_refresh_the_canonical_domain_used_by_api_rollups(): void
+    {
+        $property = $this->makeProperty('canonical-refresh-site', 'non-canonical.example.com');
+        $canonicalDomain = Domain::factory()->create([
+            'domain' => 'canonical-refresh.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property->propertyDomains()->update(['is_canonical' => false]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $canonicalDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $property->refresh()->load('propertyDomains.domain');
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock) use ($canonicalDomain): void {
+            $mock->shouldReceive('run')
+                ->once()
+                ->withArgs(fn (Domain $domain, string $type): bool => $domain->is($canonicalDomain) && $type === 'broken_links')
+                ->andReturn($this->skippedHealthResult('broken_links'));
+            $mock->shouldReceive('run')
+                ->once()
+                ->withArgs(fn (Domain $domain, string $type): bool => $domain->is($canonicalDomain) && $type === 'security_headers')
+                ->andReturn($this->skippedHealthResult('security_headers'));
+            $mock->shouldReceive('run')
+                ->once()
+                ->withArgs(fn (Domain $domain, string $type): bool => $domain->is($canonicalDomain) && $type === 'seo')
+                ->andReturn($this->skippedHealthResult('seo'));
+        });
+
+        $this->artisan('domains:refresh-fleet-context', [
+            '--property' => 'canonical-refresh-site',
+        ])->assertSuccessful();
+    }
+
+    public function test_refresh_endpoint_sanitizes_failed_step_errors(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $this->makeProperty('failed-refresh-site', 'failed-refresh.example.com');
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andThrow(new \RuntimeException('Scanner failed for https://failed-refresh.example.com/private-path'));
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => $this->skippedHealthResult($type));
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/failed-refresh-site/refresh-fleet-context');
+
+        $response->assertStatus(207)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('refreshed.conversion_links.status', 'failed')
+            ->assertJsonPath('refreshed.conversion_links.reason', 'conversion_links_refresh_failed');
+
+        $content = (string) $response->getContent();
+
+        $this->assertStringNotContainsString(
+            'https://failed-refresh.example.com/private-path',
+            $content
+        );
+    }
+
+    public function test_refresh_only_updates_the_requested_property_scope(): void
+    {
+        $targetProperty = $this->makeProperty('target-scope-site', 'target-scope.example.com');
+        $otherProperty = $this->makeProperty('other-scope-site', 'other-scope.example.com');
+        $otherScannedAt = now()->subDays(3);
+
+        $otherProperty->forceFill([
+            'current_household_quote_url' => 'https://other-scope.example.com/existing-quote',
+            'conversion_links_scanned_at' => $otherScannedAt,
+        ])->save();
+
+        Http::fake([
+            'https://target-scope.example.com' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://target-scope.example.com/quote/household">Moving Quote</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://target-scope.example.com/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
+            'https://target-scope.example.com/sitemap.xml' => Http::response('<xml></xml>', 200),
+            'https://target-scope.example.com/sitemap_index.xml' => Http::response('<xml></xml>', 200),
+        ]);
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock) use ($targetProperty): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->withArgs(fn (WebProperty $property): bool => $property->is($targetProperty))
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'missing',
+                    'message' => 'No Search Console issue detail evidence is available for enrichment.',
+                ]);
+        });
+
+        $this->artisan('domains:refresh-fleet-context', [
+            '--property' => 'target-scope-site',
+        ])->assertSuccessful();
+
+        $targetProperty->refresh();
+        $otherProperty->refresh();
+
+        $this->assertSame('https://target-scope.example.com/quote/household', $targetProperty->current_household_quote_url);
+        $this->assertNotNull($targetProperty->conversion_links_scanned_at);
+        $this->assertSame('https://other-scope.example.com/existing-quote', $otherProperty->current_household_quote_url);
+        $this->assertSame(
+            $otherScannedAt->toDateTimeString(),
+            $otherProperty->conversion_links_scanned_at?->toDateTimeString()
+        );
+        $this->assertSame(0, DomainCheck::query()->where('domain_id', $otherProperty->primary_domain_id)->count());
+    }
+
+    public function test_refresh_command_rejects_invalid_stale_day_override(): void
+    {
+        $this->mock(FleetPropertyContextRefreshService::class, function (MockInterface $mock): void {
+            $mock->shouldNotReceive('refresh');
+        });
+
+        $this->artisan('domains:refresh-fleet-context', [
+            '--property' => 'refresh-links-site',
+            '--stale-days' => 'abc',
+        ])
+            ->expectsOutputToContain('The --stale-days option must be an integer between 1 and 30.')
+            ->assertExitCode(Command::INVALID);
+    }
+
+    /**
+     * @return array{status: string, checked_at: string|null, reason: string|null}
+     */
+    private function skippedHealthResult(string $type): array
+    {
+        return [
+            'status' => 'skipped',
+            'checked_at' => null,
+            'reason' => "Skipped {$type}.",
+        ];
+    }
+
+    private function makeProperty(string $slug, string $domainName, bool $withSearchConsoleCoverage = false): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => $slug,
+            'name' => Str::of($slug)->replace('-', ' ')->title()->toString(),
+            'status' => 'active',
+            'property_type' => 'website',
+            'production_url' => 'https://'.$domainName,
+            'primary_domain_id' => $domain->id,
+            'target_household_quote_url' => 'https://'.$domainName.'/target-household',
+            'target_moveroo_subdomain_url' => 'https://'.$slug.'.moveroo.com.au',
+            'target_contact_us_page_url' => 'https://'.$domainName.'/contact-us',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => '_wp-house',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/_wp-house',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+            'is_controller' => true,
+        ]);
+
+        if ($withSearchConsoleCoverage) {
+            $source = PropertyAnalyticsSource::create([
+                'web_property_id' => $property->id,
+                'provider' => 'matomo',
+                'external_id' => '999',
+                'external_name' => $property->name,
+                'is_primary' => true,
+                'status' => 'active',
+            ]);
+
+            SearchConsoleCoverageStatus::create([
+                'domain_id' => $domain->id,
+                'web_property_id' => $property->id,
+                'property_analytics_source_id' => $source->id,
+                'source_provider' => 'matomo',
+                'matomo_site_id' => '999',
+                'matomo_site_name' => $property->name,
+                'mapping_state' => 'domain_property',
+                'property_uri' => 'sc-domain:'.$domainName,
+                'property_type' => 'domain',
+                'latest_metric_date' => now()->subDay()->toDateString(),
+                'checked_at' => now(),
+            ]);
+        }
+
+        return $property;
+    }
+}


### PR DESCRIPTION
## Summary
- add a property-scoped Fleet refresh flow that refreshes conversion links, selected health checks, and stale-aware Search Console enrichment
- expose the refresh through `domains:refresh-fleet-context --property=...` and `POST /api/web-properties/{slug}/refresh-fleet-context` using the same underlying service and persisted models the read APIs already use
- keep the refresh conservative by respecting Fleet coverage eligibility, canonical-domain health targeting, current unsuppressed Search Console evidence, sanitized failure responses, and property-scope-only behavior

## Verification
- `php artisan test tests/Feature/FleetPropertyContextRefreshTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/RefreshSearchConsoleApiEnrichmentCommandTest.php tests/Feature/WebPropertyConversionLinksTest.php`
- `./vendor/bin/phpstan analyse app/Services/SearchConsoleApiEnrichmentRefresher.php app/Services/FleetPropertyContextRefreshService.php app/Services/DomainHealthCheckRunner.php app/Http/Controllers/Api/WebPropertyFleetContextRefreshController.php app/Http/Requests/RefreshFleetPropertyContextRequest.php app/Console/Commands/RefreshFleetContextCommand.php --memory-limit=2G`
- `composer pr:preflight`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
