### PR TITLE
Expose legacy Moveroo endpoint drift evidence

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -37,6 +37,10 @@ class WebPropertyDetail extends Component
 
     public ?string $targetContactUsPageUrl = null;
 
+    public ?string $targetLegacyBookingsReplacementUrl = null;
+
+    public ?string $targetLegacyPaymentsReplacementUrl = null;
+
     public function mount(): void
     {
         $this->loadProperty();
@@ -73,6 +77,8 @@ class WebPropertyDetail extends Component
         $this->targetVehicleBookingUrl = $this->property->target_vehicle_booking_url;
         $this->targetMoverooSubdomainUrl = $this->property->target_moveroo_subdomain_url;
         $this->targetContactUsPageUrl = $this->property->target_contact_us_page_url;
+        $this->targetLegacyBookingsReplacementUrl = $this->property->target_legacy_bookings_replacement_url;
+        $this->targetLegacyPaymentsReplacementUrl = $this->property->target_legacy_payments_replacement_url;
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -124,6 +130,8 @@ class WebPropertyDetail extends Component
             'targetVehicleBookingUrl' => $this->normalizeTargetUrl($this->targetVehicleBookingUrl),
             'targetMoverooSubdomainUrl' => $this->normalizeTargetUrl($this->targetMoverooSubdomainUrl),
             'targetContactUsPageUrl' => $this->normalizeTargetUrl($this->targetContactUsPageUrl),
+            'targetLegacyBookingsReplacementUrl' => $this->normalizeTargetUrl($this->targetLegacyBookingsReplacementUrl),
+            'targetLegacyPaymentsReplacementUrl' => $this->normalizeTargetUrl($this->targetLegacyPaymentsReplacementUrl),
         ];
 
         $this->resetValidation();
@@ -137,6 +145,8 @@ class WebPropertyDetail extends Component
                 'targetVehicleBookingUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
                 'targetMoverooSubdomainUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
                 'targetContactUsPageUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetLegacyBookingsReplacementUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
+                'targetLegacyPaymentsReplacementUrl' => ['nullable', 'url', 'max:2048', 'regex:/^https?:\\/\\//i'],
             ]
         )->validate();
 
@@ -147,6 +157,8 @@ class WebPropertyDetail extends Component
             'target_vehicle_booking_url' => $validated['targetVehicleBookingUrl'],
             'target_moveroo_subdomain_url' => $validated['targetMoverooSubdomainUrl'],
             'target_contact_us_page_url' => $validated['targetContactUsPageUrl'],
+            'target_legacy_bookings_replacement_url' => $validated['targetLegacyBookingsReplacementUrl'],
+            'target_legacy_payments_replacement_url' => $validated['targetLegacyPaymentsReplacementUrl'],
         ]);
 
         $this->loadProperty();

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -36,6 +36,9 @@ use Illuminate\Support\Str;
  * @property string|null $target_vehicle_booking_url
  * @property string|null $target_moveroo_subdomain_url
  * @property string|null $target_contact_us_page_url
+ * @property string|null $target_legacy_bookings_replacement_url
+ * @property string|null $target_legacy_payments_replacement_url
+ * @property array<string, mixed>|null $legacy_moveroo_endpoint_scan
  * @property \Illuminate\Support\Carbon|null $conversion_links_scanned_at
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
@@ -74,7 +77,10 @@ class WebProperty extends Model
         'target_vehicle_booking_url',
         'target_moveroo_subdomain_url',
         'target_contact_us_page_url',
+        'target_legacy_bookings_replacement_url',
+        'target_legacy_payments_replacement_url',
         'conversion_links_scanned_at',
+        'legacy_moveroo_endpoint_scan',
     ];
 
     protected function casts(): array
@@ -82,6 +88,7 @@ class WebProperty extends Model
         return [
             'priority' => 'integer',
             'conversion_links_scanned_at' => 'datetime',
+            'legacy_moveroo_endpoint_scan' => 'array',
         ];
     }
 
@@ -586,7 +593,13 @@ class WebProperty extends Model
      *     vehicle_quote: string|null,
      *     vehicle_booking: string|null,
      *     moveroo_subdomain: string|null,
-     *     contact_us_page: string|null
+     *     contact_us_page: string|null,
+     *     legacy_bookings_replacement: string|null,
+     *     legacy_payments_replacement: string|null
+     *   },
+     *   legacy_endpoints: array{
+     *     legacy_booking_endpoint: array<string, mixed>|null,
+     *     legacy_payment_endpoint: array<string, mixed>|null
      *   },
      *   scanned_at: string|null
      * }
@@ -607,9 +620,69 @@ class WebProperty extends Model
                 'vehicle_booking' => $this->target_vehicle_booking_url,
                 'moveroo_subdomain' => $this->target_moveroo_subdomain_url,
                 'contact_us_page' => $this->target_contact_us_page_url,
