### PR TITLE
Filter intentional WordPress admin indexing exclusions

### DIFF
--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -197,6 +197,20 @@ class Domain extends Model
     }
 
     /**
+     * @return HasOne<DomainCheck, $this>
+     */
+    public function latestSeoCheck(): HasOne
+    {
+        return $this->hasOne(DomainCheck::class)
+            ->ofMany([
+                'finished_at' => 'max',
+                'created_at' => 'max',
+            ], function (Builder $query): void {
+                $query->where('check_type', 'seo');
+            });
+    }
+
+    /**
      * @return HasMany<DomainAlert, $this>
      */
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -21,7 +21,7 @@ class DashboardIssueQueueService
     /**
      * @return array<string, mixed>
      */
-    public function snapshot(): array
+    public function snapshot(bool $includeExpectedExclusions = false): array
     {
         $recentFailuresHours = app(DomainMonitorSettings::class)->recentFailuresHours();
 
@@ -66,7 +66,8 @@ class DashboardIssueQueueService
         ]);
         [$mustFixDomains, $shouldFixDomains] = $this->applyIssueVerificationQueues(
             $mustFixDomains->concat($shouldFixDomains),
-            $issueEvidence
+            $issueEvidence,
+            $includeExpectedExclusions
         );
 
         $stats['must_fix'] = $mustFixDomains->count();
@@ -89,7 +90,7 @@ class DashboardIssueQueueService
      * @param  array<string, array<string, array<string, mixed>>>  $issueEvidence
      * @return array{0: Collection<int, array<string, mixed>>, 1: Collection<int, array<string, mixed>>}
      */
-    private function applyIssueVerificationQueues(Collection $items, array $issueEvidence): array
+    private function applyIssueVerificationQueues(Collection $items, array $issueEvidence, bool $includeExpectedExclusions = false): array
     {
         if ($items->isEmpty()) {
             return [collect(), collect()];
@@ -125,7 +126,8 @@ class DashboardIssueQueueService
             $filteredItem = $this->filterVerifiedIssueEntries(
                 $item,
                 $verificationMap,
-                $issueEvidence[$evidenceKey] ?? []
+                $issueEvidence[$evidenceKey] ?? [],
+                $includeExpectedExclusions
             );
 
             if ($filteredItem === null) {
@@ -166,7 +168,7 @@ class DashboardIssueQueueService
      * @param  array<string, mixed>  $item
      * @return array<string, mixed>|null
      */
-    private function filterVerifiedIssueEntries(array $item, array $verificationMap, array $propertyIssueEvidence): ?array
+    private function filterVerifiedIssueEntries(array $item, array $verificationMap, array $propertyIssueEvidence, bool $includeExpectedExclusions = false): ?array
     {
         $domainId = (string) ($item['id'] ?? '');
         $propertySlug = is_string($item['web_property_slug'] ?? null) ? $item['web_property_slug'] : null;
@@ -174,13 +176,13 @@ class DashboardIssueQueueService
         $visibleSecondaryRecords = [];
 
         foreach ((array) ($item['primary_issue_records'] ?? []) as $record) {
-            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence)) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence, $includeExpectedExclusions)) {
                 $visiblePrimaryRecords[] = $record;
             }
         }
 
         foreach ((array) ($item['secondary_issue_records'] ?? []) as $record) {
-            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence)) {
+            if ($this->shouldKeepVerifiedRecord($record, $item, $domainId, $propertySlug, $verificationMap, $propertyIssueEvidence, $includeExpectedExclusions)) {
                 $visibleSecondaryRecords[] = $record;
             }
         }
@@ -251,7 +253,8 @@ class DashboardIssueQueueService
         string $domainId,
         ?string $propertySlug,
         array $verificationMap,
-        array $propertyIssueEvidence
+        array $propertyIssueEvidence,
+        bool $includeExpectedExclusions = false
     ): bool {
         $issueFamily = is_string($record['issue_family'] ?? null) ? $record['issue_family'] : null;
 
@@ -267,6 +270,10 @@ class DashboardIssueQueueService
             'detected_at' => $this->queueIssueDetectedAt($item, $issueFamily, $issueEvidenceForRecord),
             'evidence' => $issueEvidenceForRecord,
         ];
+
+        if (! $includeExpectedExclusions && array_key_exists('expected_exclusion', $issueEvidenceForRecord)) {
+            return false;
+        }
 
         return ! ($verification instanceof \App\Models\DetectedIssueVerification
             && $this->issueVerificationService->isCurrentlySuppressed($issue, $verification));
