### PR TITLE
Clean up stale WordPress issue noise for Fleet

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -114,16 +114,16 @@ class WebPropertyController extends Controller
                 'has_gsc_api_enrichment' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('1')
                     ->whereColumn('web_property_id', 'web_properties.id')
-                    ->where('capture_method', '!=', 'gsc_drilldown_zip')
+                    ->whereIn('capture_method', ['gsc_api', 'gsc_mcp_api'])
                     ->limit(1),
                 'gsc_api_snapshot_count' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('count(*)')
                     ->whereColumn('web_property_id', 'web_properties.id')
-                    ->where('capture_method', '!=', 'gsc_drilldown_zip'),
+                    ->whereIn('capture_method', ['gsc_api', 'gsc_mcp_api']),
                 'gsc_api_last_captured_at' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('max(captured_at)')
                     ->whereColumn('web_property_id', 'web_properties.id')
-                    ->where('capture_method', '!=', 'gsc_drilldown_zip'),
+                    ->whereIn('capture_method', ['gsc_api', 'gsc_mcp_api']),
             ])
             ->with([
                 'primaryDomain.tags',

--- a/app/Models/SearchConsoleIssueSnapshot.php
+++ b/app/Models/SearchConsoleIssueSnapshot.php
@@ -171,6 +171,7 @@ class SearchConsoleIssueSnapshot extends Model
             'referring_urls' => is_array($normalizedPayload['referring_urls'] ?? null) ? $normalizedPayload['referring_urls'] : null,
             'canonical_state' => is_array($normalizedPayload['canonical_state'] ?? null) ? $normalizedPayload['canonical_state'] : null,
             'search_analytics' => is_array($normalizedPayload['search_analytics'] ?? null) ? $normalizedPayload['search_analytics'] : null,
+            'live_url_checks' => is_array($normalizedPayload['live_url_checks'] ?? null) ? $normalizedPayload['live_url_checks'] : null,
         ], static fn (mixed $value): bool => $value !== null && $value !== []);
     }
 

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -16,6 +16,7 @@ class DashboardIssueQueueService
         private readonly DetectedIssueIdentityService $issueIdentityService,
         private readonly DetectedIssueVerificationService $issueVerificationService,
         private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
+        private readonly SearchConsoleIssueActionabilityService $issueActionabilityService,
     ) {}
 
     /**
@@ -204,6 +205,10 @@ class DashboardIssueQueueService
             return null;
         }
 
+        $visiblePrimaryRecords = $this->refreshSearchConsoleRecordReasons($visiblePrimaryRecords, $propertyIssueEvidence);
+        $visibleSecondaryRecords = $this->refreshSearchConsoleRecordReasons($visibleSecondaryRecords, $propertyIssueEvidence);
+        $visibleEntries = $this->refreshSearchConsoleRecordReasons($visibleEntries, $propertyIssueEvidence);
+
         $canonicalIssue = $visibleEntries[0] ?? null;
 
         $item['primary_issue_records'] = $visiblePrimaryRecords;
@@ -264,15 +269,23 @@ class DashboardIssueQueueService
 
         $issueId = $this->issueIdentityService->makeIssueId($domainId, $propertySlug, $issueFamily);
         $verification = $verificationMap[$issueId] ?? null;
-        $issueEvidenceForRecord = $this->queueIssueEvidence($item, $issueFamily, $propertyIssueEvidence[$issueFamily] ?? []);
+        $propertyEvidenceForRecord = $propertyIssueEvidence[$issueFamily] ?? [];
+        $issueEvidenceForRecord = $this->queueIssueEvidence($item, $issueFamily, $propertyEvidenceForRecord);
         $issue = [
             'issue_id' => $issueId,
             'detected_at' => $this->queueIssueDetectedAt($item, $issueFamily, $issueEvidenceForRecord),
             'evidence' => $issueEvidenceForRecord,
         ];
 
-        if (! $includeExpectedExclusions && array_key_exists('expected_exclusion', $issueEvidenceForRecord)) {
-            return false;
+        if ($this->isSearchConsoleIssueFamily($issueFamily)) {
+            if (! $includeExpectedExclusions && array_key_exists('expected_exclusion', $propertyEvidenceForRecord)) {
+                return false;
+            }
+
+            if (! $this->issueActionabilityService->isActionable($issueFamily, $propertyEvidenceForRecord)
+                && ! ($includeExpectedExclusions && is_array($propertyEvidenceForRecord['expected_exclusion'] ?? null))) {
+                return false;
+            }
         }
 
         return ! ($verification instanceof \App\Models\DetectedIssueVerification
@@ -289,6 +302,34 @@ class DashboardIssueQueueService
         $severity = is_string($record['severity'] ?? null) ? $record['severity'] : '';
 
         return sprintf('%s|%s|%s', $issueFamily, $severity, $reason);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $records
+     * @param  array<string, array<string, mixed>>  $propertyIssueEvidence
+     * @return array<int, array<string, mixed>>
+     */
+    private function refreshSearchConsoleRecordReasons(array $records, array $propertyIssueEvidence): array
+    {
+        return array_map(function (array $record) use ($propertyIssueEvidence): array {
+            $issueFamily = is_string($record['issue_family'] ?? null) ? $record['issue_family'] : null;
+
+            if (! is_string($issueFamily) || ! $this->isSearchConsoleIssueFamily($issueFamily)) {
+                return $record;
+            }
+
+            $record['reason'] = $this->searchConsoleReasonForEvidence(
+                $issueFamily,
+                $propertyIssueEvidence[$issueFamily] ?? []
+            );
+
+            return $record;
+        }, $records);
+    }
+
+    private function isSearchConsoleIssueFamily(string $issueFamily): bool
+    {
+        return is_array(config('domain_monitor.search_console_issue_catalog.'.$issueFamily));
     }
 
     /**
@@ -553,6 +594,26 @@ class DashboardIssueQueueService
             Str::of((string) $label)->lower()->toString(),
             $count
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     */
+    private function searchConsoleReasonForEvidence(string $issueClass, array $issueEvidence): string
+    {
+        $count = is_numeric($issueEvidence['active_affected_url_count'] ?? null)
+            ? (int) $issueEvidence['active_affected_url_count']
+            : (is_numeric($issueEvidence['affected_url_count'] ?? null)
+                ? (int) $issueEvidence['affected_url_count']
+                : null);
+
+        if ($count !== null && $count > 0) {
+            return $this->searchConsoleReason($issueClass, $count);
+        }
+
+        $label = data_get(config('domain_monitor.search_console_issue_catalog.'.$issueClass), 'label', $issueClass);
+
+        return sprintf('Search Console reports %s', Str::of((string) $label)->lower()->toString());
     }
 
     private function searchConsoleSeverity(string $issueClass): string

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -428,7 +428,9 @@ class DetectedIssueSummaryService
     private function supplementalIssueReason(string $issueClass, array $evidence): string
     {
         $label = data_get(config('domain_monitor.search_console_issue_catalog.'.$issueClass), 'label', $issueClass);
-        $count = is_numeric($evidence['affected_url_count'] ?? null) ? (int) $evidence['affected_url_count'] : null;
+        $count = is_numeric($evidence['active_affected_url_count'] ?? null)
+            ? (int) $evidence['active_affected_url_count']
+            : (is_numeric($evidence['affected_url_count'] ?? null) ? (int) $evidence['affected_url_count'] : null);
 
         if ($count !== null && $count > 0) {
             return sprintf('Search Console reports %s (%d URLs)', strtolower((string) $label), $count);

--- a/app/Services/FleetPropertyContextRefreshService.php
+++ b/app/Services/FleetPropertyContextRefreshService.php
@@ -13,6 +13,7 @@ class FleetPropertyContextRefreshService
         private readonly PropertyConversionLinkScanner $conversionLinkScanner,
         private readonly DomainHealthCheckRunner $domainHealthCheckRunner,
         private readonly SearchConsoleApiEnrichmentRefresher $searchConsoleApiEnrichmentRefresher,
+        private readonly SearchConsoleIssueLiveRecheckService $searchConsoleIssueLiveRecheckService,
     ) {}
 
     /**
@@ -47,6 +48,10 @@ class FleetPropertyContextRefreshService
             capturedBy: 'fleet_context_refresh',
             force: $forceSearchConsoleApiEnrichment,
         );
+        $searchConsoleLiveRechecks = $this->searchConsoleIssueLiveRecheckService->refreshProperty(
+            $property,
+            'fleet_context_refresh'
+        );
 
         $steps = [
             'conversion_links' => $conversionLinks,
@@ -54,6 +59,7 @@ class FleetPropertyContextRefreshService
             'security_headers' => $securityHeaders,
             'seo' => $seo,
             'search_console_api_enrichment' => $searchConsole,
+            'search_console_live_rechecks' => $searchConsoleLiveRechecks,
         ];
 
         $success = collect($steps)->every(
@@ -158,7 +164,8 @@ class FleetPropertyContextRefreshService
      *     broken_links: array{status:'skipped',checked_at:null,reason:string},
      *     security_headers: array{status:'skipped',checked_at:null,reason:string},
      *     seo: array{status:'skipped',checked_at:null,reason:string},
-     *     search_console_api_enrichment: array{status:'skipped',captured_at:null,reason:'ineligible',message:string}
+     *     search_console_api_enrichment: array{status:'skipped',captured_at:null,reason:'ineligible',message:string},
+     *     search_console_live_rechecks: array{status:'skipped',captured_at:null,checked_url_count:0,reason:string}
      *   }
      * }
      */
@@ -196,6 +203,12 @@ class FleetPropertyContextRefreshService
                     'captured_at' => null,
                     'reason' => 'ineligible',
                     'message' => 'Property is not eligible for Fleet context refresh.',
+                ],
+                'search_console_live_rechecks' => [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'checked_url_count' => 0,
+                    'reason' => $reason,
                 ],
             ],
         ];