+                'legacy_bookings_replacement' => $this->target_legacy_bookings_replacement_url,
+                'legacy_payments_replacement' => $this->target_legacy_payments_replacement_url,
+            ],
+            'legacy_endpoints' => [
+                'legacy_booking_endpoint' => $this->legacyMoverooEndpointSummary(
+                    'legacy_booking_endpoint',
+                    $this->target_legacy_bookings_replacement_url,
+                ),
+                'legacy_payment_endpoint' => $this->legacyMoverooEndpointSummary(
+                    'legacy_payment_endpoint',
+                    $this->target_legacy_payments_replacement_url,
+                ),
             ],
             'scanned_at' => $this->conversion_links_scanned_at?->toIso8601String(),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function legacyMoverooEndpointSummary(string $classification, ?string $preferredReplacement): ?array
+    {
+        $scan = $this->legacy_moveroo_endpoint_scan;
+        $entry = is_array($scan) && is_array($scan[$classification] ?? null)
+            ? $scan[$classification]
+            : null;
+
+        if ($entry === null) {
+            return null;
+        }
+
+        return [
+            'classification' => $classification,
+            'found_on' => is_string($entry['found_on'] ?? null) ? $entry['found_on'] : null,
+            'url' => is_string($entry['url'] ?? null) ? $entry['url'] : null,
+            'resolved_url' => $this->sanitizeLegacyResolvedUrl($entry['resolved_url'] ?? null),
+            'resolved_status' => is_numeric($entry['resolved_status'] ?? null) ? (int) $entry['resolved_status'] : null,
+            'resolved_host_changed' => is_bool($entry['resolved_host_changed'] ?? null) ? $entry['resolved_host_changed'] : null,
+            'preferred_replacement' => $preferredReplacement,
+        ];
+    }
+
+    private function sanitizeLegacyResolvedUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        $parts = parse_url($value);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $sanitizedUrl = strtolower((string) $parts['scheme']).'://'.$parts['host'];
+
+        if (isset($parts['port'])) {
+            $sanitizedUrl .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $sanitizedUrl.($path !== '' ? $path : '/');
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -44,7 +44,7 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties:id,slug,name,property_type,status,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,conversion_links_scanned_at',
+                'webProperties:id,slug,name,property_type,status,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,target_legacy_bookings_replacement_url,target_legacy_payments_replacement_url,conversion_links_scanned_at,legacy_moveroo_endpoint_scan',
                 'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
             ])

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -117,7 +117,10 @@ class DetectedIssueSummaryService
                     'target_vehicle_booking_url',
                     'target_moveroo_subdomain_url',
                     'target_contact_us_page_url',
+                    'target_legacy_bookings_replacement_url',
+                    'target_legacy_payments_replacement_url',
                     'conversion_links_scanned_at',
+                    'legacy_moveroo_endpoint_scan',
                 ])
                 ->where('slug', $verification->property_slug)
                 ->first();

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -375,9 +375,9 @@ class PropertyConversionLinkScanner
     {
         $originalHost = parse_url($url, PHP_URL_HOST);
         $currentUrl = $url;
-        $redirectsRemaining = self::LEGACY_ENDPOINT_PROBE_REDIRECT_LIMIT;
+        $lastStatus = null;
 
-        while ($redirectsRemaining >= 0) {
+        for ($attempt = 0; $attempt <= self::LEGACY_ENDPOINT_PROBE_REDIRECT_LIMIT; $attempt++) {
             if (! $this->isSafeLegacyEndpointProbeUrl($currentUrl)) {
                 return $this->failedLegacyEndpointResolution();
             }
@@ -396,9 +396,10 @@ class PropertyConversionLinkScanner
             }
 
             $status = $response->status();
+            $lastStatus = $status;
             $location = $response->header('Location');
 
-            if ($status >= 300 && $status < 400 && $location !== '' && $redirectsRemaining > 0) {
+            if ($status >= 300 && $status < 400 && $location !== '' && $attempt < self::LEGACY_ENDPOINT_PROBE_REDIRECT_LIMIT) {
                 $nextUrl = $this->normalizeUrl($location, $currentUrl);
 
                 if ($nextUrl === null || ! $this->isSafeLegacyEndpointProbeUrl($nextUrl)) {
@@ -406,7 +407,6 @@ class PropertyConversionLinkScanner
                 }
 
                 $currentUrl = $nextUrl;
-                $redirectsRemaining--;
 
                 continue;
             }
@@ -425,11 +425,7 @@ class PropertyConversionLinkScanner
             ];
         }
 
-        return [
-            'resolved_url' => $this->sanitizeResolvedUrl($currentUrl),
-            'resolved_status' => null,
-            'resolved_host_changed' => null,
-        ];
+        return $this->failedLegacyEndpointResolution($lastStatus);
     }
 
     /**

--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -11,6 +11,10 @@ use Illuminate\Support\Str;
 
 class PropertyConversionLinkScanner
 {
+    private const LEGACY_ENDPOINT_PROBE_REDIRECT_LIMIT = 3;
+
+    private const LEGACY_ENDPOINT_PROBE_TIMEOUT_SECONDS = 5;
+
     public function __construct(
         private readonly HttpFactory $http,
     ) {}
@@ -21,7 +25,11 @@ class PropertyConversionLinkScanner
      *   current_household_booking_url: string|null,
      *   current_vehicle_quote_url: string|null,
      *   current_vehicle_booking_url: string|null,
-     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon,
+     *   legacy_moveroo_endpoint_scan: array{
+     *     legacy_booking_endpoint: array<string, mixed>|null,
+     *     legacy_payment_endpoint: array<string, mixed>|null
+     *   }
      * }
      */
     public function scanForProperty(WebProperty $property): array