@@ -287,7 +294,7 @@ class DashboardIssueQueueService
     /**
      * @param  array<string, mixed>  $item
      * @param  array<string, mixed>  $issueEvidence
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     private function queueIssueEvidence(array $item, string $issueFamily, array $issueEvidence): array
     {
@@ -302,6 +309,10 @@ class DashboardIssueQueueService
 
             if (is_string($issueEvidence['api_captured_at'] ?? null) && $issueEvidence['api_captured_at'] !== '') {
                 $evidence['api_captured_at'] = $issueEvidence['api_captured_at'];
+            }
+
+            if (is_array($issueEvidence['expected_exclusion'] ?? null)) {
+                $evidence['expected_exclusion'] = $issueEvidence['expected_exclusion'];
             }
 
             return $evidence;

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -22,33 +22,9 @@ class DetectedIssueSummaryService
      */
     public function snapshot(): array
     {
-        $queueSnapshot = $this->queueService->snapshot();
-        $queueItems = [
-            ...($queueSnapshot['must_fix'] ?? []),
-            ...($queueSnapshot['should_fix'] ?? []),
-        ];
-        $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems([
-            ...$queueItems,
-        ]);
-        $brokenLinksEvidence = $this->brokenLinksEvidenceMapForQueueItems($queueItems);
-        $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence, $brokenLinksEvidence)
-            ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence, $brokenLinksEvidence))
-            ->pipe(function (Collection $issues): Collection {
-                $issueIds = $issues
-                    ->pluck('issue_id')
-                    ->filter(fn (mixed $issueId): bool => is_string($issueId) && $issueId !== '')
-                    ->values()
-                    ->all();
-                $verificationMap = $this->issueVerificationService->latestMapForIssueIds($issueIds);
-
-                return $issues->map(fn (array $issue): array => $this->issueVerificationService->annotateIssue(
-                    $issue,
-                    $verificationMap[$issue['issue_id']] ?? null
-                ))->reject(
-                    fn (array $issue): bool => (bool) data_get($issue, 'verification.is_currently_suppressed', false)
-                )->values();
-            })
-            ->values();
+        $snapshotData = $this->buildSnapshotData();
+        $queueSnapshot = $snapshotData['queue_snapshot'];
+        $issues = $snapshotData['issues'];
         $mustFix = $issues->where('severity', 'must_fix')->values();
         $shouldFix = $issues->where('severity', 'should_fix')->values();
 
@@ -74,7 +50,7 @@ class DetectedIssueSummaryService
     public function find(string $issueId): ?array
     {
         /** @var array<int, array<string, mixed>> $issues */
-        $issues = $this->snapshot()['issues'] ?? [];
+        $issues = $this->buildSnapshotData(includeSuppressed: true, includeExpectedExclusions: true)['issues']->all();
         /** @var array<string, mixed>|null $issue */
         $issue = collect($issues)->firstWhere('issue_id', $issueId);
 
@@ -83,6 +59,47 @@ class DetectedIssueSummaryService
         }
 
         return $this->issueFromStoredVerification($issueId);