--- a/app/Services/SearchConsoleApiEnrichmentRefresher.php
+++ b/app/Services/SearchConsoleApiEnrichmentRefresher.php
@@ -251,7 +251,7 @@ class SearchConsoleApiEnrichmentRefresher
                 'gsc_api_last_captured_at' => SearchConsoleIssueSnapshot::query()
                     ->selectRaw('max(captured_at)')
                     ->whereColumn('web_property_id', 'web_properties.id')
-                    ->where('capture_method', '!=', 'gsc_drilldown_zip'),
+                    ->whereIn('capture_method', ['gsc_api', 'gsc_mcp_api']),
             ])
             ->orderBy('name')
             ->get();
@@ -326,7 +326,7 @@ class SearchConsoleApiEnrichmentRefresher
         return $this->normalizeCapturedAt(
             SearchConsoleIssueSnapshot::query()
                 ->where('web_property_id', $property->id)
-                ->where('capture_method', '!=', 'gsc_drilldown_zip')
+                ->whereIn('capture_method', ['gsc_api', 'gsc_mcp_api'])
                 ->max('captured_at')
         );
     }

--- a/app/Services/SearchConsoleIssueActionabilityService.php
+++ b/app/Services/SearchConsoleIssueActionabilityService.php
@@ -395,7 +395,7 @@ class SearchConsoleIssueActionabilityService
             return null;
         }
 