@@ -60,6 +68,7 @@ class PropertyConversionLinkScanner
             'current_vehicle_quote_url' => $this->pickLink($anchors, 'vehicle_quote'),
             'current_vehicle_booking_url' => $this->pickLink($anchors, 'vehicle_booking'),
             'conversion_links_scanned_at' => now(),
+            'legacy_moveroo_endpoint_scan' => $this->scanLegacyMoverooEndpoints($anchors, $homepageUrl, $property),
         ];
     }
 
@@ -111,7 +120,7 @@ class PropertyConversionLinkScanner
                     'score' => $classification['score'],
                 ];
             })
-            ->filter(fn (?array $anchor): bool => is_array($anchor) && $anchor['bucket'] !== null)
+            ->filter(fn (?array $anchor): bool => is_array($anchor))
             ->values()
             ->all();
     }
@@ -134,7 +143,11 @@ class PropertyConversionLinkScanner
      *   current_household_booking_url: string|null,
      *   current_vehicle_quote_url: string|null,
      *   current_vehicle_booking_url: string|null,
-     *   conversion_links_scanned_at: \Illuminate\Support\Carbon
+     *   conversion_links_scanned_at: \Illuminate\Support\Carbon,
+     *   legacy_moveroo_endpoint_scan: array{
+     *     legacy_booking_endpoint: array<string, mixed>|null,
+     *     legacy_payment_endpoint: array<string, mixed>|null
+     *   }
      * }
      */
     public function persistForProperty(WebProperty $property): array
@@ -258,6 +271,252 @@ class PropertyConversionLinkScanner
         }
 
         return $prefix.'/'.ltrim($href, '/');