+    }
+
+    /**
+     * @return array{queue_snapshot: array<string, mixed>, issues: Collection<int, array<string, mixed>>}
+     */
+    private function buildSnapshotData(bool $includeSuppressed = false, bool $includeExpectedExclusions = false): array
+    {
+        $queueSnapshot = $this->queueService->snapshot($includeExpectedExclusions);
+        $queueItems = [
+            ...($queueSnapshot['must_fix'] ?? []),
+            ...($queueSnapshot['should_fix'] ?? []),
+        ];
+        $issueEvidence = $this->issueEvidenceService->evidenceMapForQueueItems($queueItems);
+        $brokenLinksEvidence = $this->brokenLinksEvidenceMapForQueueItems($queueItems);
+        $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence, $brokenLinksEvidence)
+            ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence, $brokenLinksEvidence))
+            ->pipe(function (Collection $issues) use ($includeExpectedExclusions, $includeSuppressed): Collection {
+                $issueIds = $issues
+                    ->pluck('issue_id')
+                    ->filter(fn (mixed $issueId): bool => is_string($issueId) && $issueId !== '')
+                    ->values()
+                    ->all();
+                $verificationMap = $this->issueVerificationService->latestMapForIssueIds($issueIds);
+
+                return $issues
+                    ->map(fn (array $issue): array => $this->issueVerificationService->annotateIssue(
+                        $issue,
+                        $verificationMap[$issue['issue_id']] ?? null
+                    ))
+                    ->reject(fn (array $issue): bool => ! $includeSuppressed
+                        && (bool) data_get($issue, 'verification.is_currently_suppressed', false))
+                    ->reject(fn (array $issue): bool => ! $includeExpectedExclusions
+                        && is_array(data_get($issue, 'evidence.expected_exclusion')))
+                    ->values();
+            })
+            ->values();
+
+        return [
+            'queue_snapshot' => $queueSnapshot,
+            'issues' => $issues,
+        ];
     }
 
     /**

--- a/app/Services/IntentionalSearchConsoleExclusionService.php
+++ b/app/Services/IntentionalSearchConsoleExclusionService.php
@@ -42,6 +42,10 @@ class IntentionalSearchConsoleExclusionService
      */
     private function classifyBlockedByRobotsIssue(Domain $domain, array $candidateUrls): ?array
     {
+        if (! $this->allUrlsAreWordPressAdminPaths($candidateUrls)) {
+            return null;
+        }
+
         $robotsInspection = $this->inspectStoredSeoRobotsState($domain);
 
         if (! is_array($robotsInspection) || ($robotsInspection['has_standard_wordpress_admin_rule'] ?? false) !== true) {
@@ -126,7 +130,8 @@ class IntentionalSearchConsoleExclusionService
         $candidateUrlCount = count($candidateUrls);
 
         if ($exactExampleCount !== null && $affectedUrlCount !== null) {
-            return $exactExampleCount >= $affectedUrlCount;
+            return $candidateUrlCount >= $exactExampleCount
+                && $candidateUrlCount >= $affectedUrlCount;
         }
 
         if ($exactExampleCount !== null) {
@@ -154,13 +159,38 @@ class IntentionalSearchConsoleExclusionService
         return true;
     }
 
+    /**
+     * @param  array<int, string>  $candidateUrls
+     */
+    private function allUrlsAreWordPressAdminPaths(array $candidateUrls): bool
+    {
+        foreach ($candidateUrls as $url) {
+            if (! $this->isWordPressAdminPath($url)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function isIntentionalUtilityPath(string $url): bool
     {
         $path = Str::lower((string) parse_url($url, PHP_URL_PATH));
 
+        if ($this->isWordPressAdminPath($url)) {
+            return true;
+        }
+
         if ($path === '/wp-login.php') {
             return true;
         }
+
+        return false;
+    }
+
+    private function isWordPressAdminPath(string $url): bool
+    {
+        $path = Str::lower((string) parse_url($url, PHP_URL_PATH));
 
         return in_array($path, ['/wp-admin', '/wp-admin/'], true)
             || Str::startsWith($path, '/wp-admin/');

--- a/app/Services/IntentionalSearchConsoleExclusionService.php
+++ b/app/Services/IntentionalSearchConsoleExclusionService.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use App\Models\WebProperty;
+use Illuminate\Support\Str;
+
+class IntentionalSearchConsoleExclusionService
+{
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>|null
+     */
+    public function classify(WebProperty $property, string $issueClass, array $issueEvidence): ?array
+    {
+        $candidateUrls = $this->candidateUrls($issueEvidence);
+
+        if ($candidateUrls === []
+            || ! $this->issueEvidenceRepresentsCompleteSet($issueEvidence, $candidateUrls)
+            || ! $this->allUrlsAreIntentionalUtilityPaths($candidateUrls)) {
+            return null;
+        }
+
+        $candidateDomain = $this->candidateDomainForUrls($property, $candidateUrls);
+
+        if (! $candidateDomain instanceof Domain) {
+            return null;
+        }
+
+        return match ($issueClass) {
+            'blocked_by_robots_in_indexing' => $this->classifyBlockedByRobotsIssue($candidateDomain, $candidateUrls),
+            'excluded_by_noindex' => $this->classifyNoindexIssue($candidateUrls),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     * @return array<string, mixed>|null
+     */
+    private function classifyBlockedByRobotsIssue(Domain $domain, array $candidateUrls): ?array
+    {
+        $robotsInspection = $this->inspectStoredSeoRobotsState($domain);
+
+        if (! is_array($robotsInspection) || ($robotsInspection['has_standard_wordpress_admin_rule'] ?? false) !== true) {
+            return null;
+        }
+
+        return [
+            'state' => 'expected_robots_exclusion',
+            'code' => 'intentional_admin_exclusion',
+            'reason' => 'standard_wordpress_admin_paths_blocked_in_robots',
+            'matched_urls' => array_slice($candidateUrls, 0, 5),
+            'matched_url_count' => count($candidateUrls),
+            'robots' => [
+                'url' => $robotsInspection['url'] ?? null,
+                'disallow_wp_admin' => true,
+                'allow_admin_ajax' => (bool) ($robotsInspection['allow_admin_ajax'] ?? false),
+                'checked_at' => $robotsInspection['checked_at'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     * @return array<string, mixed>
+     */
+    private function classifyNoindexIssue(array $candidateUrls): array
+    {
+        return [
+            'state' => 'expected_noindex_exclusion',
+            'code' => 'intentional_admin_exclusion',
+            'reason' => 'admin_or_login_utility_paths_are_intentionally_noindexed',
+            'matched_urls' => array_slice($candidateUrls, 0, 5),
+            'matched_url_count' => count($candidateUrls),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<int, string>
+     */
+    private function candidateUrls(array $issueEvidence): array
+    {
+        $urls = [];
+
+        foreach ((array) ($issueEvidence['affected_urls'] ?? []) as $url) {
+            if (is_string($url) && $url !== '') {
+                $urls[] = $url;
+            }
+        }
+
+        foreach ((array) ($issueEvidence['sample_urls'] ?? []) as $url) {
+            if (is_string($url) && $url !== '') {
+                $urls[] = $url;
+            }
+        }
+
+        foreach ((array) ($issueEvidence['examples'] ?? []) as $example) {
+            if (is_array($example) && is_string($example['url'] ?? null) && $example['url'] !== '') {
+                $urls[] = $example['url'];
+            }
+        }
+
+        return array_values(array_unique($urls));
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @param  array<int, string>  $candidateUrls
+     */
+    private function issueEvidenceRepresentsCompleteSet(array $issueEvidence, array $candidateUrls): bool
+    {
+        if (($issueEvidence['is_example_set_truncated'] ?? false) === true) {
+            return false;
+        }
+
+        $affectedUrlCount = is_numeric($issueEvidence['affected_url_count'] ?? null)
+            ? (int) $issueEvidence['affected_url_count']
+            : null;
+        $exactExampleCount = is_numeric($issueEvidence['exact_example_count'] ?? null)
+            ? (int) $issueEvidence['exact_example_count']
+            : null;
+        $candidateUrlCount = count($candidateUrls);
+
+        if ($exactExampleCount !== null && $affectedUrlCount !== null) {
+            return $exactExampleCount >= $affectedUrlCount;
+        }
+
+        if ($exactExampleCount !== null) {
+            return $candidateUrlCount >= $exactExampleCount;
+        }
+
+        if ($affectedUrlCount !== null) {
+            return $candidateUrlCount >= $affectedUrlCount;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     */
+    private function allUrlsAreIntentionalUtilityPaths(array $candidateUrls): bool
+    {
+        foreach ($candidateUrls as $url) {
+            if (! $this->isIntentionalUtilityPath($url)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isIntentionalUtilityPath(string $url): bool
+    {
+        $path = Str::lower((string) parse_url($url, PHP_URL_PATH));
+
+        if ($path === '/wp-login.php') {
+            return true;
+        }
+
+        return in_array($path, ['/wp-admin', '/wp-admin/'], true)
+            || Str::startsWith($path, '/wp-admin/');
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     */
+    private function candidateDomainForUrls(WebProperty $property, array $candidateUrls): ?Domain
+    {
+        $property->loadMissing(['primaryDomain.latestSeoCheck', 'propertyDomains.domain.latestSeoCheck']);
+
+        $parsedHosts = collect($candidateUrls)
+            ->map(function (string $url): ?string {
+                $scheme = Str::lower((string) parse_url($url, PHP_URL_SCHEME));
+                $host = Str::lower((string) parse_url($url, PHP_URL_HOST));
+
+                if (! in_array($scheme, ['http', 'https'], true) || $host === '') {
+                    return null;
+                }
+
+                return $host;
+            });
+
+        if ($parsedHosts->contains(fn (?string $host): bool => ! is_string($host))) {
+            return null;
+        }
+
+        $hosts = $parsedHosts
+            ->unique()
+            ->values();
+
+        if ($hosts->count() !== 1) {
+            return null;
+        }
+
+        $candidateHost = $hosts->first();
+
+        if (! is_string($candidateHost)) {
+            return null;
+        }
+
+        foreach ($this->knownPropertyDomains($property) as $domain) {
+            if (Str::lower($domain->domain) === $candidateHost) {
+                return $domain;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, Domain>
+     */
+    private function knownPropertyDomains(WebProperty $property): array
+    {
+        $domains = [];
+
+        if ($property->primaryDomain instanceof Domain) {
+            $domains[$property->primaryDomain->id] = $property->primaryDomain;
+        }
+
+        foreach ($property->propertyDomains as $link) {
+            if ($link->domain instanceof Domain) {
+                $domains[$link->domain->id] = $link->domain;
+            }
+        }
+
+        return array_values($domains);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function inspectStoredSeoRobotsState(Domain $domain): ?array
+    {
+        $seoCheck = $domain->relationLoaded('latestSeoCheck')
+            ? $domain->latestSeoCheck
+            : $domain->latestSeoCheck()->first();
+
+        if (! $seoCheck instanceof DomainCheck) {
+            return null;
+        }
+
+        $robots = data_get($seoCheck->payload, 'results.robots');
+
+        if (! is_array($robots)) {
+            return null;
+        }
+
+        return [
+            'url' => is_string($robots['url'] ?? null) ? $robots['url'] : null,
+            'has_standard_wordpress_admin_rule' => ($robots['has_standard_wordpress_admin_rule'] ?? false) === true,
+            'allow_admin_ajax' => ($robots['allow_admin_ajax'] ?? false) === true,
+            'checked_at' => $seoCheck->finished_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -12,6 +12,7 @@ class SearchConsoleIssueEvidenceService
     public function __construct(
         private readonly DetectedIssueIdentityService $issueIdentityService,
         private readonly DetectedIssueVerificationService $issueVerificationService,
+        private readonly IntentionalSearchConsoleExclusionService $intentionalSearchConsoleExclusionService,
     ) {}
 
     /**
@@ -32,8 +33,12 @@ class SearchConsoleIssueEvidenceService
 
         $properties = WebProperty::query()
             ->whereIn('slug', $propertySlugs)
-            ->with('latestSeoBaselineForProperty')
-            ->get(['id', 'slug']);
+            ->with([
+                'latestSeoBaselineForProperty',
+                'primaryDomain.latestSeoCheck',
+                'propertyDomains.domain.latestSeoCheck',
+            ])
+            ->get(['id', 'slug', 'primary_domain_id']);
 
         return $this->evidenceMapForProperties($properties);
     }
@@ -106,6 +111,10 @@ class SearchConsoleIssueEvidenceService
                     return null;
                 }
 
+                if (is_array($evidence['expected_exclusion'] ?? null)) {
+                    return null;
+                }
+
                 return [
                     'issue_class' => $issueClass,
                     'label' => is_string($catalogEntry['label'] ?? null) ? $catalogEntry['label'] : $issueClass,
@@ -175,7 +184,18 @@ class SearchConsoleIssueEvidenceService
                     'detail' => null,
                     'api' => null,
                 ]);
-                $issueEvidence[$issueClass] = array_replace($baselineEvidence, $snapshotEvidence);
+                $mergedEvidence = array_replace($baselineEvidence, $snapshotEvidence);
+                $expectedExclusion = $this->intentionalSearchConsoleExclusionService->classify(
+                    $property,
+                    $issueClass,
+                    $mergedEvidence
+                );
+
+                if (is_array($expectedExclusion)) {
+                    $mergedEvidence['expected_exclusion'] = $expectedExclusion;
+                }
+
+                $issueEvidence[$issueClass] = $mergedEvidence;
             }
 
             return [$property->slug => $issueEvidence];

--- a/app/Services/SeoHealthCheck.php
+++ b/app/Services/SeoHealthCheck.php
@@ -14,7 +14,15 @@ class SeoHealthCheck
      *     is_valid: bool,
      *     verified: bool,
      *     results: array{
-     *         robots: array{exists: bool, verified: bool, status: int, url: string, error: string|null},
+     *         robots: array{
+     *             exists: bool,
+     *             verified: bool,
+     *             status: int,
+     *             url: string,
+     *             error: string|null,
+     *             has_standard_wordpress_admin_rule: bool,
+     *             allow_admin_ajax: bool
+     *         },
      *         sitemap: array{exists: bool, verified: bool, status: int, url: string, error: string|null}
      *     },
      *     error_message: string|null,
@@ -27,14 +35,10 @@ class SeoHealthCheck
         $baseUrl = $this->normalizeUrl($domain);
 
         try {
-            // Check robots.txt
-            $robotsResult = $this->checkFile($baseUrl, '/robots.txt');
+            $robotsResult = $this->checkRobotsFile($baseUrl);
 
-            // Check sitemap.xml (try common locations if standard one fails, or just standard for now)
-            // For MVP, we just check /sitemap.xml. A more advanced version could parse robots.txt for the sitemap URL.
             $sitemapResult = $this->checkFile($baseUrl, '/sitemap.xml');
 
-            // If sitemap not found at root, try sitemap_index.xml (common in WordPress/Yoast)
             if (! $sitemapResult['exists']) {
                 $altSitemapResult = $this->checkFile($baseUrl, '/sitemap_index.xml');
                 if ($altSitemapResult['exists']) {
@@ -42,8 +46,6 @@ class SeoHealthCheck
                 }
             }
 
-            // Consider valid if robots.txt exists (crucial). Sitemap is important but sometimes named differently.
-            // Let's set is_valid to true if robots.txt exists.
             $isValid = $robotsResult['exists'];
 
             $duration = (int) ((microtime(true) - $startTime) * 1000);
@@ -70,7 +72,15 @@ class SeoHealthCheck
                 'is_valid' => false,
                 'verified' => false,
                 'results' => [
-                    'robots' => ['exists' => false, 'verified' => false, 'status' => 0, 'url' => '', 'error' => 'Check failed'],
+                    'robots' => [
+                        'exists' => false,
+                        'verified' => false,
+                        'status' => 0,
+                        'url' => '',
+                        'error' => 'Check failed',
+                        'has_standard_wordpress_admin_rule' => false,
+                        'allow_admin_ajax' => false,
+                    ],
                     'sitemap' => ['exists' => false, 'verified' => false, 'status' => 0, 'url' => '', 'error' => 'Check failed'],
                 ],
                 'error_message' => 'Exception: '.$e->getMessage(),
@@ -90,6 +100,55 @@ class SeoHealthCheck
         }
 
         return 'https://'.rtrim($domain, '/');
+    }
+
+    /**
+     * @return array{
+     *     exists: bool,
+     *     verified: bool,
+     *     status: int,
+     *     url: string,
+     *     error: string|null,
+     *     has_standard_wordpress_admin_rule: bool,
+     *     allow_admin_ajax: bool
+     * }
+     */
+    private function checkRobotsFile(string $baseUrl): array
+    {
+        $url = $baseUrl.'/robots.txt';
+
+        try {
+            $response = Http::timeout(10)
+                ->withHeaders(['User-Agent' => 'DomainMonitor/1.0'])
+                ->get($url);
+
+            /** @var \Illuminate\Http\Client\Response $response */
+            $status = $response->status();
+            $exists = $response->successful();
+            $body = $exists ? $response->body() : '';
+
+            return [
+                'exists' => $exists,
+                'verified' => true,
+                'status' => $status,
+                'url' => $url,
+                'error' => $exists ? null : "Returned status {$status}",
+                'has_standard_wordpress_admin_rule' => $exists
+                    && preg_match('/^\s*disallow:\s*\/wp-admin\/\s*$/im', $body) === 1,
+                'allow_admin_ajax' => $exists
+                    && preg_match('/^\s*allow:\s*\/wp-admin\/admin-ajax\.php\s*$/im', $body) === 1,
+            ];
+        } catch (Exception $e) {
+            return [
+                'exists' => false,
+                'verified' => false,
+                'status' => 0,
+                'url' => $url,
+                'error' => $e->getMessage(),
+                'has_standard_wordpress_admin_rule' => false,
+                'allow_admin_ajax' => false,
+            ];
+        }
     }
 
     /**

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -671,4 +671,236 @@ class DashboardPriorityQueueApiTest extends TestCase
         $this->assertSame('transport.http_health', $mustFix['control_id']);
         $this->assertContains('blocked_by_robots_in_indexing', $mustFix['issue_families']);
     }
+
+    public function test_priority_queue_hides_intentional_wordpress_admin_robots_exclusion(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'intentional-admin-queue.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+            'expires_at' => null,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'intentional-admin-queue-site',
+            'name' => 'Intentional Admin Queue Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://intentional-admin-queue.example.com/robots.txt',
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'intentional-admin-queue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/intentional-admin-queue-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '77',
+            'search_console_property_uri' => 'sc-domain:intentional-admin-queue.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_plus_manual_csv',
+            'clicks' => 0,
+            'impressions' => 0,
+            'ctr' => 0,
+            'average_position' => 0,
+            'indexed_pages' => 10,
+            'not_indexed_pages' => 1,
+            'blocked_by_robots' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Blocked by robots.txt', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        \App\Models\SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:intentional-admin-queue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://intentional-admin-queue.example.com/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://intentional-admin-queue.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://intentional-admin-queue.example.com/wp-admin/'],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk();
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+        /** @var array<int, array<string, mixed>> $shouldFixPayload */
+        $shouldFixPayload = $response->json('should_fix') ?? [];
+
+        $this->assertNull(collect($mustFixPayload)->firstWhere('domain', 'intentional-admin-queue.example.com'));
+        $this->assertNull(collect($shouldFixPayload)->firstWhere('domain', 'intentional-admin-queue.example.com'));
+    }
+
+    public function test_priority_queue_keeps_admin_robots_issue_when_stored_seo_check_does_not_confirm_wordpress_rule(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'non-standard-admin-queue.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+            'expires_at' => null,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'non-standard-admin-queue-site',
+            'name' => 'Non Standard Admin Queue Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://non-standard-admin-queue.example.com/robots.txt',
+                        'has_standard_wordpress_admin_rule' => false,
+                        'allow_admin_ajax' => false,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'non-standard-admin-queue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/non-standard-admin-queue-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '78',
+            'search_console_property_uri' => 'sc-domain:non-standard-admin-queue.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_plus_manual_csv',
+            'clicks' => 0,
+            'impressions' => 0,
+            'ctr' => 0,
+            'average_position' => 0,
+            'indexed_pages' => 10,
+            'not_indexed_pages' => 1,
+            'blocked_by_robots' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Blocked by robots.txt', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        \App\Models\SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:non-standard-admin-queue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://non-standard-admin-queue.example.com/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://non-standard-admin-queue.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://non-standard-admin-queue.example.com/wp-admin/'],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk();
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+
+        $mustFix = collect($mustFixPayload)->firstWhere('domain', 'non-standard-admin-queue.example.com');
+
+        $this->assertIsArray($mustFix);
+        $this->assertContains('blocked_by_robots_in_indexing', $mustFix['issue_families']);
+    }
 }

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -492,6 +492,371 @@ class DetectedIssueApiTest extends TestCase
         $this->assertCount(2, $issues->pluck('issue_id')->unique());
     }
 
+    public function test_issues_endpoint_hides_intentional_wordpress_admin_exclusions_but_detail_remains_available(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'intentional-admin.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'intentional-admin-site',
+            'name' => 'Intentional Admin Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://intentional-admin.example.com/robots.txt',
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '42',
+            'search_console_property_uri' => 'sc-domain:intentional-admin.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'blocked_by_robots' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Blocked by robots.txt', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:intentional-admin.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://intentional-admin.example.com/wp-admin/',
+            ],
+            'examples' => [
+                ['url' => 'https://intentional-admin.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://intentional-admin.example.com/wp-admin/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'excluded_by_noindex',
+            'source_issue_label' => "Excluded by 'noindex' tag",
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:intentional-admin.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://intentional-admin.example.com/wp-login.php?redirect_to=/wp-admin/',
+            ],
+            'examples' => [
+                ['url' => 'https://intentional-admin.example.com/wp-login.php?redirect_to=/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://intentional-admin.example.com/wp-login.php?redirect_to=/wp-admin/',
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response
+            ->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.blocked_by_robots_in_indexing')
+            ->assertJsonMissingPath('stats.issue_class_counts.excluded_by_noindex');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $issues = collect($payloadIssues);
+
+        $this->assertNull($issues->firstWhere('issue_class', 'blocked_by_robots_in_indexing'));
+        $this->assertNull($issues->firstWhere('issue_class', 'excluded_by_noindex'));
+
+        $identity = app(\App\Services\DetectedIssueIdentityService::class);
+        $blockedIssueId = $identity->makeIssueId($domain->id, $property->slug, 'blocked_by_robots_in_indexing');
+        $noindexIssueId = $identity->makeIssueId($domain->id, $property->slug, 'excluded_by_noindex');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($blockedIssueId))
+            ->assertOk()
+            ->assertJsonPath('issue_class', 'blocked_by_robots_in_indexing')
+            ->assertJsonPath('evidence.expected_exclusion.state', 'expected_robots_exclusion')
+            ->assertJsonPath('evidence.expected_exclusion.code', 'intentional_admin_exclusion')
+            ->assertJsonPath('evidence.expected_exclusion.robots.disallow_wp_admin', true);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($noindexIssueId))
+            ->assertOk()
+            ->assertJsonPath('issue_class', 'excluded_by_noindex')
+            ->assertJsonPath('evidence.expected_exclusion.state', 'expected_noindex_exclusion')
+            ->assertJsonPath('evidence.expected_exclusion.code', 'intentional_admin_exclusion');
+    }
+
+    public function test_issues_endpoint_keeps_admin_issue_visible_when_examples_are_truncated(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'truncated-admin.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'truncated-admin-site',
+            'name' => 'Truncated Admin Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://truncated-admin.example.com/robots.txt',
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '84',
+            'search_console_property_uri' => 'sc-domain:truncated-admin.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'blocked_by_robots' => 2,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Blocked by robots.txt', 'count' => 2],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:truncated-admin.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://truncated-admin.example.com/wp-admin/',
+            ],
+            'examples' => [
+                ['url' => 'https://truncated-admin.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://truncated-admin.example.com/wp-admin/',
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.blocked_by_robots_in_indexing', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $blockedIssue = collect($payloadIssues)->firstWhere('issue_class', 'blocked_by_robots_in_indexing');
+
+        $this->assertIsArray($blockedIssue);
+        $this->assertNull(data_get($blockedIssue, 'evidence.expected_exclusion'));
+    }
+
+    public function test_issues_endpoint_keeps_admin_issue_visible_when_urls_are_on_a_non_property_host(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'canonical-admin.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'canonical-admin-site',
+            'name' => 'Canonical Admin Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://canonical-admin.example.com/robots.txt',
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '85',
+            'search_console_property_uri' => 'sc-domain:canonical-admin.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'blocked_by_robots' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Blocked by robots.txt', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:canonical-admin.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://staging.canonical-admin.example.com/wp-admin/',
+            ],
+            'examples' => [
+                ['url' => 'https://staging.canonical-admin.example.com/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://staging.canonical-admin.example.com/wp-admin/',
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.blocked_by_robots_in_indexing', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $blockedIssue = collect($payloadIssues)->firstWhere('issue_class', 'blocked_by_robots_in_indexing');
+
+        $this->assertIsArray($blockedIssue);
+        $this->assertNull(data_get($blockedIssue, 'evidence.expected_exclusion'));
+    }
+
     public function test_issues_endpoint_includes_broken_link_source_pages(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php
+++ b/tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainCheck;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use App\Services\IntentionalSearchConsoleExclusionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class IntentionalSearchConsoleExclusionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_classifies_wordpress_admin_robots_exclusions_when_evidence_is_complete(): void
+    {
+        $property = $this->makePropertyWithSeoRobotsRule('service-intentional-admin.example.com');
+
+        $classification = app(IntentionalSearchConsoleExclusionService::class)->classify(
+            $property,
+            'blocked_by_robots_in_indexing',
+            [
+                'affected_urls' => ['https://service-intentional-admin.example.com/wp-admin/'],
+                'affected_url_count' => 1,
+                'exact_example_count' => 1,
+                'examples' => [
+                    ['url' => 'https://service-intentional-admin.example.com/wp-admin/'],
+                ],
+            ]
+        );
+
+        $this->assertIsArray($classification);
+        $this->assertSame('expected_robots_exclusion', $classification['state']);
+    }
+
+    public function test_it_does_not_classify_wp_login_as_a_robots_exclusion(): void
+    {
+        $property = $this->makePropertyWithSeoRobotsRule('service-intentional-login.example.com');
+
+        $classification = app(IntentionalSearchConsoleExclusionService::class)->classify(
+            $property,
+            'blocked_by_robots_in_indexing',
+            [
+                'affected_urls' => ['https://service-intentional-login.example.com/wp-login.php?redirect_to=/wp-admin/'],
+                'affected_url_count' => 1,
+                'exact_example_count' => 1,
+                'examples' => [
+                    ['url' => 'https://service-intentional-login.example.com/wp-login.php?redirect_to=/wp-admin/'],
+                ],
+            ]
+        );
+
+        $this->assertNull($classification);
+    }
+
+    public function test_it_does_not_classify_when_unique_candidate_urls_do_not_cover_the_reported_count(): void
+    {
+        $property = $this->makePropertyWithSeoRobotsRule('service-incomplete-admin.example.com');
+
+        $classification = app(IntentionalSearchConsoleExclusionService::class)->classify(
+            $property,
+            'blocked_by_robots_in_indexing',
+            [
+                'affected_urls' => ['https://service-incomplete-admin.example.com/wp-admin/'],
+                'affected_url_count' => 2,
+                'exact_example_count' => 1,
+                'examples' => [
+                    ['url' => 'https://service-incomplete-admin.example.com/wp-admin/'],
+                ],
+            ]
+        );
+
+        $this->assertNull($classification);
+    }
+
+    private function makePropertyWithSeoRobotsRule(string $domainName): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+            'expires_at' => null,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => 'Intentional Search Console Exclusion Test',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => sprintf('https://%s/robots.txt', $domainName),
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        return $property->fresh(['primaryDomain.latestSeoCheck', 'propertyDomains.domain.latestSeoCheck']);
+    }
+}

--- a/tests/Feature/SeoHealthCheckServiceTest.php
+++ b/tests/Feature/SeoHealthCheckServiceTest.php
@@ -21,7 +21,25 @@ class SeoHealthCheckServiceTest extends TestCase
         $this->assertTrue($result['verified']);
         $this->assertTrue($result['is_valid']);
         $this->assertTrue($result['results']['robots']['exists']);
+        $this->assertFalse($result['results']['robots']['has_standard_wordpress_admin_rule']);
         $this->assertFalse($result['results']['sitemap']['exists']);
+    }
+
+    public function test_it_records_standard_wordpress_admin_robots_metadata(): void
+    {
+        Http::fake([
+            'https://example.com/robots.txt' => Http::response(
+                "User-agent: *\nDisallow: /wp-admin/\nAllow: /wp-admin/admin-ajax.php\n",
+                200
+            ),
+            'https://example.com/sitemap.xml' => Http::response('', 404),
+            'https://example.com/sitemap_index.xml' => Http::response('', 404),
+        ]);
+
+        $result = app(SeoHealthCheck::class)->check('example.com');
+
+        $this->assertTrue($result['results']['robots']['has_standard_wordpress_admin_rule']);
+        $this->assertTrue($result['results']['robots']['allow_admin_ajax']);
     }
 
     public function test_it_marks_seo_as_unverified_when_requests_fail(): void

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\AnalyticsInstallAudit;
 use App\Models\DetectedIssueVerification;
 use App\Models\Domain;
+use App\Models\DomainCheck;
 use App\Models\DomainSeoBaseline;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
@@ -477,5 +478,94 @@ class WebPropertyUiTest extends TestCase
         $response->assertDontSee('4 affected URLs');
         $response->assertSee('Blocked by robots.txt');
         $response->assertSee('1 affected URLs');
+    }
+
+    public function test_web_property_detail_hides_intentional_admin_login_search_console_noise(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'intentional-admin-ui.example.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'intentional-admin-ui-site',
+            'name' => 'Intentional Admin UI Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => 'https://intentional-admin-ui.example.au/robots.txt',
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'blocked_by_robots_in_indexing',
+            'source_issue_label' => 'Blocked by robots.txt',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:intentional-admin-ui.example.au',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://intentional-admin-ui.example.au/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://intentional-admin-ui.example.au/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://intentional-admin-ui.example.au/wp-admin/'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'excluded_by_noindex',
+            'source_issue_label' => "Excluded by 'noindex' tag",
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:intentional-admin-ui.example.au',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://intentional-admin-ui.example.au/wp-login.php?redirect_to=/wp-admin/'],
+            'examples' => [
+                ['url' => 'https://intentional-admin-ui.example.au/wp-login.php?redirect_to=/wp-admin/', 'last_crawled' => now()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://intentional-admin-ui.example.au/wp-login.php?redirect_to=/wp-admin/'],
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/web-properties/intentional-admin-ui-site');
+
+        $response->assertOk();
+        $response->assertDontSee('Blocked by robots.txt');
+        $response->assertDontSee("Excluded by 'noindex' tag");
     }
 }


### PR DESCRIPTION
## Summary
- suppress intentional WordPress admin/login Search Console noise from active issue feeds and dashboard queues
- keep direct issue detail available while requiring complete same-host evidence before suppression
- move the WordPress robots rule check onto stored SEO health-check payloads instead of live read-time fetches

## Testing
- php artisan test tests/Feature/SeoHealthCheckServiceTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php
- php artisan test tests/Feature/DashboardPriorityQueueApiTest.php
- php artisan test tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Models/Domain.php app/Services/SeoHealthCheck.php app/Services/IntentionalSearchConsoleExclusionService.php app/Services/SearchConsoleIssueEvidenceService.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/SeoHealthCheckServiceTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