-        $normalizedUrl = Str::lower((string) $parts['scheme']).'://'.$parts['host'];
+        $normalizedUrl = Str::lower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
 
         if (isset($parts['port'])) {
             $normalizedUrl .= ':'.$parts['port'];

--- a/app/Services/SearchConsoleIssueActionabilityService.php
+++ b/app/Services/SearchConsoleIssueActionabilityService.php
@@ -1,0 +1,477 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use Illuminate\Support\Str;
+
+class SearchConsoleIssueActionabilityService
+{
+    public function __construct(
+        private readonly IntentionalSearchConsoleExclusionService $intentionalSearchConsoleExclusionService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>
+     */
+    public function normalize(WebProperty $property, string $issueClass, array $issueEvidence): array
+    {
+        $normalizedEvidence = $issueClass === 'not_found_404'
+            ? $this->normalizeNotFound404Issue($property, $issueEvidence)
+            : $issueEvidence;
+
+        $expectedExclusion = $this->intentionalSearchConsoleExclusionService->classify(
+            $property,
+            $issueClass,
+            $normalizedEvidence
+        );
+
+        if (is_array($expectedExclusion)) {
+            $normalizedEvidence['expected_exclusion'] = $expectedExclusion;
+        }
+
+        return $normalizedEvidence;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     */
+    public function isActionable(string $issueClass, array $issueEvidence): bool
+    {
+        if (! is_array(config('domain_monitor.search_console_issue_catalog.'.$issueClass))) {
+            return true;
+        }
+
+        if (is_array($issueEvidence['expected_exclusion'] ?? null)) {
+            return false;
+        }
+
+        $activeAffectedUrlCount = is_numeric($issueEvidence['active_affected_url_count'] ?? null)
+            ? (int) $issueEvidence['active_affected_url_count']
+            : null;
+
+        if ($activeAffectedUrlCount !== null) {
+            return $activeAffectedUrlCount > 0
+                || ((int) ($issueEvidence['affected_url_count'] ?? 0) > 0);
+        }
+
+        if (is_numeric($issueEvidence['affected_url_count'] ?? null)) {
+            return (int) $issueEvidence['affected_url_count'] > 0;
+        }
+
+        foreach (['affected_urls', 'examples', 'url_inspection', 'sitemaps', 'referring_urls', 'canonical_state', 'search_analytics'] as $key) {
+            if (! empty($issueEvidence[$key])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>
+     */
+    private function normalizeNotFound404Issue(WebProperty $property, array $issueEvidence): array
+    {
+        $candidateUrls = $this->candidateUrls($issueEvidence);
+
+        if ($candidateUrls === []) {
+            return $issueEvidence;
+        }
+
+        $activeUrls = [];
+        $retiredUrls = [];
+        $allSystemNoise = true;
+        $allAuthorArchives = true;
+        $allLegacyEndpoints = true;
+
+        foreach ($candidateUrls as $url) {
+            $isSystemNoise = $this->isExpectedWordPressSystem404($url);
+            $isAuthorArchive = $this->isWordPressAuthorArchiveUrl($url);
+            $isLegacyEndpoint = $this->isLegacyEndpointUrl($property, $url);
+
+            if (! $isSystemNoise) {
+                $allSystemNoise = false;
+            }
+
+            if (! $isAuthorArchive) {
+                $allAuthorArchives = false;
+            }
+
+            if (! $isLegacyEndpoint) {
+                $allLegacyEndpoints = false;
+            }
+
+            if ($isSystemNoise) {
+                $retiredUrls[$url] = 'expected_wordpress_system_404';
+
+                continue;
+            }
+
+            if ($this->isResolvedLegacyEndpoint($property, $url)) {
+                $retiredUrls[$url] = 'resolved_legacy_endpoint';
+
+                continue;
+            }
+
+            $liveCheck = $this->liveUrlCheckForUrl($issueEvidence, $url);
+
+            if ($liveCheck !== null && $this->isResolvedLiveUrlCheck($liveCheck)) {
+                $retiredUrls[$url] = $this->isRetiredAuthorArchive($property, $url, $issueEvidence, $liveCheck)
+                    ? 'retired_wordpress_author_archive'
+                    : 'resolved_live_url';
+
+                continue;
+            }
+
+            $activeUrls[] = $url;
+        }
+
+        if ($activeUrls === $candidateUrls) {
+            return $issueEvidence;
+        }
+
+        if (! $this->issueEvidenceRepresentsCompleteSet($issueEvidence, $candidateUrls)) {
+            return $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+        }
+
+        $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls);
+
+        if ($activeUrls !== []) {
+            return $normalizedEvidence;
+        }
+
+        $matchedUrls = array_keys($retiredUrls);
+        $state = 'resolved_or_retired_404';
+        $reason = 'all_exact_examples_are_non_actionable_or_already_resolved';
+        $code = 'resolved_or_retired_404';
+
+        if ($matchedUrls !== [] && $allSystemNoise) {
+            $state = 'expected_wordpress_system_404';
+            $reason = 'wordpress_system_paths_are_expected_404_noise';
+            $code = 'expected_wordpress_system_404';
+        } elseif ($matchedUrls !== [] && $allLegacyEndpoints) {
+            $state = 'resolved_legacy_endpoint_404';
+            $reason = 'legacy_subdomain_endpoints_now_resolve_successfully';
+            $code = 'resolved_legacy_endpoint_404';
+        } elseif ($matchedUrls !== [] && $allAuthorArchives) {
+            $state = 'retired_wordpress_author_archive';
+            $reason = 'retired_wordpress_author_archives_now_redirect_safely';
+            $code = 'retired_wordpress_author_archive';
+        }
+
+        $normalizedEvidence['expected_exclusion'] = [
+            'state' => $state,
+            'code' => $code,
+            'reason' => $reason,
+            'matched_urls' => array_slice($matchedUrls, 0, 10),
+            'matched_url_count' => count($matchedUrls),
+        ];
+
+        return $normalizedEvidence;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<int, string>
+     */
+    private function candidateUrls(array $issueEvidence): array
+    {
+        $urls = [];
+
+        foreach ((array) ($issueEvidence['affected_urls'] ?? []) as $url) {
+            if (is_string($url) && $url !== '') {
+                $urls[] = $url;
+            }
+        }
+
+        foreach ((array) ($issueEvidence['sample_urls'] ?? []) as $url) {
+            if (is_string($url) && $url !== '') {
+                $urls[] = $url;
+            }
+        }
+
+        foreach ((array) ($issueEvidence['examples'] ?? []) as $example) {
+            if (is_array($example) && is_string($example['url'] ?? null) && $example['url'] !== '') {
+                $urls[] = $example['url'];
+            }
+        }
+
+        return array_values(array_unique($urls));
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @param  array<int, string>  $candidateUrls
+     */
+    private function issueEvidenceRepresentsCompleteSet(array $issueEvidence, array $candidateUrls): bool
+    {
+        if (($issueEvidence['is_example_set_truncated'] ?? false) === true) {
+            return false;
+        }
+
+        $affectedUrlCount = is_numeric($issueEvidence['affected_url_count'] ?? null)
+            ? (int) $issueEvidence['affected_url_count']
+            : null;
+        $exactExampleCount = is_numeric($issueEvidence['exact_example_count'] ?? null)
+            ? (int) $issueEvidence['exact_example_count']
+            : null;
+        $candidateUrlCount = count($candidateUrls);
+
+        if ($exactExampleCount !== null && $affectedUrlCount !== null) {
+            return $candidateUrlCount >= $exactExampleCount
+                && $candidateUrlCount >= $affectedUrlCount;
+        }
+
+        if ($exactExampleCount !== null) {
+            return $candidateUrlCount >= $exactExampleCount;
+        }
+
+        if ($affectedUrlCount !== null) {
+            return $candidateUrlCount >= $affectedUrlCount;
+        }
+
+        return false;
+    }
+
+    private function isExpectedWordPressSystem404(string $url): bool
+    {
+        $path = Str::lower((string) parse_url($url, PHP_URL_PATH));
+
+        if ($path === '' || $path === '/*') {
+            return true;
+        }
+
+        if (Str::startsWith($path, ['/wp-content/', '/wp-content/plugins/', '/wp-content/themes/', '/wp-content/uploads/'])) {
+            return true;
+        }
+
+        return (bool) preg_match('#^/wp-[^/]+\.php$#', $path);
+    }
+
+    private function isResolvedLegacyEndpoint(WebProperty $property, string $url): bool
+    {
+        $scan = is_array($property->legacy_moveroo_endpoint_scan) ? $property->legacy_moveroo_endpoint_scan : [];
+
+        foreach ([
+            'legacy_booking_endpoint' => $property->target_legacy_bookings_replacement_url,
+            'legacy_payment_endpoint' => $property->target_legacy_payments_replacement_url,
+        ] as $key => $preferredReplacement) {
+            $entry = $scan[$key] ?? null;
+
+            if (! is_array($entry) || ! is_string($entry['url'] ?? null) || $entry['url'] !== $url) {
+                continue;
+            }
+
+            $status = is_numeric($entry['resolved_status'] ?? null) ? (int) $entry['resolved_status'] : null;
+            $resolvedUrl = $this->normalizeComparableUrl($entry['resolved_url'] ?? null);
+            $preferredTarget = $this->normalizeComparableUrl($preferredReplacement);
+
+            return $status !== null
+                && $status >= 200
+                && $status < 300
+                && $preferredTarget !== null
+                && $resolvedUrl === $preferredTarget;
+        }
+
+        return false;
+    }
+
+    private function isLegacyEndpointUrl(WebProperty $property, string $url): bool
+    {
+        $scan = is_array($property->legacy_moveroo_endpoint_scan) ? $property->legacy_moveroo_endpoint_scan : [];
+
+        foreach (['legacy_booking_endpoint', 'legacy_payment_endpoint'] as $key) {
+            if (is_string($scan[$key]['url'] ?? null) && $scan[$key]['url'] === $url) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>|null
+     */
+    private function liveUrlCheckForUrl(array $issueEvidence, string $url): ?array
+    {
+        foreach ((array) ($issueEvidence['live_url_checks'] ?? []) as $check) {
+            if (is_array($check) && is_string($check['url'] ?? null) && $check['url'] === $url) {
+                return $check;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $liveCheck
+     */
+    private function isResolvedLiveUrlCheck(array $liveCheck): bool
+    {
+        if (($liveCheck['resolved_ok'] ?? false) === true) {
+            return true;
+        }
+
+        $finalStatus = is_numeric($liveCheck['final_status'] ?? null)
+            ? (int) $liveCheck['final_status']
+            : null;
+
+        return $finalStatus !== null && $finalStatus >= 200 && $finalStatus < 300;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @param  array<string, mixed>  $liveCheck
+     */
+    private function isRetiredAuthorArchive(WebProperty $property, string $url, array $issueEvidence, array $liveCheck): bool
+    {
+        if (! $this->isWordPressAuthorArchiveUrl($url)) {
+            return false;
+        }
+
+        $finalUrl = is_string($liveCheck['final_url'] ?? null) ? $liveCheck['final_url'] : null;
+
+        if (! $this->isSafeResolvedPropertyUrl($property, $finalUrl) || $this->inspectionSuggestsCurrentSources($issueEvidence, $url)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isWordPressAuthorArchiveUrl(string $url): bool
+    {
+        $path = Str::lower((string) parse_url($url, PHP_URL_PATH));
+
+        return (bool) preg_match('#^/author/[^/]+/?$#', $path);
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     */
+    private function inspectionSuggestsCurrentSources(array $issueEvidence, string $url): bool
+    {
+        foreach ((array) data_get($issueEvidence, 'url_inspection.inspected_urls', []) as $inspection) {
+            if (! is_array($inspection) || ! is_string($inspection['url'] ?? null) || $inspection['url'] !== $url) {
+                continue;
+            }
+
+            if (! empty($inspection['referring_urls']) || ! empty($inspection['sitemaps'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isSafeResolvedPropertyUrl(WebProperty $property, ?string $url): bool
+    {
+        if (! is_string($url) || $url === '') {
+            return false;
+        }
+
+        $host = Str::lower((string) parse_url($url, PHP_URL_HOST));
+        $path = (string) parse_url($url, PHP_URL_PATH);
+
+        if ($host === '' || ! in_array($host, $this->knownPropertyHosts($property), true)) {
+            return false;
+        }
+
+        return ! Str::startsWith(Str::lower($path), '/author/');
+    }
+
+    private function normalizeComparableUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        $parts = parse_url($value);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $normalizedUrl = Str::lower((string) $parts['scheme']).'://'.$parts['host'];
+
+        if (isset($parts['port'])) {
+            $normalizedUrl .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $normalizedUrl.($path !== '' ? $path : '/');
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @param  array<int, string>  $activeUrls
+     * @return array<string, mixed>
+     */
+    private function filterEvidenceToUrls(array $issueEvidence, array $activeUrls, bool $preserveCounts = false): array
+    {
+        $activeUrlMap = array_fill_keys($activeUrls, true);
+
+        $issueEvidence['affected_urls'] = $activeUrls;
+        $issueEvidence['sample_urls'] = array_slice($activeUrls, 0, 10);
+        $issueEvidence['examples'] = array_values(array_filter(
+            (array) ($issueEvidence['examples'] ?? []),
+            static fn (mixed $example): bool => is_array($example)
+                && is_string($example['url'] ?? null)
+                && isset($activeUrlMap[$example['url']])
+        ));
+        $issueEvidence['live_url_checks'] = array_values(array_filter(
+            (array) ($issueEvidence['live_url_checks'] ?? []),
+            static fn (mixed $check): bool => is_array($check)
+                && is_string($check['url'] ?? null)
+                && isset($activeUrlMap[$check['url']])
+        ));
+
+        if (! $preserveCounts) {
+            $issueEvidence['affected_url_count'] = count($activeUrls);
+            $issueEvidence['exact_example_count'] = count($activeUrls);
+            $issueEvidence['is_example_set_truncated'] = false;
+            unset($issueEvidence['active_affected_url_count'], $issueEvidence['raw_affected_url_count']);
+        } else {
+            $issueEvidence['active_affected_url_count'] = count($activeUrls);
+            $issueEvidence['raw_affected_url_count'] = is_numeric($issueEvidence['affected_url_count'] ?? null)
+                ? (int) $issueEvidence['affected_url_count']
+                : null;
+        }
+
+        return $issueEvidence;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function knownPropertyHosts(WebProperty $property): array
+    {
+        $hosts = [];
+
+        $property->loadMissing(['primaryDomain', 'propertyDomains.domain']);
+
+        if (is_string($property->primaryDomain?->domain) && $property->primaryDomain->domain !== '') {
+            $hosts[] = Str::lower($property->primaryDomain->domain);
+        }
+
+        foreach ($property->propertyDomains as $link) {
+            if (is_string($link->domain?->domain) && $link->domain->domain !== '') {
+                $hosts[] = Str::lower($link->domain->domain);
+            }
+        }
+
+        if (is_string($property->target_moveroo_subdomain_url) && $property->target_moveroo_subdomain_url !== '') {
+            $targetHost = parse_url($property->target_moveroo_subdomain_url, PHP_URL_HOST);
+
+            if (is_string($targetHost) && $targetHost !== '') {
+                $hosts[] = Str::lower($targetHost);
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+}

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -38,7 +38,15 @@ class SearchConsoleIssueEvidenceService
                 'primaryDomain.latestSeoCheck',
                 'propertyDomains.domain.latestSeoCheck',
             ])
-            ->get(['id', 'slug', 'primary_domain_id']);
+            ->get([
+                'id',
+                'slug',
+                'primary_domain_id',
+                'target_moveroo_subdomain_url',
+                'target_legacy_bookings_replacement_url',
+                'target_legacy_payments_replacement_url',
+                'legacy_moveroo_endpoint_scan',
+            ]);
 
         return $this->evidenceMapForProperties($properties);
     }

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -12,7 +12,7 @@ class SearchConsoleIssueEvidenceService
     public function __construct(
         private readonly DetectedIssueIdentityService $issueIdentityService,
         private readonly DetectedIssueVerificationService $issueVerificationService,
-        private readonly IntentionalSearchConsoleExclusionService $intentionalSearchConsoleExclusionService,
+        private readonly SearchConsoleIssueActionabilityService $issueActionabilityService,
     ) {}
 
     /**
@@ -87,7 +87,7 @@ class SearchConsoleIssueEvidenceService
                 $catalogEntry = config('domain_monitor.search_console_issue_catalog.'.$issueClass, []);
                 $detailSnapshot = $snapshots[$issueClass]['detail'] ?? null;
                 $apiSnapshot = $snapshots[$issueClass]['api'] ?? null;
-                $count = is_numeric($evidence['affected_url_count'] ?? null) ? (int) $evidence['affected_url_count'] : null;
+                $count = $this->displayAffectedUrlCount($evidence);
                 $examples = is_array($evidence['examples'] ?? null) ? $evidence['examples'] : [];
                 $summaryCount = $count ?? $baseline?->issueCount($issueClass);
 
@@ -112,6 +112,10 @@ class SearchConsoleIssueEvidenceService
                 }
 
                 if (is_array($evidence['expected_exclusion'] ?? null)) {
+                    return null;
+                }
+
+                if (! $this->issueActionabilityService->isActionable($issueClass, $evidence)) {
                     return null;
                 }
 
@@ -161,7 +165,7 @@ class SearchConsoleIssueEvidenceService
      * @param  Collection<int, WebProperty>  $properties
      * @return array{
      *   evidence: array<string, array<string, array<string, mixed>>>,
-     *   snapshots: array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot}>>
+     *   snapshots: array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot, live:?SearchConsoleIssueSnapshot}>>
      * }
      */
     private function buildPropertyEvidenceContext(Collection $properties): array
@@ -183,19 +187,10 @@ class SearchConsoleIssueEvidenceService
                 $snapshotEvidence = $this->snapshotEvidenceForClass($snapshotEntries[$issueClass] ?? [
                     'detail' => null,
                     'api' => null,
+                    'live' => null,
                 ]);
                 $mergedEvidence = array_replace($baselineEvidence, $snapshotEvidence);
-                $expectedExclusion = $this->intentionalSearchConsoleExclusionService->classify(
-                    $property,
-                    $issueClass,
-                    $mergedEvidence
-                );
-
-                if (is_array($expectedExclusion)) {
-                    $mergedEvidence['expected_exclusion'] = $expectedExclusion;
-                }
-
-                $issueEvidence[$issueClass] = $mergedEvidence;
+                $issueEvidence[$issueClass] = $this->issueActionabilityService->normalize($property, $issueClass, $mergedEvidence);
             }
 
             return [$property->slug => $issueEvidence];
@@ -209,7 +204,7 @@ class SearchConsoleIssueEvidenceService
 
     /**
      * @param  array<int, string>  $propertyIds
-     * @return array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot}>>
+     * @return array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot, live:?SearchConsoleIssueSnapshot}>>
      */
     private function latestSnapshotsForProperties(array $propertyIds): array
     {
@@ -217,7 +212,7 @@ class SearchConsoleIssueEvidenceService
             return [];
         }
 
-        /** @var array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot}>> $grouped */
+        /** @var array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot, live:?SearchConsoleIssueSnapshot}>> $grouped */
         $grouped = [];
 
         SearchConsoleIssueSnapshot::query()
@@ -226,9 +221,13 @@ class SearchConsoleIssueEvidenceService
             ->orderByDesc('created_at')
             ->get()
             ->each(function (SearchConsoleIssueSnapshot $snapshot) use (&$grouped): void {
-                $bucket = $snapshot->capture_method === 'gsc_drilldown_zip' ? 'detail' : 'api';
+                $bucket = match ($snapshot->capture_method) {
+                    'gsc_drilldown_zip' => 'detail',
+                    'gsc_live_recheck' => 'live',
+                    default => 'api',
+                };
                 $grouped[$snapshot->web_property_id] ??= [];
-                $grouped[$snapshot->web_property_id][$snapshot->issue_class] ??= ['detail' => null, 'api' => null];
+                $grouped[$snapshot->web_property_id][$snapshot->issue_class] ??= ['detail' => null, 'api' => null, 'live' => null];
                 $grouped[$snapshot->web_property_id][$snapshot->issue_class][$bucket] ??= $snapshot;
             });
 
@@ -280,7 +279,7 @@ class SearchConsoleIssueEvidenceService
     }
 
     /**
-     * @param  array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot}  $snapshots
+     * @param  array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot, live:?SearchConsoleIssueSnapshot}  $snapshots
      * @return array<string, mixed>
      */
     private function snapshotEvidenceForClass(array $snapshots): array
@@ -320,6 +319,32 @@ class SearchConsoleIssueEvidenceService
             }
         }
 
+        if ($snapshots['live'] instanceof SearchConsoleIssueSnapshot) {
+            $liveEvidence = $snapshots['live']->issueEvidence();
+
+            if (array_key_exists('live_url_checks', $liveEvidence)) {
+                $evidence['live_url_checks'] = $liveEvidence['live_url_checks'];
+            }
+
+            if (is_string($liveEvidence['captured_at'] ?? null) && $liveEvidence['captured_at'] !== '') {
+                $evidence['live_captured_at'] = $liveEvidence['captured_at'];
+            }
+        }
+
         return $evidence;
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function displayAffectedUrlCount(array $evidence): ?int
+    {
+        if (is_numeric($evidence['active_affected_url_count'] ?? null)) {
+            return (int) $evidence['active_affected_url_count'];
+        }
+
+        return is_numeric($evidence['affected_url_count'] ?? null)
+            ? (int) $evidence['affected_url_count']
+            : null;
     }
 }

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -1,0 +1,377 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\WebProperty;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SearchConsoleIssueLiveRecheckService
+{
+    private const ISSUE_CLASS = 'not_found_404';
+
+    private const REDIRECT_LIMIT = 5;
+
+    private const TIMEOUT_SECONDS = 5;
+
+    private const URL_LIMIT = 10;
+
+    private const TOTAL_BUDGET_SECONDS = 20;
+
+    /**
+     * @return array{status:'refreshed'|'skipped'|'failed',captured_at:string|null,checked_url_count:int,reason:string|null}
+     */
+    public function refreshProperty(WebProperty $property, ?string $capturedBy = null): array
+    {
+        $property->loadMissing(['primaryDomain', 'propertyDomains.domain']);
+
+        try {
+            $sourceSnapshot = $this->latestSourceSnapshot($property);
+
+            if (! $sourceSnapshot instanceof SearchConsoleIssueSnapshot) {
+                return [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'checked_url_count' => 0,
+                    'reason' => 'missing',
+                ];
+            }
+
+            $candidateUrls = $this->candidateUrls($sourceSnapshot->issueEvidence());
+
+            if ($candidateUrls === []) {
+                return [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'checked_url_count' => 0,
+                    'reason' => 'missing',
+                ];
+            }
+
+            $checks = [];
+            $deadline = microtime(true) + self::TOTAL_BUDGET_SECONDS;
+
+            foreach ($candidateUrls as $url) {
+                if (microtime(true) >= $deadline) {
+                    break;
+                }
+
+                $checks[] = $this->probeUrl($property, $url);
+            }
+
+            $capturedAt = now();
+            $primaryDomain = $property->primaryDomainModel();
+
+            if (! $primaryDomain instanceof \App\Models\Domain) {
+                return [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'checked_url_count' => 0,
+                    'reason' => 'missing',
+                ];
+            }
+
+            SearchConsoleIssueSnapshot::query()
+                ->where('web_property_id', $property->id)
+                ->where('issue_class', self::ISSUE_CLASS)
+                ->where('capture_method', 'gsc_live_recheck')
+                ->delete();
+
+            SearchConsoleIssueSnapshot::query()->create([
+                'domain_id' => $primaryDomain->id,
+                'web_property_id' => $property->id,
+                'property_analytics_source_id' => null,
+                'issue_class' => self::ISSUE_CLASS,
+                'source_issue_label' => data_get(config('domain_monitor.search_console_issue_catalog.'.self::ISSUE_CLASS), 'label'),
+                'capture_method' => 'gsc_live_recheck',
+                'source_report' => 'search_console_live_http_recheck',
+                'source_property' => $property->searchConsolePropertyUri(),
+                'artifact_path' => null,
+                'captured_at' => $capturedAt,
+                'captured_by' => $capturedBy ?: 'fleet_context_refresh',
+                'first_detected_at' => $sourceSnapshot->first_detected_at,
+                'last_updated_at' => $sourceSnapshot->last_updated_at,
+                'property_scope' => $sourceSnapshot->property_scope,
+                'affected_url_count' => count($checks),
+                'sample_urls' => array_slice(array_map(
+                    static fn (array $check): string => (string) $check['url'],
+                    $checks
+                ), 0, 10),
+                'examples' => $sourceSnapshot->examples,
+                'chart_points' => null,
+                'normalized_payload' => [
+                    'affected_urls' => array_map(
+                        static fn (array $check): string => (string) $check['url'],
+                        $checks
+                    ),
+                    'live_url_checks' => $checks,
+                ],
+                'raw_payload' => [
+                    'source_snapshot_id' => $sourceSnapshot->id,
+                    'live_url_checks' => $checks,
+                ],
+            ]);
+
+            return [
+                'status' => 'refreshed',
+                'captured_at' => $capturedAt->toIso8601String(),
+                'checked_url_count' => count($checks),
+                'reason' => null,
+            ];
+        } catch (\Throwable $exception) {
+            Log::warning('Search Console live URL recheck failed', [
+                'web_property_id' => $property->id,
+                'property_slug' => $property->slug,
+                'issue_class' => self::ISSUE_CLASS,
+                'exception' => $exception->getMessage(),
+            ]);
+
+            return [
+                'status' => 'failed',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'live_recheck_failed',
+            ];
+        }
+    }
+
+    private function latestSourceSnapshot(WebProperty $property): ?SearchConsoleIssueSnapshot
+    {
+        return SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $property->id)
+            ->where('issue_class', self::ISSUE_CLASS)
+            ->whereIn('capture_method', ['gsc_drilldown_zip', 'gsc_api', 'gsc_mcp_api'])
+            ->orderByRaw("case when capture_method = 'gsc_drilldown_zip' then 0 else 1 end")
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<int, string>
+     */
+    private function candidateUrls(array $issueEvidence): array
+    {
+        $urls = [];
+
+        foreach (['affected_urls', 'sample_urls'] as $key) {
+            foreach ((array) ($issueEvidence[$key] ?? []) as $url) {
+                if (is_string($url) && $url !== '') {
+                    $urls[] = $url;
+                }
+            }
+        }
+
+        foreach ((array) ($issueEvidence['examples'] ?? []) as $example) {
+            if (is_array($example) && is_string($example['url'] ?? null) && $example['url'] !== '') {
+                $urls[] = $example['url'];
+            }
+        }
+
+        return array_slice(array_values(array_unique($urls)), 0, self::URL_LIMIT);
+    }
+
+    /**
+     * @return array{url:string,checked_at:string,final_url:string|null,final_status:int|null,resolved_ok:bool,host_changed:bool|null}
+     */
+    private function probeUrl(WebProperty $property, string $url): array
+    {
+        $originalHost = parse_url($url, PHP_URL_HOST);
+        $currentUrl = $url;
+        $lastStatus = null;
+        $resolvedUrl = null;
+
+        for ($attempt = 0; $attempt <= self::REDIRECT_LIMIT; $attempt++) {
+            if (! $this->isSafeProbeUrl($property, $currentUrl)) {
+                break;
+            }
+
+            try {
+                $response = Http::timeout(self::TIMEOUT_SECONDS)
+                    ->withoutRedirecting()
+                    ->withHeaders([
+                        'Accept' => 'text/html,application/xhtml+xml',
+                        'User-Agent' => 'DomainMonitorSearchConsoleRecheck/1.0 (+https://monitor.again.com.au)',
+                    ])
+                    ->get($currentUrl);
+            } catch (\Throwable) {
+                break;
+            }
+
+            $lastStatus = $response->status();
+            $location = $response->header('Location');
+
+            if ($lastStatus >= 300 && $lastStatus < 400 && $location !== '' && $attempt < self::REDIRECT_LIMIT) {
+                $nextUrl = $this->normalizeUrl($location, $currentUrl);
+
+                if ($nextUrl === null) {
+                    break;
+                }
+
+                $currentUrl = $nextUrl;
+
+                continue;
+            }
+
+            $resolvedUrl = $this->sanitizeUrl($currentUrl);
+
+            break;
+        }
+
+        $resolvedHost = is_string($resolvedUrl) ? parse_url($resolvedUrl, PHP_URL_HOST) : null;
+
+        return [
+            'url' => $url,
+            'checked_at' => now()->toIso8601String(),
+            'final_url' => $resolvedUrl,
+            'final_status' => $lastStatus,
+            'resolved_ok' => $lastStatus !== null && $lastStatus >= 200 && $lastStatus < 300,
+            'host_changed' => is_string($originalHost) && is_string($resolvedHost)
+                ? Str::lower($originalHost) !== Str::lower($resolvedHost)
+                : null,
+        ];
+    }
+
+    private function isSafeProbeUrl(WebProperty $property, string $url): bool
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+
+        $scheme = Str::lower((string) $parts['scheme']);
+        $host = Str::lower((string) $parts['host']);
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return filter_var(
+                $host,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ) !== false;
+        }
+
+        if (! str_contains($host, '.') || Str::endsWith($host, ['.local', '.internal'])) {
+            return false;
+        }
+
+        return in_array($host, $this->knownHosts($property), true)
+            && $this->hostResolvesPublicly($host);
+    }
+
+    private function normalizeUrl(string $url, string $baseUrl): ?string
+    {
+        if (preg_match('#^https?://#i', $url) === 1) {
+            return $url;
+        }
+
+        $baseParts = parse_url($baseUrl);
+
+        if (! is_array($baseParts) || ! isset($baseParts['scheme'], $baseParts['host'])) {
+            return null;
+        }
+
+        $scheme = Str::lower((string) $baseParts['scheme']);
+        $host = (string) $baseParts['host'];
+        $port = isset($baseParts['port']) ? ':'.$baseParts['port'] : '';
+
+        if (Str::startsWith($url, '//')) {
+            return $scheme.':'.$url;
+        }
+
+        if (Str::startsWith($url, '/')) {
+            return $scheme.'://'.$host.$port.$url;
+        }
+
+        $basePath = (string) ($baseParts['path'] ?? '/');
+        $baseDirectory = rtrim(str_replace('\\', '/', dirname($basePath)), '/');
+        $baseDirectory = $baseDirectory === '' ? '' : $baseDirectory;
+
+        return $scheme.'://'.$host.$port.$baseDirectory.'/'.$url;
+    }
+
+    private function sanitizeUrl(string $url): ?string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $sanitizedUrl = Str::lower((string) $parts['scheme']).'://'.$parts['host'];
+
+        if (isset($parts['port'])) {
+            $sanitizedUrl .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $sanitizedUrl.($path !== '' ? $path : '/');
+    }
+
+    private function hostResolvesPublicly(string $host): bool
+    {
+        if (app()->runningUnitTests()) {
+            return true;
+        }
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if (! is_array($records) || $records === []) {
+            return false;
+        }
+
+        foreach ($records as $record) {
+            $ipAddress = $record['ip'] ?? $record['ipv6'] ?? null;
+
+            if (! is_string($ipAddress)) {
+                continue;
+            }
+
+            if (filter_var(
+                $ipAddress,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function knownHosts(WebProperty $property): array
+    {
+        $hosts = [];
+
+        if ($property->primaryDomain instanceof \App\Models\Domain && $property->primaryDomain->domain !== '') {
+            $hosts[] = Str::lower($property->primaryDomain->domain);
+        }
+
+        foreach ($property->propertyDomains as $link) {
+            if ($link->domain instanceof \App\Models\Domain && $link->domain->domain !== '') {
+                $hosts[] = Str::lower($link->domain->domain);
+            }
+        }
+
+        if (is_string($property->target_moveroo_subdomain_url) && $property->target_moveroo_subdomain_url !== '') {
+            $targetHost = parse_url($property->target_moveroo_subdomain_url, PHP_URL_HOST);
+
+            if (is_string($targetHost) && $targetHost !== '') {
+                $hosts[] = Str::lower($targetHost);
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+}

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -50,6 +51,17 @@ class SearchConsoleIssueLiveRecheckService
                 ];
             }
 
+            $primaryDomain = $property->primaryDomainModel();
+
+            if (! $primaryDomain instanceof \App\Models\Domain) {
+                return [
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'checked_url_count' => 0,
+                    'reason' => 'missing',
+                ];
+            }
+
             $checks = [];
             $deadline = microtime(true) + self::TOTAL_BUDGET_SECONDS;
 
@@ -62,57 +74,49 @@ class SearchConsoleIssueLiveRecheckService
             }
 
             $capturedAt = now();
-            $primaryDomain = $property->primaryDomainModel();
 
-            if (! $primaryDomain instanceof \App\Models\Domain) {
-                return [
-                    'status' => 'skipped',
-                    'captured_at' => null,
-                    'checked_url_count' => 0,
-                    'reason' => 'missing',
-                ];
-            }
+            DB::transaction(function () use ($property, $primaryDomain, $sourceSnapshot, $capturedAt, $capturedBy, $checks): void {
+                SearchConsoleIssueSnapshot::query()
+                    ->where('web_property_id', $property->id)
+                    ->where('issue_class', self::ISSUE_CLASS)
+                    ->where('capture_method', 'gsc_live_recheck')
+                    ->delete();
 
-            SearchConsoleIssueSnapshot::query()
-                ->where('web_property_id', $property->id)
-                ->where('issue_class', self::ISSUE_CLASS)
-                ->where('capture_method', 'gsc_live_recheck')
-                ->delete();
-
-            SearchConsoleIssueSnapshot::query()->create([
-                'domain_id' => $primaryDomain->id,
-                'web_property_id' => $property->id,
-                'property_analytics_source_id' => null,
-                'issue_class' => self::ISSUE_CLASS,
-                'source_issue_label' => data_get(config('domain_monitor.search_console_issue_catalog.'.self::ISSUE_CLASS), 'label'),
-                'capture_method' => 'gsc_live_recheck',
-                'source_report' => 'search_console_live_http_recheck',
-                'source_property' => $property->searchConsolePropertyUri(),
-                'artifact_path' => null,
-                'captured_at' => $capturedAt,
-                'captured_by' => $capturedBy ?: 'fleet_context_refresh',
-                'first_detected_at' => $sourceSnapshot->first_detected_at,
-                'last_updated_at' => $sourceSnapshot->last_updated_at,
-                'property_scope' => $sourceSnapshot->property_scope,
-                'affected_url_count' => count($checks),
-                'sample_urls' => array_slice(array_map(
-                    static fn (array $check): string => (string) $check['url'],
-                    $checks
-                ), 0, 10),
-                'examples' => $sourceSnapshot->examples,
-                'chart_points' => null,
-                'normalized_payload' => [
-                    'affected_urls' => array_map(
+                SearchConsoleIssueSnapshot::query()->create([
+                    'domain_id' => $primaryDomain->id,
+                    'web_property_id' => $property->id,
+                    'property_analytics_source_id' => null,
+                    'issue_class' => self::ISSUE_CLASS,
+                    'source_issue_label' => data_get(config('domain_monitor.search_console_issue_catalog.'.self::ISSUE_CLASS), 'label'),
+                    'capture_method' => 'gsc_live_recheck',
+                    'source_report' => 'search_console_live_http_recheck',
+                    'source_property' => $property->searchConsolePropertyUri(),
+                    'artifact_path' => null,
+                    'captured_at' => $capturedAt,
+                    'captured_by' => $capturedBy ?: 'fleet_context_refresh',
+                    'first_detected_at' => $sourceSnapshot->first_detected_at,
+                    'last_updated_at' => $sourceSnapshot->last_updated_at,
+                    'property_scope' => $sourceSnapshot->property_scope,
+                    'affected_url_count' => count($checks),
+                    'sample_urls' => array_slice(array_map(
                         static fn (array $check): string => (string) $check['url'],
                         $checks
-                    ),
-                    'live_url_checks' => $checks,
-                ],
-                'raw_payload' => [
-                    'source_snapshot_id' => $sourceSnapshot->id,
-                    'live_url_checks' => $checks,
-                ],
-            ]);
+                    ), 0, 10),
+                    'examples' => $sourceSnapshot->examples,
+                    'chart_points' => null,
+                    'normalized_payload' => [
+                        'affected_urls' => array_map(
+                            static fn (array $check): string => (string) $check['url'],
+                            $checks
+                        ),
+                        'live_url_checks' => $checks,
+                    ],
+                    'raw_payload' => [
+                        'source_snapshot_id' => $sourceSnapshot->id,
+                        'live_url_checks' => $checks,
+                    ],
+                ]);
+            });
 
             return [
                 'status' => 'refreshed',

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -6,6 +6,7 @@ use App\Models\Domain;
 use App\Models\DomainCheck;
 use App\Models\DomainSeoBaseline;
 use App\Models\PropertyRepository;
+use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -902,5 +903,146 @@ class DashboardPriorityQueueApiTest extends TestCase
 
         $this->assertIsArray($mustFix);
         $this->assertContains('blocked_by_robots_in_indexing', $mustFix['issue_families']);
+    }
+
+    public function test_priority_queue_rebuilds_search_console_reason_counts_from_filtered_404_examples(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'filtered-404-queue.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+            'expires_at' => null,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'filtered-404-queue-site',
+            'name' => 'Filtered 404 Queue Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'filtered-404-queue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/filtered-404-queue-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '790',
+            'search_console_property_uri' => 'sc-domain:filtered-404-queue.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_plus_manual_csv',
+            'not_found_404' => 2,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 2],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:filtered-404-queue.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://filtered-404-queue.example.com/fixed-page/',
+                'https://filtered-404-queue.example.com/still-missing/',
+            ],
+            'examples' => [
+                ['url' => 'https://filtered-404-queue.example.com/fixed-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://filtered-404-queue.example.com/still-missing/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://filtered-404-queue.example.com/fixed-page/',
+                    'https://filtered-404-queue.example.com/still-missing/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'source_property' => 'sc-domain:filtered-404-queue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://filtered-404-queue.example.com/fixed-page/',
+                'https://filtered-404-queue.example.com/still-missing/',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://filtered-404-queue.example.com/fixed-page/',
+                    'https://filtered-404-queue.example.com/still-missing/',
+                ],
+                'live_url_checks' => [
+                    [
+                        'url' => 'https://filtered-404-queue.example.com/fixed-page/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://filtered-404-queue.example.com/fixed-page/',
+                        'final_status' => 200,
+                        'resolved_ok' => true,
+                        'host_changed' => false,
+                    ],
+                    [
+                        'url' => 'https://filtered-404-queue.example.com/still-missing/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://filtered-404-queue.example.com/still-missing/',
+                        'final_status' => 404,
+                        'resolved_ok' => false,
+                        'host_changed' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk();
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+        /** @var array<int, array<string, mixed>> $shouldFixPayload */
+        $shouldFixPayload = $response->json('should_fix') ?? [];
+        $queueItem = collect([...$mustFixPayload, ...$shouldFixPayload])->firstWhere('domain', 'filtered-404-queue.example.com');
+
+        $this->assertIsArray($queueItem);
+        $this->assertContains('Search Console reports not found (404) (1 URLs)', $queueItem['primary_reasons']);
+        $this->assertSame('Search Console reports not found (404) (1 URLs)', data_get($queueItem, 'issue_entries.0.reason'));
     }
 }

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -1045,4 +1045,115 @@ class DashboardPriorityQueueApiTest extends TestCase
         $this->assertContains('Search Console reports not found (404) (1 URLs)', $queueItem['primary_reasons']);
         $this->assertSame('Search Console reports not found (404) (1 URLs)', data_get($queueItem, 'issue_entries.0.reason'));
     }
+
+    public function test_priority_queue_suppresses_resolved_legacy_payment_404_when_queue_evidence_uses_slim_property_select(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'resolved-legacy-queue.example.com',
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+            'expires_at' => null,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'resolved-legacy-queue-site',
+            'name' => 'Resolved Legacy Queue Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'target_moveroo_subdomain_url' => 'https://quotes.resolved-legacy-queue.example.com',
+            'target_legacy_payments_replacement_url' => 'https://quotes.resolved-legacy-queue.example.com/contact',
+            'legacy_moveroo_endpoint_scan' => [
+                'legacy_payment_endpoint' => [
+                    'classification' => 'legacy_payment_endpoint',
+                    'found_on' => 'https://resolved-legacy-queue.example.com/',
+                    'url' => 'https://quotes.resolved-legacy-queue.example.com/payments',
+                    'resolved_url' => 'https://quotes.resolved-legacy-queue.example.com/contact',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => false,
+                ],
+            ],
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'resolved-legacy-queue-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/resolved-legacy-queue-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '610',
+            'search_console_property_uri' => 'sc-domain:resolved-legacy-queue.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:resolved-legacy-queue.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://quotes.resolved-legacy-queue.example.com/payments',
+            ],
+            'examples' => [
+                ['url' => 'https://quotes.resolved-legacy-queue.example.com/payments', 'last_crawled' => now()->subDays(1)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://quotes.resolved-legacy-queue.example.com/payments',
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk();
+
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+        /** @var array<int, array<string, mixed>> $shouldFixPayload */
+        $shouldFixPayload = $response->json('should_fix') ?? [];
+        $queueItem = collect([...$mustFixPayload, ...$shouldFixPayload])->first(function (array $item): bool {
+            return ($item['property_slug'] ?? null) === 'resolved-legacy-queue-site'
+                && ($item['issue_family'] ?? null) === 'search_console.not_found_404';
+        });
+
+        $this->assertNull($queueItem);
+    }
 }

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -857,6 +857,592 @@ class DetectedIssueApiTest extends TestCase
         $this->assertNull(data_get($blockedIssue, 'evidence.expected_exclusion'));
     }
 
+    public function test_issues_endpoint_suppresses_expected_wordpress_system_404_noise_and_retired_author_archives(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $systemDomain = Domain::factory()->create([
+            'domain' => 'system-noise.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $systemProperty = WebProperty::factory()->create([
+            'slug' => 'system-noise-site',
+            'name' => 'System Noise Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $systemDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $systemProperty->id,
+            'domain_id' => $systemDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $systemProperty->id,
+            'repo_name' => 'system-noise-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/system-noise-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $systemDomain->id,
+            'web_property_id' => $systemProperty->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '301',
+            'search_console_property_uri' => 'sc-domain:system-noise.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 2,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 2],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $systemDomain->id,
+            'web_property_id' => $systemProperty->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:system-noise.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://system-noise.example.com/wp-content/plugins/revslider/readme.txt',
+                'https://system-noise.example.com/wp-comments-post.php',
+            ],
+            'examples' => [
+                ['url' => 'https://system-noise.example.com/wp-content/plugins/revslider/readme.txt', 'last_crawled' => now()->subDay()->toDateString()],
+                ['url' => 'https://system-noise.example.com/wp-comments-post.php', 'last_crawled' => now()->subDay()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://system-noise.example.com/wp-content/plugins/revslider/readme.txt',
+                    'https://system-noise.example.com/wp-comments-post.php',
+                ],
+            ],
+        ]);
+
+        $authorDomain = Domain::factory()->create([
+            'domain' => 'author-archive.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $authorProperty = WebProperty::factory()->create([
+            'slug' => 'author-archive-site',
+            'name' => 'Author Archive Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $authorDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $authorProperty->id,
+            'domain_id' => $authorDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $authorProperty->id,
+            'repo_name' => 'author-archive-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/author-archive-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $authorDomain->id,
+            'web_property_id' => $authorProperty->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '302',
+            'search_console_property_uri' => 'sc-domain:author-archive.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $authorDomain->id,
+            'web_property_id' => $authorProperty->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:author-archive.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://author-archive.example.com/author/removalist/',
+            ],
+            'examples' => [
+                ['url' => 'https://author-archive.example.com/author/removalist/', 'last_crawled' => now()->subDay()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://author-archive.example.com/author/removalist/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $authorDomain->id,
+            'web_property_id' => $authorProperty->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_api',
+            'source_report' => 'search_console_api_bundle',
+            'source_property' => 'sc-domain:author-archive.example.com',
+            'captured_at' => now()->subHours(12),
+            'captured_by' => 'test',
+            'normalized_payload' => [
+                'url_inspection' => [
+                    'inspected_urls' => [
+                        [
+                            'url' => 'https://author-archive.example.com/author/removalist/',
+                            'coverage_state' => 'Not found (404)',
+                            'referring_urls' => [],
+                            'sitemaps' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $authorDomain->id,
+            'web_property_id' => $authorProperty->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'source_property' => 'sc-domain:author-archive.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://author-archive.example.com/author/removalist/'],
+            'normalized_payload' => [
+                'affected_urls' => ['https://author-archive.example.com/author/removalist/'],
+                'live_url_checks' => [
+                    [
+                        'url' => 'https://author-archive.example.com/author/removalist/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://author-archive.example.com/',
+                        'final_status' => 200,
+                        'resolved_ok' => true,
+                        'host_changed' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.not_found_404');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'system-noise-site'
+                && ($issue['issue_class'] ?? null) === 'not_found_404';
+        }));
+        $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'author-archive-site'
+                && ($issue['issue_class'] ?? null) === 'not_found_404';
+        }));
+
+        $identity = app(\App\Services\DetectedIssueIdentityService::class);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($identity->makeIssueId($systemDomain->id, $systemProperty->slug, 'not_found_404')))
+            ->assertOk()
+            ->assertJsonPath('evidence.expected_exclusion.state', 'expected_wordpress_system_404');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($identity->makeIssueId($authorDomain->id, $authorProperty->slug, 'not_found_404')))
+            ->assertOk()
+            ->assertJsonPath('evidence.expected_exclusion.state', 'retired_wordpress_author_archive');
+    }
+
+    public function test_issues_endpoint_keeps_only_still_failing_404_examples_after_live_rechecks(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'mixed-404.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'mixed-404-site',
+            'name' => 'Mixed 404 Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '303',
+            'search_console_property_uri' => 'sc-domain:mixed-404.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 2,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 2],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:mixed-404.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://mixed-404.example.com/fixed-page/',
+                'https://mixed-404.example.com/still-missing/',
+            ],
+            'examples' => [
+                ['url' => 'https://mixed-404.example.com/fixed-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://mixed-404.example.com/still-missing/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://mixed-404.example.com/fixed-page/',
+                    'https://mixed-404.example.com/still-missing/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'source_property' => 'sc-domain:mixed-404.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://mixed-404.example.com/fixed-page/',
+                'https://mixed-404.example.com/still-missing/',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://mixed-404.example.com/fixed-page/',
+                    'https://mixed-404.example.com/still-missing/',
+                ],
+                'live_url_checks' => [
+                    [
+                        'url' => 'https://mixed-404.example.com/fixed-page/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://mixed-404.example.com/fixed-page/',
+                        'final_status' => 200,
+                        'resolved_ok' => true,
+                        'host_changed' => false,
+                    ],
+                    [
+                        'url' => 'https://mixed-404.example.com/still-missing/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://mixed-404.example.com/still-missing/',
+                        'final_status' => 404,
+                        'resolved_ok' => false,
+                        'host_changed' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.not_found_404', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('issue_class', 'not_found_404');
+
+        $this->assertIsArray($issue);
+        $this->assertSame(1, data_get($issue, 'evidence.affected_url_count'));
+        $this->assertSame(
+            ['https://mixed-404.example.com/still-missing/'],
+            data_get($issue, 'evidence.affected_urls')
+        );
+        $this->assertSame(
+            'https://mixed-404.example.com/still-missing/',
+            data_get($issue, 'evidence.examples.0.url')
+        );
+        $this->assertSame(
+            ['https://mixed-404.example.com/still-missing/'],
+            collect((array) data_get($issue, 'evidence.live_url_checks'))
+                ->pluck('url')
+                ->values()
+                ->all()
+        );
+    }
+
+    public function test_issues_endpoint_does_not_treat_wp_json_as_expected_system_404_noise(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'wp-json-404.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'wp-json-404-site',
+            'name' => 'WP JSON 404 Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'wp-json-404-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/wp-json-404-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '304',
+            'search_console_property_uri' => 'sc-domain:wp-json-404.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:wp-json-404.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://wp-json-404.example.com/wp-json/'],
+            'examples' => [
+                ['url' => 'https://wp-json-404.example.com/wp-json/', 'last_crawled' => now()->subDay()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://wp-json-404.example.com/wp-json/'],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.not_found_404', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('property_slug', 'wp-json-404-site');
+
+        $this->assertIsArray($issue);
+        $this->assertNull(data_get($issue, 'evidence.expected_exclusion'));
+    }
+
+    public function test_issues_endpoint_keeps_legacy_payment_404_active_without_explicit_replacement_target(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'legacy-payment.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'legacy-payment-site',
+            'name' => 'Legacy Payment Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'target_moveroo_subdomain_url' => 'https://quotes.legacy-payment.example.com',
+            'legacy_moveroo_endpoint_scan' => [
+                'legacy_payment_endpoint' => [
+                    'classification' => 'legacy_payment_endpoint',
+                    'found_on' => 'https://legacy-payment.example.com/',
+                    'url' => 'https://quotes.legacy-payment.example.com/payments',
+                    'resolved_url' => 'https://quotes.legacy-payment.example.com/contact',
+                    'resolved_status' => 200,
+                    'resolved_host_changed' => false,
+                ],
+            ],
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'legacy-payment-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/legacy-payment-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '305',
+            'search_console_property_uri' => 'sc-domain:legacy-payment.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:legacy-payment.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://quotes.legacy-payment.example.com/payments'],
+            'examples' => [
+                ['url' => 'https://quotes.legacy-payment.example.com/payments', 'last_crawled' => now()->subDay()->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => ['https://quotes.legacy-payment.example.com/payments'],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.not_found_404', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('property_slug', 'legacy-payment-site');
+
+        $this->assertIsArray($issue);
+        $this->assertNull(data_get($issue, 'evidence.expected_exclusion'));
+    }
+
     public function test_issues_endpoint_includes_broken_link_source_pages(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/FleetPropertyContextRefreshTest.php
+++ b/tests/Feature/FleetPropertyContextRefreshTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\DetectedIssueVerification;
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\DomainSeoBaseline;
 use App\Models\DomainTag;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
@@ -617,6 +618,129 @@ class FleetPropertyContextRefreshTest extends TestCase
         $this->assertStringNotContainsString(
             'https://failed-refresh.example.com/private-path',
             $content
+        );
+    }
+
+    public function test_refresh_runs_live_rechecks_and_prunes_resolved_404_examples_from_active_issues(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('recheck-404-site', 'recheck-404.example.com');
+
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '555',
+            'search_console_property_uri' => 'sc-domain:recheck-404.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 2,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:recheck-404.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://recheck-404.example.com/fixed-page/',
+                'https://recheck-404.example.com/missing-page/',
+            ],
+            'examples' => [
+                ['url' => 'https://recheck-404.example.com/fixed-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://recheck-404.example.com/missing-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://recheck-404.example.com/fixed-page/',
+                    'https://recheck-404.example.com/missing-page/',
+                ],
+            ],
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => $this->skippedHealthResult($type));
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'fresh',
+                    'message' => null,
+                ]);
+        });
+
+        Http::fake([
+            'https://recheck-404.example.com/fixed-page/' => Http::response('<html>Fixed</html>', 200),
+            'https://recheck-404.example.com/missing-page/' => Http::response('', 404),
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/recheck-404-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('refreshed.search_console_live_rechecks.status', 'refreshed')
+            ->assertJsonPath('refreshed.search_console_live_rechecks.checked_url_count', 2);
+
+        $this->assertDatabaseHas('search_console_issue_snapshots', [
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_live_recheck',
+        ]);
+
+        $issuesResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $issuesResponse->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.not_found_404', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $issuesResponse->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('issue_class', 'not_found_404');
+
+        $this->assertIsArray($issue);
+        $this->assertSame(1, data_get($issue, 'evidence.affected_url_count'));
+        $this->assertSame(
+            ['https://recheck-404.example.com/missing-page/'],
+            data_get($issue, 'evidence.affected_urls')
+        );
+        $this->assertSame(
+            ['https://recheck-404.example.com/missing-page/'],
+            collect((array) data_get($issue, 'evidence.live_url_checks'))
+                ->pluck('url')
+                ->values()
+                ->all()
         );
     }
 

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -568,4 +568,104 @@ class WebPropertyUiTest extends TestCase
         $response->assertDontSee('Blocked by robots.txt');
         $response->assertDontSee("Excluded by 'noindex' tag");
     }
+
+    public function test_web_property_detail_shows_only_surviving_404_examples_after_live_rechecks(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'ui-filtered-404.example.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'ui-filtered-404-site',
+            'name' => 'UI Filtered 404 Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:ui-filtered-404.example.au',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://ui-filtered-404.example.au/fixed-page/',
+                'https://ui-filtered-404.example.au/still-missing/',
+            ],
+            'examples' => [
+                ['url' => 'https://ui-filtered-404.example.au/fixed-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://ui-filtered-404.example.au/still-missing/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://ui-filtered-404.example.au/fixed-page/',
+                    'https://ui-filtered-404.example.au/still-missing/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'source_property' => 'sc-domain:ui-filtered-404.example.au',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://ui-filtered-404.example.au/fixed-page/',
+                'https://ui-filtered-404.example.au/still-missing/',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://ui-filtered-404.example.au/fixed-page/',
+                    'https://ui-filtered-404.example.au/still-missing/',
+                ],
+                'live_url_checks' => [
+                    [
+                        'url' => 'https://ui-filtered-404.example.au/fixed-page/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://ui-filtered-404.example.au/fixed-page/',
+                        'final_status' => 200,
+                        'resolved_ok' => true,
+                        'host_changed' => false,
+                    ],
+                    [
+                        'url' => 'https://ui-filtered-404.example.au/still-missing/',
+                        'checked_at' => now()->toIso8601String(),
+                        'final_url' => 'https://ui-filtered-404.example.au/still-missing/',
+                        'final_status' => 404,
+                        'resolved_ok' => false,
+                        'host_changed' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/web-properties/ui-filtered-404-site');
+
+        $response->assertOk();
+        $response->assertSee('Not found (404)');
+        $response->assertSee('1 affected URLs');
+        $response->assertSee('https://ui-filtered-404.example.au/still-missing/');
+        $response->assertDontSee('https://ui-filtered-404.example.au/fixed-page/');
+    }
 }


### PR DESCRIPTION
## Summary
- filter expected WordPress admin/login exclusions and WordPress system-path 404 noise out of the active issue feeds
- add targeted live Search Console 404 rechecks so mixed rows shrink to only the still-failing URLs
- rebuild queue and property summary counts from the filtered active evidence, including verified-fixed and resolved legacy endpoint behavior

## Testing
- `php artisan test tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/FleetPropertyContextRefreshTest.php tests/Feature/WebPropertyUiTest.php`
- `./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueActionabilityService.php app/Services/SearchConsoleIssueLiveRecheckService.php app/Services/SearchConsoleIssueEvidenceService.php app/Services/FleetPropertyContextRefreshService.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php app/Models/SearchConsoleIssueSnapshot.php app/Http/Controllers/Api/WebPropertyController.php app/Services/SearchConsoleApiEnrichmentRefresher.php --memory-limit=2G`
- `vendor/bin/pint --dirty`
- `composer pr:preflight`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