+    }
+
+    /**
+     * @param  array<int, array{href: string, text: string, bucket: string|null, score: int}>  $anchors
+     * @return array{
+     *   legacy_booking_endpoint: array<string, mixed>|null,
+     *   legacy_payment_endpoint: array<string, mixed>|null
+     * }
+     */
+    private function scanLegacyMoverooEndpoints(array $anchors, string $homepageUrl, WebProperty $property): array
+    {
+        $previousMatches = is_array($property->legacy_moveroo_endpoint_scan)
+            ? $property->legacy_moveroo_endpoint_scan
+            : [];
+
+        /** @var array{legacy_booking_endpoint: array<string, mixed>|null, legacy_payment_endpoint: array<string, mixed>|null} $matches */
+        $matches = [
+            'legacy_booking_endpoint' => null,
+            'legacy_payment_endpoint' => null,
+        ];
+
+        foreach ($anchors as $anchor) {
+            $classification = $this->legacyMoverooEndpointClassification($anchor['href'], $property);
+
+            if ($classification === null || $matches[$classification] !== null) {
+                continue;
+            }
+
+            $resolution = $this->resolveLegacyEndpoint($anchor['href']);
+            $resolution = $this->mergePreviousLegacyResolution(
+                $resolution,
+                $previousMatches[$classification] ?? null,
+                $anchor['href'],
+            );
+
+            $matches[$classification] = [
+                'classification' => $classification,
+                'found_on' => $homepageUrl,
+                'url' => $anchor['href'],
+                'resolved_url' => $resolution['resolved_url'],
+                'resolved_status' => $resolution['resolved_status'],
+                'resolved_host_changed' => $resolution['resolved_host_changed'],
+            ];
+        }
+
+        return [
+            'legacy_booking_endpoint' => $matches['legacy_booking_endpoint'],
+            'legacy_payment_endpoint' => $matches['legacy_payment_endpoint'],
+        ];
+    }
+
+    private function legacyMoverooEndpointClassification(string $url, WebProperty $property): ?string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['host'])) {
+            return null;
+        }
+
+        $path = '/'.trim((string) ($parts['path'] ?? '/'), '/');
+        $normalizedPath = Str::lower(rtrim($path, '/'));
+        $host = Str::lower((string) $parts['host']);
+
+        $classification = match ($normalizedPath) {
+            '/bookings' => 'legacy_booking_endpoint',
+            '/payments' => 'legacy_payment_endpoint',
+            default => null,
+        };
+
+        if ($classification === null) {
+            return null;
+        }
+
+        if ($host === $this->targetMoverooHost($property)) {
+            return $classification;
+        }
+
+        return null;
+    }
+
+    private function targetMoverooHost(WebProperty $property): ?string
+    {
+        if (! is_string($property->target_moveroo_subdomain_url) || $property->target_moveroo_subdomain_url === '') {
+            return null;
+        }
+
+        $targetMoverooHost = parse_url($property->target_moveroo_subdomain_url, PHP_URL_HOST);
+
+        return is_string($targetMoverooHost) && $targetMoverooHost !== ''
+            ? Str::lower($targetMoverooHost)
+            : null;
+    }
+
+    /**
+     * @return array{
+     *   resolved_url: string|null,
+     *   resolved_status: int|null,
+     *   resolved_host_changed: bool|null
+     * }
+     */
+    private function resolveLegacyEndpoint(string $url): array
+    {
+        $originalHost = parse_url($url, PHP_URL_HOST);
+        $currentUrl = $url;
+        $redirectsRemaining = self::LEGACY_ENDPOINT_PROBE_REDIRECT_LIMIT;
+
+        while ($redirectsRemaining >= 0) {
+            if (! $this->isSafeLegacyEndpointProbeUrl($currentUrl)) {
+                return $this->failedLegacyEndpointResolution();
+            }
+
+            try {
+                $response = $this->http
+                    ->timeout(self::LEGACY_ENDPOINT_PROBE_TIMEOUT_SECONDS)
+                    ->withoutRedirecting()
+                    ->withHeaders([
+                        'Accept' => 'text/html,application/xhtml+xml',
+                        'User-Agent' => 'DomainMonitorConversionLinkScanner/1.0 (+https://monitor.again.com.au)',
+                    ])
+                    ->get($currentUrl);
+            } catch (\Throwable) {
+                return $this->failedLegacyEndpointResolution();
+            }
+
+            $status = $response->status();
+            $location = $response->header('Location');
+
+            if ($status >= 300 && $status < 400 && $location !== '' && $redirectsRemaining > 0) {
+                $nextUrl = $this->normalizeUrl($location, $currentUrl);
+
+                if ($nextUrl === null || ! $this->isSafeLegacyEndpointProbeUrl($nextUrl)) {
+                    return $this->failedLegacyEndpointResolution($status);
+                }
+
+                $currentUrl = $nextUrl;
+                $redirectsRemaining--;
+
+                continue;
+            }
+
+            $resolvedUrl = $this->sanitizeResolvedUrl($currentUrl);
+            $resolvedHost = $resolvedUrl !== null
+                ? parse_url($resolvedUrl, PHP_URL_HOST)
+                : parse_url($currentUrl, PHP_URL_HOST);
+
+            return [
+                'resolved_url' => $resolvedUrl,
+                'resolved_status' => $status,
+                'resolved_host_changed' => is_string($originalHost) && is_string($resolvedHost)
+                    ? Str::lower($originalHost) !== Str::lower($resolvedHost)
+                    : null,
+            ];
+        }
+
+        return [
+            'resolved_url' => $this->sanitizeResolvedUrl($currentUrl),
+            'resolved_status' => null,
+            'resolved_host_changed' => null,
+        ];
+    }
+
+    /**
+     * @param  array{resolved_url: string|null, resolved_status: int|null, resolved_host_changed: bool|null}  $resolution
+     * @return array{resolved_url: string|null, resolved_status: int|null, resolved_host_changed: bool|null}
+     */
+    private function mergePreviousLegacyResolution(array $resolution, mixed $previousEntry, string $url): array
+    {
+        if ($resolution['resolved_status'] !== null || ! is_array($previousEntry)) {
+            return $resolution;
+        }
+
+        $previousUrl = is_string($previousEntry['url'] ?? null) ? $previousEntry['url'] : null;
+
+        if ($previousUrl !== $url) {
+            return $resolution;
+        }
+
+        return [
+            'resolved_url' => is_string($previousEntry['resolved_url'] ?? null)
+                ? $this->sanitizeResolvedUrl($previousEntry['resolved_url'])
+                : null,
+            'resolved_status' => is_numeric($previousEntry['resolved_status'] ?? null)
+                ? (int) $previousEntry['resolved_status']
+                : null,
+            'resolved_host_changed' => is_bool($previousEntry['resolved_host_changed'] ?? null)
+                ? $previousEntry['resolved_host_changed']
+                : null,
+        ];
+    }
+
+    private function isSafeLegacyEndpointProbeUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+
+        $scheme = Str::lower((string) $parts['scheme']);
+        $host = Str::lower((string) $parts['host']);
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return filter_var(
+                $host,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ) !== false;
+        }
+
+        return str_contains($host, '.')
+            && ! Str::endsWith($host, ['.local', '.internal']);
+    }
+
+    private function sanitizeResolvedUrl(string $url): ?string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $sanitizedUrl = Str::lower((string) $parts['scheme']).'://'.$parts['host'];
+
+        if (isset($parts['port'])) {
+            $sanitizedUrl .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $sanitizedUrl.($path !== '' ? $path : '/');
+    }
+
+    /**
+     * @return array{resolved_url: string|null, resolved_status: int|null, resolved_host_changed: bool|null}
+     */
+    private function failedLegacyEndpointResolution(?int $status = null): array
+    {
+        return [
+            'resolved_url' => null,
+            'resolved_status' => $status,
+            'resolved_host_changed' => null,
+        ];
     }
 
     /**

--- a/database/migrations/2026_04_05_140247_add_legacy_moveroo_endpoint_fields_to_web_properties_table.php
+++ b/database/migrations/2026_04_05_140247_add_legacy_moveroo_endpoint_fields_to_web_properties_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->string('target_legacy_bookings_replacement_url', 2048)->nullable()->after('target_contact_us_page_url');
+            $table->string('target_legacy_payments_replacement_url', 2048)->nullable()->after('target_legacy_bookings_replacement_url');
+            $table->json('legacy_moveroo_endpoint_scan')->nullable()->after('conversion_links_scanned_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->dropColumn([
+                'target_legacy_bookings_replacement_url',
+                'target_legacy_payments_replacement_url',
+                'legacy_moveroo_endpoint_scan',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -221,6 +221,37 @@
                                     @endif
                                 </div>
                             @endforeach
+
+                            <div class="border-t border-gray-200 pt-4 dark:border-gray-700">
+                                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Legacy Moveroo Endpoint Drift</div>
+                                <div class="mt-3 space-y-4">
+                                    @foreach([
+                                        'Legacy /bookings' => $conversionLinks['legacy_endpoints']['legacy_booking_endpoint'] ?? null,
+                                        'Legacy /payments' => $conversionLinks['legacy_endpoints']['legacy_payment_endpoint'] ?? null,
+                                    ] as $label => $endpoint)
+                                        <div>
+                                            <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $label }}</div>
+                                            @if($endpoint)
+                                                <div class="mt-1 break-all text-gray-900 dark:text-gray-100">{{ $endpoint['url'] }}</div>
+                                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                                    Found on {{ $endpoint['found_on'] ?? 'n/a' }}
+                                                </div>
+                                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                                    Resolves to {{ $endpoint['resolved_url'] ?? 'unknown' }} @if(isset($endpoint['resolved_status'])) (HTTP {{ $endpoint['resolved_status'] }}) @endif
+                                                </div>
+                                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                                    Host changed: {{ array_key_exists('resolved_host_changed', $endpoint) ? ($endpoint['resolved_host_changed'] ? 'Yes' : 'No') : 'Unknown' }}
+                                                </div>
+                                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                                    Preferred replacement: {{ $endpoint['preferred_replacement'] ?? 'Manual review' }}
+                                                </div>
+                                            @else
+                                                <div class="mt-1 text-gray-500 dark:text-gray-400">Not detected</div>
+                                            @endif
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
                         </div>
                     </div>
 
@@ -268,6 +299,16 @@
                                 <label for="target_contact_us_page_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Contact Us Page</label>
                                 <input id="target_contact_us_page_url" type="url" wire:model="targetContactUsPageUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
                                 @error('targetContactUsPageUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_legacy_bookings_replacement_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Legacy /bookings Replacement</label>
+                                <input id="target_legacy_bookings_replacement_url" type="url" wire:model="targetLegacyBookingsReplacementUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetLegacyBookingsReplacementUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="target_legacy_payments_replacement_url" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Legacy /payments Replacement</label>
+                                <input id="target_legacy_payments_replacement_url" type="url" wire:model="targetLegacyPaymentsReplacementUrl" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="https://..." />
+                                @error('targetLegacyPaymentsReplacementUrl') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
                             </div>
                         </div>
                     </div>

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -37,6 +37,26 @@ class DetectedIssueApiTest extends TestCase
             'target_household_quote_url' => 'https://quote.redirect-issue.example.com/household',
             'target_moveroo_subdomain_url' => 'https://redirect-issue.moveroo.com.au',
             'target_contact_us_page_url' => 'https://redirect-issue.example.com/contact-us',
+            'target_legacy_bookings_replacement_url' => 'https://removalist.net/booking/create',
+            'target_legacy_payments_replacement_url' => 'https://redirect-issue.moveroo.com.au/contact',
+            'legacy_moveroo_endpoint_scan' => [
+                'legacy_booking_endpoint' => [
+                    'classification' => 'legacy_booking_endpoint',
+                    'found_on' => 'https://redirect-issue.example.com',
+                    'url' => 'https://redirect-issue.moveroo.com.au/bookings',
+                    'resolved_url' => 'https://removalist.net/booking/create',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => true,
+                ],
+                'legacy_payment_endpoint' => [
+                    'classification' => 'legacy_payment_endpoint',
+                    'found_on' => 'https://redirect-issue.example.com',
+                    'url' => 'https://redirect-issue.moveroo.com.au/payments',
+                    'resolved_url' => 'https://redirect-issue.moveroo.com.au/contact',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => false,
+                ],
+            ],
         ]);
 
         WebPropertyDomain::create([
@@ -312,6 +332,11 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('https://quote.redirect-issue.example.com/household', data_get($redirectIssue, 'conversion_links.target.household_quote'));
         $this->assertSame('https://redirect-issue.moveroo.com.au', data_get($redirectIssue, 'conversion_links.target.moveroo_subdomain'));
         $this->assertSame('https://redirect-issue.example.com/contact-us', data_get($redirectIssue, 'conversion_links.target.contact_us_page'));
+        $this->assertSame('https://removalist.net/booking/create', data_get($redirectIssue, 'conversion_links.target.legacy_bookings_replacement'));
+        $this->assertSame('https://redirect-issue.moveroo.com.au/contact', data_get($redirectIssue, 'conversion_links.target.legacy_payments_replacement'));
+        $this->assertSame('https://redirect-issue.moveroo.com.au/bookings', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.url'));
+        $this->assertSame('https://removalist.net/booking/create', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_url'));
+        $this->assertTrue((bool) data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_host_changed'));
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
         $this->assertSame(
             ['https://redirect-issue.example.com/', 'http://redirect-issue.example.com/'],
@@ -361,6 +386,8 @@ class DetectedIssueApiTest extends TestCase
             ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
             ->assertJsonPath('conversion_links.target.moveroo_subdomain', 'https://redirect-issue.moveroo.com.au')
             ->assertJsonPath('conversion_links.target.contact_us_page', 'https://redirect-issue.example.com/contact-us')
+            ->assertJsonPath('conversion_links.target.legacy_bookings_replacement', 'https://removalist.net/booking/create')
+            ->assertJsonPath('conversion_links.legacy_endpoints.legacy_payment_endpoint.resolved_url', 'https://redirect-issue.moveroo.com.au/contact')
             ->assertJsonPath('evidence.source_domain_id', $redirectDomain->id)
             ->assertJsonPath('evidence.examples.0.url', 'https://redirect-issue.example.com/');
     }

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -61,7 +61,27 @@ class WebPropertyApiTest extends TestCase
             'target_vehicle_quote_url' => 'https://quote.moveroo.com.au/vehicle',
             'target_moveroo_subdomain_url' => 'https://wemove.moveroo.com.au',
             'target_contact_us_page_url' => 'https://moveroo.com.au/contact-us',
+            'target_legacy_bookings_replacement_url' => 'https://removalist.net/booking/create',
+            'target_legacy_payments_replacement_url' => 'https://wemove.moveroo.com.au/contact',
             'conversion_links_scanned_at' => now(),
+            'legacy_moveroo_endpoint_scan' => [
+                'legacy_booking_endpoint' => [
+                    'classification' => 'legacy_booking_endpoint',
+                    'found_on' => 'https://moveroo.com.au',
+                    'url' => 'https://wemove.moveroo.com.au/bookings',
+                    'resolved_url' => 'https://removalist.net/booking/create',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => true,
+                ],
+                'legacy_payment_endpoint' => [
+                    'classification' => 'legacy_payment_endpoint',
+                    'found_on' => 'https://moveroo.com.au',
+                    'url' => 'https://wemove.moveroo.com.au/payments',
+                    'resolved_url' => 'https://wemove.moveroo.com.au/contact',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => false,
+                ],
+            ],
         ]);
 
         WebPropertyDomain::create([
@@ -199,6 +219,13 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_quote', 'https://quote.moveroo.com.au/vehicle')
             ->assertJsonPath('web_properties.0.conversion_links.target.moveroo_subdomain', 'https://wemove.moveroo.com.au')
             ->assertJsonPath('web_properties.0.conversion_links.target.contact_us_page', 'https://moveroo.com.au/contact-us')
+            ->assertJsonPath('web_properties.0.conversion_links.target.legacy_bookings_replacement', 'https://removalist.net/booking/create')
+            ->assertJsonPath('web_properties.0.conversion_links.target.legacy_payments_replacement', 'https://wemove.moveroo.com.au/contact')
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_booking_endpoint.url', 'https://wemove.moveroo.com.au/bookings')
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_url', 'https://removalist.net/booking/create')
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_host_changed', true)
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_payment_endpoint.url', 'https://wemove.moveroo.com.au/payments')
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_payment_endpoint.resolved_url', 'https://wemove.moveroo.com.au/contact')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.has_issue_detail', false)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.issue_detail_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', null)

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -47,6 +47,8 @@ class WebPropertyConversionLinksTest extends TestCase
             ->set('targetVehicleBookingUrl', 'https://quote.moveroo.com.au/vehicle-booking')
             ->set('targetMoverooSubdomainUrl', 'https://wemove.moveroo.com.au')
             ->set('targetContactUsPageUrl', 'https://moveroo.com.au/contact-us')
+            ->set('targetLegacyBookingsReplacementUrl', 'https://removalist.net/booking/create')
+            ->set('targetLegacyPaymentsReplacementUrl', 'https://wemove.moveroo.com.au/contact')
             ->call('saveConversionTargets')
             ->assertHasNoErrors();
 
@@ -58,6 +60,8 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://quote.moveroo.com.au/vehicle-booking', $property->target_vehicle_booking_url);
         $this->assertSame('https://wemove.moveroo.com.au', $property->target_moveroo_subdomain_url);
         $this->assertSame('https://moveroo.com.au/contact-us', $property->target_contact_us_page_url);
+        $this->assertSame('https://removalist.net/booking/create', $property->target_legacy_bookings_replacement_url);
+        $this->assertSame('https://wemove.moveroo.com.au/contact', $property->target_legacy_payments_replacement_url);
     }
 
     public function test_property_detail_can_clear_target_conversion_links(): void
@@ -139,6 +143,302 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://cars.moveroo.com.au/quote/v2', $property->current_vehicle_quote_url);
         $this->assertNull($property->current_vehicle_booking_url);
         $this->assertNotNull($property->conversion_links_scanned_at);
+    }
+
+    public function test_property_detail_refresh_captures_legacy_moveroo_endpoint_drift(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'discountbackloading.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'discountbackloading-com-au',
+            'name' => 'Discount Backloading',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://discountbackloading.com.au',
+            'target_moveroo_subdomain_url' => 'https://mymoveportal.discountbackloading.com.au',
+            'target_legacy_bookings_replacement_url' => 'https://removalist.net/booking/create',
+            'target_legacy_payments_replacement_url' => 'https://mymoveportal.discountbackloading.com.au/contact',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymoveportal.discountbackloading.com.au/bookings">Book Online</a>
+                            <a href="https://mymoveportal.discountbackloading.com.au/payments">Make Payment</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://mymoveportal.discountbackloading.com.au/bookings' => Http::response('', 302, [
+                'Location' => 'https://removalist.net/booking/create',
+            ]),
+            'https://removalist.net/booking/create' => Http::response('<html><body>Booking</body></html>', 200),
+            'https://mymoveportal.discountbackloading.com.au/payments' => Http::response('', 302, [
+                'Location' => 'https://mymoveportal.discountbackloading.com.au/contact',
+            ]),
+            'https://mymoveportal.discountbackloading.com.au/contact' => Http::response('<html><body>Contact</body></html>', 200),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'discountbackloading-com-au'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertSee('Host changed: Yes')
+            ->assertSee('Preferred replacement: https://removalist.net/booking/create')
+            ->assertHasNoErrors();
+
+        $legacyEndpoints = $property->fresh()->conversionLinkSummary()['legacy_endpoints'];
+
+        $this->assertSame(
+            'https://mymoveportal.discountbackloading.com.au/bookings',
+            $legacyEndpoints['legacy_booking_endpoint']['url']
+        );
+        $this->assertSame(
+            'https://removalist.net/booking/create',
+            $legacyEndpoints['legacy_booking_endpoint']['resolved_url']
+        );
+        $this->assertSame(200, $legacyEndpoints['legacy_booking_endpoint']['resolved_status']);
+        $this->assertTrue($legacyEndpoints['legacy_booking_endpoint']['resolved_host_changed']);
+        $this->assertSame(
+            'https://removalist.net/booking/create',
+            $legacyEndpoints['legacy_booking_endpoint']['preferred_replacement']
+        );
+        $this->assertSame(
+            'https://mymoveportal.discountbackloading.com.au/payments',
+            $legacyEndpoints['legacy_payment_endpoint']['url']
+        );
+        $this->assertSame(
+            'https://mymoveportal.discountbackloading.com.au/contact',
+            $legacyEndpoints['legacy_payment_endpoint']['resolved_url']
+        );
+        $this->assertFalse($legacyEndpoints['legacy_payment_endpoint']['resolved_host_changed']);
+        $this->assertSame(
+            'https://mymoveportal.discountbackloading.com.au/contact',
+            $legacyEndpoints['legacy_payment_endpoint']['preferred_replacement']
+        );
+    }
+
+    public function test_property_detail_refresh_requires_an_explicit_moveroo_subdomain_target_for_legacy_endpoint_detection(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'discountbackloading.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'discountbackloading-com-au',
+            'name' => 'Discount Backloading',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://discountbackloading.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://portal.discountbackloading.com.au/bookings">Book Online</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'discountbackloading-com-au'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertHasNoErrors();
+
+        $legacyEndpoints = $property->fresh()->conversionLinkSummary()['legacy_endpoints'];
+
+        $this->assertNull($legacyEndpoints['legacy_booking_endpoint']);
+        $this->assertNull($legacyEndpoints['legacy_payment_endpoint']);
+    }
+
+    public function test_property_detail_refresh_preserves_previous_legacy_resolution_when_probe_fails(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'discountbackloading.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'discountbackloading-com-au',
+            'name' => 'Discount Backloading',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://discountbackloading.com.au',
+            'target_moveroo_subdomain_url' => 'https://mymoveportal.discountbackloading.com.au',
+            'legacy_moveroo_endpoint_scan' => [
+                'legacy_booking_endpoint' => [
+                    'classification' => 'legacy_booking_endpoint',
+                    'found_on' => 'https://discountbackloading.com.au',
+                    'url' => 'https://mymoveportal.discountbackloading.com.au/bookings',
+                    'resolved_url' => 'https://removalist.net/booking/create',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => true,
+                ],
+                'legacy_payment_endpoint' => null,
+            ],
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymoveportal.discountbackloading.com.au/bookings">Book Online</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://mymoveportal.discountbackloading.com.au/bookings' => Http::failedConnection(),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'discountbackloading-com-au'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertHasNoErrors();
+
+        $legacyEndpoints = $property->fresh()->conversionLinkSummary()['legacy_endpoints'];
+
+        $this->assertSame(
+            'https://removalist.net/booking/create',
+            $legacyEndpoints['legacy_booking_endpoint']['resolved_url']
+        );
+        $this->assertSame(200, $legacyEndpoints['legacy_booking_endpoint']['resolved_status']);
+        $this->assertTrue($legacyEndpoints['legacy_booking_endpoint']['resolved_host_changed']);
+    }
+
+    public function test_property_detail_refresh_blocks_unsafe_legacy_redirect_targets(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'discountbackloading.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'discountbackloading-com-au',
+            'name' => 'Discount Backloading',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://discountbackloading.com.au',
+            'target_moveroo_subdomain_url' => 'https://mymoveportal.discountbackloading.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymoveportal.discountbackloading.com.au/bookings">Book Online</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://mymoveportal.discountbackloading.com.au/bookings' => Http::response('', 302, [
+                'Location' => 'http://127.0.0.1/private?token=secret',
+            ]),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'discountbackloading-com-au'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertHasNoErrors();
+
+        $legacyEndpoints = $property->fresh()->conversionLinkSummary()['legacy_endpoints'];
+
+        $this->assertNull($legacyEndpoints['legacy_booking_endpoint']['resolved_url']);
+        $this->assertSame(302, $legacyEndpoints['legacy_booking_endpoint']['resolved_status']);
+        $this->assertNull($legacyEndpoints['legacy_booking_endpoint']['resolved_host_changed']);
+
+        Http::assertSentCount(2);
+    }
+
+    public function test_property_detail_refresh_sanitizes_resolved_legacy_endpoint_urls(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'discountbackloading.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'discountbackloading-com-au',
+            'name' => 'Discount Backloading',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://discountbackloading.com.au',
+            'target_moveroo_subdomain_url' => 'https://mymoveportal.discountbackloading.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymoveportal.discountbackloading.com.au/bookings">Book Online</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+            'https://mymoveportal.discountbackloading.com.au/bookings' => Http::response('', 302, [
+                'Location' => 'https://removalist.net/booking/create?token=secret#frag',
+            ]),
+            'https://removalist.net/booking/create?token=secret#frag' => Http::response('<html><body>Booking</body></html>', 200),
+            'https://removalist.net/booking/create' => Http::response('<html><body>Booking</body></html>', 200),
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'discountbackloading-com-au'])
+            ->call('refreshCurrentConversionLinks')
+            ->assertHasNoErrors();
+
+        $legacyEndpoints = $property->fresh()->conversionLinkSummary()['legacy_endpoints'];
+
+        $this->assertSame(
+            'https://removalist.net/booking/create',
+            $legacyEndpoints['legacy_booking_endpoint']['resolved_url']
+        );
     }
 
     public function test_property_detail_rejects_mutations_for_unauthorized_users_outside_local_env(): void


### PR DESCRIPTION
## Summary
- expose legacy Moveroo `/bookings` and `/payments` drift evidence through existing `conversion_links` payloads
- add explicit admin-maintained replacement targets for legacy bookings and payments endpoints
- harden endpoint resolution by requiring an explicit Moveroo subdomain target, sanitizing resolved URLs, blocking unsafe redirect hops, and preserving prior evidence on transient probe failures

## Testing
- `php artisan test tests/Feature/WebPropertyConversionLinksTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php`
- `./vendor/bin/phpstan analyse app/Services/PropertyConversionLinkScanner.php app/Models/WebProperty.php app/Livewire/WebPropertyDetail.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/WebPropertyConversionLinksTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G`
- `vendor/bin/pint --dirty`
- `composer pr:preflight`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
