### PR TITLE
Add property canonical origin policy

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -41,6 +41,18 @@ class WebPropertyDetail extends Component
 
     public ?string $targetLegacyPaymentsReplacementUrl = null;
 
+    public ?string $canonicalOriginScheme = null;
+
+    public ?string $canonicalOriginHost = null;
+
+    public string $canonicalOriginPolicy = 'unknown';
+
+    public bool $canonicalOriginEnforcementEligible = false;
+
+    public string $canonicalOriginExcludedSubdomainsText = '';
+
+    public bool $canonicalOriginSitemapPolicyKnown = false;
+
     public function mount(): void
     {
         $this->loadProperty();
@@ -79,6 +91,14 @@ class WebPropertyDetail extends Component
         $this->targetContactUsPageUrl = $this->property->target_contact_us_page_url;
         $this->targetLegacyBookingsReplacementUrl = $this->property->target_legacy_bookings_replacement_url;
         $this->targetLegacyPaymentsReplacementUrl = $this->property->target_legacy_payments_replacement_url;
+        $this->canonicalOriginScheme = $this->property->canonical_origin_scheme;
+        $this->canonicalOriginHost = $this->property->canonical_origin_host;
+        $this->canonicalOriginPolicy = $this->property->canonical_origin_policy === 'known' ? 'known' : 'unknown';
+        $this->canonicalOriginEnforcementEligible = (bool) $this->property->canonical_origin_enforcement_eligible;
+        $this->canonicalOriginExcludedSubdomainsText = implode("\n", $this->normalizedCanonicalOriginSubdomains(
+            $this->property->canonical_origin_excluded_subdomains
+        ));
+        $this->canonicalOriginSitemapPolicyKnown = (bool) $this->property->canonical_origin_sitemap_policy_known;
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -166,6 +186,110 @@ class WebPropertyDetail extends Component
         session()->flash('message', 'Target conversion links updated.');
     }
 
+    public function saveCanonicalOriginPolicy(): void
+    {
+        if (! $this->property instanceof WebProperty) {
+            session()->flash('error', 'Property not found.');
+
+            return;
+        }
+
+        $this->authorizePropertyMutation();
+
+        $normalizedScheme = $this->normalizeCanonicalOriginScheme($this->canonicalOriginScheme);
+        $normalizedHost = $this->normalizeCanonicalOriginHost($this->canonicalOriginHost);
+        $normalizedExcludedSubdomains = $this->normalizedCanonicalOriginSubdomains(
+            $this->canonicalOriginExcludedSubdomainsText
+        );
+        $declaredHosts = $this->declaredCanonicalOriginHosts();
+
+        $this->resetValidation();
+
+        $validator = Validator::make(
+            [
+                'canonicalOriginScheme' => $normalizedScheme,
+                'canonicalOriginHost' => $normalizedHost,
+                'canonicalOriginPolicy' => $this->canonicalOriginPolicy,
+                'canonicalOriginEnforcementEligible' => $this->canonicalOriginEnforcementEligible,
+                'canonicalOriginExcludedSubdomains' => $normalizedExcludedSubdomains,
+                'canonicalOriginSitemapPolicyKnown' => $this->canonicalOriginSitemapPolicyKnown,
+            ],
+            [
+                'canonicalOriginScheme' => ['nullable', 'in:http,https'],
+                'canonicalOriginHost' => ['nullable', 'string', 'max:255', 'regex:/^(?=.{1,255}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\\.([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/i'],
+                'canonicalOriginPolicy' => ['required', 'in:known,unknown'],
+                'canonicalOriginEnforcementEligible' => ['boolean'],
+                'canonicalOriginExcludedSubdomains' => ['array'],
+                'canonicalOriginExcludedSubdomains.*' => ['string', 'max:255', 'regex:/^(?=.{1,255}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\\.([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/i'],
+                'canonicalOriginSitemapPolicyKnown' => ['boolean'],
+            ],
+            [
+                'canonicalOriginScheme.in' => 'Canonical origin scheme must be http or https.',
+                'canonicalOriginHost.regex' => 'Canonical origin host must be a valid hostname.',
+                'canonicalOriginPolicy.in' => 'Canonical origin policy must be known or unknown.',
+                'canonicalOriginExcludedSubdomains.*.regex' => 'Excluded subdomains must be valid hostnames.',
+            ]
+        );
+
+        $validator->after(function ($validator) use ($normalizedScheme, $normalizedHost, $normalizedExcludedSubdomains, $declaredHosts): void {
+            if (($normalizedScheme === null) !== ($normalizedHost === null)) {
+                $validator->errors()->add(
+                    'canonicalOriginHost',
+                    'Canonical origin scheme and host must be provided together.'
+                );
+            }
+
+            if ($this->canonicalOriginPolicy === 'known' && ($normalizedScheme === null || $normalizedHost === null)) {
+                $validator->errors()->add(
+                    'canonicalOriginHost',
+                    'Known canonical origin policy requires both scheme and host.'
+                );
+            }
+
+            if ($this->canonicalOriginEnforcementEligible && $this->canonicalOriginPolicy !== 'known') {
+                $validator->errors()->add(
+                    'canonicalOriginEnforcementEligible',
+                    'Canonical origin enforcement can only be enabled when policy is known.'
+                );
+            }
+
+            if ($normalizedHost !== null && ! in_array($normalizedHost, $declaredHosts, true)) {
+                $validator->errors()->add(
+                    'canonicalOriginHost',
+                    'Canonical origin host must belong to this property’s declared domain surface.'
+                );
+            }
+
+            if ($normalizedHost !== null) {
+                foreach ($normalizedExcludedSubdomains as $excludedHost) {
+                    if ($excludedHost === $normalizedHost || ! str_ends_with($excludedHost, '.'.$normalizedHost)) {
+                        $validator->errors()->add(
+                            'canonicalOriginExcludedSubdomains',
+                            'Excluded subdomains must be strict subdomains of the canonical origin host.'
+                        );
+
+                        break;
+                    }
+                }
+            }
+        });
+
+        $validated = $validator->validate();
+
+        $this->property->update([
+            'canonical_origin_scheme' => $validated['canonicalOriginScheme'],
+            'canonical_origin_host' => $validated['canonicalOriginHost'],
+            'canonical_origin_policy' => $validated['canonicalOriginPolicy'],
+            'canonical_origin_enforcement_eligible' => (bool) $validated['canonicalOriginEnforcementEligible'],
+            'canonical_origin_excluded_subdomains' => $validated['canonicalOriginExcludedSubdomains'],
+            'canonical_origin_sitemap_policy_known' => (bool) $validated['canonicalOriginSitemapPolicyKnown'],
+        ]);
+
+        $this->loadProperty();
+
+        session()->flash('message', 'Canonical origin policy updated.');
+    }
+
     public function refreshCurrentConversionLinks(PropertyConversionLinkScanner $scanner): void
     {
         if (! $this->property instanceof WebProperty) {
@@ -200,6 +324,83 @@ class WebPropertyDetail extends Component
         $trimmed = trim($value);
 
         return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function normalizeCanonicalOriginScheme(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = strtolower(trim($value));
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    private function normalizeCanonicalOriginHost(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (str_contains($trimmed, '://')) {
+            $host = parse_url($trimmed, PHP_URL_HOST);
+
+            return is_string($host) && $host !== '' ? strtolower(rtrim($host, '.')) : null;
+        }
+
+        return strtolower(rtrim($trimmed, '.'));
+    }
+
+    /**
+     * @param  array<int, string>|string|null  $value
+     * @return array<int, string>
+     */
+    private function normalizedCanonicalOriginSubdomains(array|string|null $value): array
+    {
+        $entries = match (true) {
+            is_array($value) => $value,
+            is_string($value) => preg_split('/[\r\n,]+/', $value) ?: [],
+            default => [],
+        };
+
+        return collect($entries)
+            ->map(fn (string $entry): ?string => $this->normalizeCanonicalOriginHost($entry))
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function declaredCanonicalOriginHosts(): array
+    {
+        if (! $this->property instanceof WebProperty) {
+            return [];
+        }
+
+        $this->property->loadMissing(['primaryDomain', 'propertyDomains.domain']);
+        $productionUrlHost = parse_url((string) $this->property->production_url, PHP_URL_HOST);
+
+        return collect([
+            $this->normalizeCanonicalOriginHost($this->property->primaryDomain?->domain),
+            $this->normalizeCanonicalOriginHost(is_string($productionUrlHost) ? $productionUrlHost : null),
+            ...$this->property->propertyDomains
+                ->map(fn ($link): ?string => $this->normalizeCanonicalOriginHost($link->domain?->domain))
+                ->all(),
+        ])
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->values()
+            ->all();
     }
 
     private function authorizePropertyMutation(): void

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -260,6 +260,13 @@ class WebPropertyDetail extends Component
                 );
             }
 
+            if ($normalizedHost === null && $normalizedExcludedSubdomains !== []) {
+                $validator->errors()->add(
+                    'canonicalOriginExcludedSubdomains',
+                    'Excluded subdomains require a canonical origin host.'
+                );
+            }
+
             if ($normalizedHost !== null) {
                 foreach ($normalizedExcludedSubdomains as $excludedHost) {
                     if ($excludedHost === $normalizedHost || ! str_ends_with($excludedHost, '.'.$normalizedHost)) {

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -21,6 +21,12 @@ use Illuminate\Support\Str;
  * @property string|null $primary_domain_id
  * @property string|null $production_url
  * @property string|null $staging_url
+ * @property string|null $canonical_origin_scheme
+ * @property string|null $canonical_origin_host
+ * @property string $canonical_origin_policy
+ * @property bool $canonical_origin_enforcement_eligible
+ * @property array<int, string>|null $canonical_origin_excluded_subdomains
+ * @property bool $canonical_origin_sitemap_policy_known
  * @property string|null $platform
  * @property string|null $target_platform
  * @property string|null $owner
@@ -62,6 +68,12 @@ class WebProperty extends Model
         'primary_domain_id',
         'production_url',
         'staging_url',
+        'canonical_origin_scheme',
+        'canonical_origin_host',
+        'canonical_origin_policy',
+        'canonical_origin_enforcement_eligible',
+        'canonical_origin_excluded_subdomains',
+        'canonical_origin_sitemap_policy_known',
         'platform',
         'target_platform',
         'owner',
@@ -87,6 +99,9 @@ class WebProperty extends Model
     {
         return [
             'priority' => 'integer',
+            'canonical_origin_enforcement_eligible' => 'boolean',
+            'canonical_origin_excluded_subdomains' => 'array',
+            'canonical_origin_sitemap_policy_known' => 'boolean',
             'conversion_links_scanned_at' => 'datetime',
             'legacy_moveroo_endpoint_scan' => 'array',
         ];
@@ -638,6 +653,45 @@ class WebProperty extends Model
     }
 
     /**
+     * @return array{
+     *   scheme: string|null,
+     *   host: string|null,
+     *   base_url: string|null,
+     *   policy: 'known'|'unknown',
+     *   scope: 'property_only',
+     *   enforcement_eligible: bool,
+     *   owned_subdomains: array<int, string>,
+     *   excluded_subdomains: array<int, string>,
+     *   sitemap_policy_known: bool
+     * }
+     */
+    public function canonicalOriginSummary(): array
+    {
+        $scheme = $this->canonicalOriginSchemeValue();
+        $host = $this->canonicalOriginHostValue();
+        $baseUrl = $scheme !== null && $host !== null ? $scheme.'://'.$host : null;
+        $policy = $this->canonical_origin_policy === 'known' ? 'known' : 'unknown';
+        $hasExplicitCanonicalOrigin = is_string($this->canonical_origin_scheme)
+            && $this->canonical_origin_scheme !== ''
+            && is_string($this->canonical_origin_host)
+            && $this->canonical_origin_host !== '';
+
+        return [
+            'scheme' => $scheme,
+            'host' => $host,
+            'base_url' => $baseUrl,
+            'policy' => $policy,
+            'scope' => 'property_only',
+            'enforcement_eligible' => (bool) $this->canonical_origin_enforcement_eligible
+                && $policy === 'known'
+                && $hasExplicitCanonicalOrigin,
+            'owned_subdomains' => $this->ownedSubdomainHosts($host),
+            'excluded_subdomains' => $this->normalizedCanonicalOriginSubdomains($this->canonical_origin_excluded_subdomains),
+            'sitemap_policy_known' => (bool) $this->canonical_origin_sitemap_policy_known,
+        ];
+    }
+
+    /**
      * @return array<string, mixed>|null
      */
     private function legacyMoverooEndpointSummary(string $classification, ?string $preferredReplacement): ?array
@@ -700,6 +754,7 @@ class WebProperty extends Model
             'primary_domain' => $this->primaryDomainName(),
             'production_url' => $this->production_url,
             'staging_url' => $this->staging_url,
+            'canonical_origin' => $this->canonicalOriginSummary(),
             'platform' => $this->platform,
             'target_platform' => $this->target_platform,
             'owner' => $this->owner,
@@ -727,6 +782,88 @@ class WebProperty extends Model
             'gsc_evidence_summary' => $this->gscEvidenceSummary(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
+    }
+
+    private function canonicalOriginSchemeValue(): ?string
+    {
+        if (is_string($this->canonical_origin_scheme) && $this->canonical_origin_scheme !== '') {
+            return strtolower($this->canonical_origin_scheme);
+        }
+
+        $scheme = parse_url((string) $this->production_url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && $scheme !== '' ? strtolower($scheme) : null;
+    }
+
+    private function canonicalOriginHostValue(): ?string
+    {
+        if (is_string($this->canonical_origin_host) && $this->canonical_origin_host !== '') {
+            return strtolower($this->canonical_origin_host);
+        }
+
+        $host = parse_url((string) $this->production_url, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? strtolower($host) : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizedCanonicalOriginSubdomains(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return collect($value)
+            ->map(fn (mixed $host): ?string => $this->normalizeCanonicalOriginHost($host))
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function ownedSubdomainHosts(?string $canonicalHost): array
+    {
+        if (! is_string($canonicalHost) || $canonicalHost === '') {
+            return [];
+        }
+
+        return $this->orderedDomainLinks()
+            ->map(fn (WebPropertyDomain $link): ?string => $this->normalizeCanonicalOriginHost($link->domain?->domain))
+            ->filter(
+                fn (?string $host): bool => is_string($host)
+                    && $host !== ''
+                    && $host !== $canonicalHost
+                    && Str::endsWith($host, '.'.$canonicalHost)
+            )
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function normalizeCanonicalOriginHost(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (Str::contains($trimmed, '://')) {
+            $host = parse_url($trimmed, PHP_URL_HOST);
+
+            return is_string($host) && $host !== '' ? strtolower($host) : null;
+        }
+
+        return strtolower(rtrim($trimmed, '.'));
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -45,7 +45,8 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties:id,slug,name,property_type,status,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,target_legacy_bookings_replacement_url,target_legacy_payments_replacement_url,conversion_links_scanned_at,legacy_moveroo_endpoint_scan',
+                'webProperties:id,slug,name,property_type,status,production_url,canonical_origin_scheme,canonical_origin_host,canonical_origin_policy,canonical_origin_enforcement_eligible,canonical_origin_excluded_subdomains,canonical_origin_sitemap_policy_known,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,target_legacy_bookings_replacement_url,target_legacy_payments_replacement_url,conversion_links_scanned_at,legacy_moveroo_endpoint_scan',
+                'webProperties.propertyDomains.domain:id,domain',
                 'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
             ])
@@ -839,6 +840,7 @@ class DashboardIssueQueueService
         $item['deployment_project_name'] = $executionReadiness['deployment_project_name'];
         $item['deployment_project_id'] = $executionReadiness['deployment_project_id'];
         $item['conversion_links'] = $property?->conversionLinkSummary();
+        $item['canonical_origin'] = $property?->canonicalOriginSummary();
 
         return $item;
     }

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -115,15 +115,25 @@ class DetectedIssueSummaryService
 
         $propertyName = null;
         $conversionLinks = null;
+        $canonicalOrigin = null;
         $platformProfile = null;
         $baselineSurface = null;
 
         if (is_string($verification->property_slug) && $verification->property_slug !== '') {
             $property = WebProperty::query()
+                ->with(['propertyDomains.domain:id,domain'])
                 ->select([
+                    'id',
                     'slug',
                     'name',
                     'property_type',
+                    'production_url',
+                    'canonical_origin_scheme',
+                    'canonical_origin_host',
+                    'canonical_origin_policy',
+                    'canonical_origin_enforcement_eligible',
+                    'canonical_origin_excluded_subdomains',
+                    'canonical_origin_sitemap_policy_known',
                     'current_household_quote_url',
                     'current_household_booking_url',
                     'current_vehicle_quote_url',
@@ -145,6 +155,7 @@ class DetectedIssueSummaryService
             if ($property instanceof WebProperty) {
                 $propertyName = $property->name;
                 $conversionLinks = $property->conversionLinkSummary();
+                $canonicalOrigin = $property->canonicalOriginSummary();
             }
         }
 
@@ -176,6 +187,7 @@ class DetectedIssueSummaryService
             'controller_repo' => null,
             'controller_repo_url' => null,
             'conversion_links' => $conversionLinks,
+            'canonical_origin' => $canonicalOrigin,
             'evidence' => [
                 'primary_reasons' => [],
                 'secondary_reasons' => [],
@@ -260,6 +272,7 @@ class DetectedIssueSummaryService
                 'controller_repo' => is_string($item['controller_repo'] ?? null) ? $item['controller_repo'] : null,
                 'controller_repo_url' => is_string($item['controller_repo_url'] ?? null) ? $item['controller_repo_url'] : null,
                 'conversion_links' => is_array($item['conversion_links'] ?? null) ? $item['conversion_links'] : null,
+                'canonical_origin' => is_array($item['canonical_origin'] ?? null) ? $item['canonical_origin'] : null,
                 'evidence' => [
                     'primary_reasons' => [$issueEntry['reason']],
                     'secondary_reasons' => array_values(array_filter(

--- a/database/migrations/2026_04_05_183120_add_canonical_origin_fields_to_web_properties_table.php
+++ b/database/migrations/2026_04_05_183120_add_canonical_origin_fields_to_web_properties_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->string('canonical_origin_scheme', 16)->nullable()->after('staging_url');
+            $table->string('canonical_origin_host', 255)->nullable()->after('canonical_origin_scheme');
+            $table->string('canonical_origin_policy', 32)->default('unknown')->after('canonical_origin_host');
+            $table->boolean('canonical_origin_enforcement_eligible')->default(false)->after('canonical_origin_policy');
+            $table->json('canonical_origin_excluded_subdomains')->nullable()->after('canonical_origin_enforcement_eligible');
+            $table->boolean('canonical_origin_sitemap_policy_known')->default(false)->after('canonical_origin_excluded_subdomains');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table): void {
+            $table->dropColumn([
+                'canonical_origin_scheme',
+                'canonical_origin_host',
+                'canonical_origin_policy',
+                'canonical_origin_enforcement_eligible',
+                'canonical_origin_excluded_subdomains',
+                'canonical_origin_sitemap_policy_known',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -7,6 +7,7 @@
             $analyticsSources = $property->analyticsSources;
             $tags = collect($property->tagSummaries());
             $conversionLinks = $property->conversionLinkSummary();
+            $canonicalOrigin = $property->canonicalOriginSummary();
             $automationCoverage = $property->automationCoverageSummary();
             $automationChecks = [
                 [
@@ -165,6 +166,130 @@
                                 </span>
                             @endforeach
                         @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+            <div class="p-6">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                        <h4 class="text-lg font-medium text-gray-900 dark:text-gray-100">Canonical Origin Policy</h4>
+                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                            This defines the one public origin Fleet may normalize within for this property only. It does not authorize apex normalization across unrelated subdomains.
+                        </p>
+                    </div>
+
+                    <button
+                        type="button"
+                        wire:click="saveCanonicalOriginPolicy"
+                        wire:loading.attr="disabled"
+                        wire:target="saveCanonicalOriginPolicy"
+                        class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        Save Canonical Policy
+                    </button>
+                </div>
+
+                <div class="mt-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+                    <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                        <h5 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Current Contract</h5>
+                        <div class="mt-4 space-y-4 text-sm">
+                            @foreach([
+                                'Scheme' => $canonicalOrigin['scheme'],
+                                'Host' => $canonicalOrigin['host'],
+                                'Base URL' => $canonicalOrigin['base_url'],
+                                'Policy' => $canonicalOrigin['policy'],
+                                'Scope' => $canonicalOrigin['scope'],
+                                'Enforcement Eligible' => $canonicalOrigin['enforcement_eligible'] ? 'Yes' : 'No',
+                                'Sitemap Policy Known' => $canonicalOrigin['sitemap_policy_known'] ? 'Yes' : 'No',
+                            ] as $label => $value)
+                                <div>
+                                    <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ $label }}</div>
+                                    <div class="mt-1 break-all font-medium text-gray-900 dark:text-gray-100">{{ $value ?: 'Not set' }}</div>
+                                </div>
+                            @endforeach
+
+                            <div class="border-t border-gray-200 pt-4 dark:border-gray-700">
+                                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Owned Subdomains</div>
+                                @if(($canonicalOrigin['owned_subdomains'] ?? []) !== [])
+                                    <div class="mt-2 space-y-1">
+                                        @foreach($canonicalOrigin['owned_subdomains'] as $host)
+                                            <div class="break-all text-gray-900 dark:text-gray-100">{{ $host }}</div>
+                                        @endforeach
+                                    </div>
+                                @else
+                                    <div class="mt-1 text-gray-500 dark:text-gray-400">None declared on this property</div>
+                                @endif
+                            </div>
+
+                            <div class="border-t border-gray-200 pt-4 dark:border-gray-700">
+                                <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Excluded Subdomains</div>
+                                @if(($canonicalOrigin['excluded_subdomains'] ?? []) !== [])
+                                    <div class="mt-2 space-y-1">
+                                        @foreach($canonicalOrigin['excluded_subdomains'] as $host)
+                                            <div class="break-all text-gray-900 dark:text-gray-100">{{ $host }}</div>
+                                        @endforeach
+                                    </div>
+                                @else
+                                    <div class="mt-1 text-gray-500 dark:text-gray-400">No excluded subdomains configured</div>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                        <h5 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Declared Policy</h5>
+
+                        <div class="mt-4 grid grid-cols-1 gap-4">
+                            <div>
+                                <label for="canonical_origin_policy" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Policy</label>
+                                <select id="canonical_origin_policy" wire:model="canonicalOriginPolicy" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
+                                    <option value="unknown">Unknown</option>
+                                    <option value="known">Known</option>
+                                </select>
+                                @error('canonicalOriginPolicy') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="canonical_origin_scheme" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Scheme</label>
+                                <select id="canonical_origin_scheme" wire:model="canonicalOriginScheme" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
+                                    <option value="">Not set</option>
+                                    <option value="https">https</option>
+                                    <option value="http">http</option>
+                                </select>
+                                @error('canonicalOriginScheme') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="canonical_origin_host" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Host</label>
+                                <input id="canonical_origin_host" type="text" wire:model="canonicalOriginHost" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="movingagain.com.au" />
+                                @error('canonicalOriginHost') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <div>
+                                <label for="canonical_origin_excluded_subdomains" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Excluded Subdomains</label>
+                                <textarea id="canonical_origin_excluded_subdomains" wire:model="canonicalOriginExcludedSubdomainsText" rows="4" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="cartransport.movingagain.com.au&#10;quotes.movingagain.com.au"></textarea>
+                                <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">One hostname per line. These stay outside canonical-origin normalization for this property.</div>
+                                @error('canonicalOriginExcludedSubdomains') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                                @error('canonicalOriginExcludedSubdomains.*') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                            </div>
+                            <label class="inline-flex items-start gap-3">
+                                <input type="checkbox" wire:model="canonicalOriginEnforcementEligible" class="mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900" />
+                                <span>
+                                    <span class="block text-sm font-medium text-gray-900 dark:text-gray-100">Canonical origin enforcement eligible</span>
+                                    <span class="block text-xs text-gray-500 dark:text-gray-400">Only enable when this property has a known canonical public origin and Fleet may safely normalize within it.</span>
+                                </span>
+                            </label>
+                            @error('canonicalOriginEnforcementEligible') <div class="text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+
+                            <label class="inline-flex items-start gap-3">
+                                <input type="checkbox" wire:model="canonicalOriginSitemapPolicyKnown" class="mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900" />
+                                <span>
+                                    <span class="block text-sm font-medium text-gray-900 dark:text-gray-100">Sitemap policy known</span>
+                                    <span class="block text-xs text-gray-500 dark:text-gray-400">Mark this once the property’s sitemap host policy is known well enough for automated normalization work.</span>
+                                </span>
+                            </label>
+                            @error('canonicalOriginSitemapPolicyKnown') <div class="text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -34,6 +34,10 @@ class DashboardPriorityQueueApiTest extends TestCase
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $mustFixDomain->id,
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'must-fix.example.com',
+            'canonical_origin_policy' => 'known',
+            'canonical_origin_enforcement_eligible' => true,
             'target_household_quote_url' => 'https://quote.must-fix.example.com/household',
             'target_moveroo_subdomain_url' => 'https://must-fix.moveroo.com.au',
             'target_contact_us_page_url' => 'https://must-fix.example.com/contact-us',
@@ -222,6 +226,10 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('must_fix.0.issue_family', 'health.http')
             ->assertJsonPath('must_fix.0.control_id', 'transport.http_health')
             ->assertJsonPath('must_fix.0.platform_profile', 'wordpress_legacy_unmanaged')
+            ->assertJsonPath('must_fix.0.canonical_origin.base_url', 'https://must-fix.example.com')
+            ->assertJsonPath('must_fix.0.canonical_origin.policy', 'known')
+            ->assertJsonPath('must_fix.0.canonical_origin.scope', 'property_only')
+            ->assertJsonPath('must_fix.0.canonical_origin.enforcement_eligible', true)
             ->assertJsonPath('must_fix.0.conversion_links.target.household_quote', 'https://quote.must-fix.example.com/household')
             ->assertJsonPath('must_fix.0.conversion_links.target.moveroo_subdomain', 'https://must-fix.moveroo.com.au')
             ->assertJsonPath('must_fix.0.conversion_links.target.contact_us_page', 'https://must-fix.example.com/contact-us')

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -34,6 +34,12 @@ class DetectedIssueApiTest extends TestCase
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $redirectDomain->id,
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'redirect-issue.example.com',
+            'canonical_origin_policy' => 'known',
+            'canonical_origin_enforcement_eligible' => true,
+            'canonical_origin_excluded_subdomains' => ['cartransport.redirect-issue.example.com'],
+            'canonical_origin_sitemap_policy_known' => true,
             'target_household_quote_url' => 'https://quote.redirect-issue.example.com/household',
             'target_moveroo_subdomain_url' => 'https://redirect-issue.moveroo.com.au',
             'target_contact_us_page_url' => 'https://redirect-issue.example.com/contact-us',
@@ -64,6 +70,21 @@ class DetectedIssueApiTest extends TestCase
             'domain_id' => $redirectDomain->id,
             'usage_type' => 'primary',
             'is_canonical' => true,
+        ]);
+
+        $redirectSubdomain = Domain::factory()->create([
+            'domain' => 'quotes.redirect-issue.example.com',
+            'expires_at' => null,
+            'is_active' => false,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $redirectProperty->id,
+            'domain_id' => $redirectSubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
         ]);
 
         PropertyRepository::create([
@@ -337,6 +358,21 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('https://redirect-issue.moveroo.com.au/bookings', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.url'));
         $this->assertSame('https://removalist.net/booking/create', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_url'));
         $this->assertTrue((bool) data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_host_changed'));
+        $this->assertSame('https', data_get($redirectIssue, 'canonical_origin.scheme'));
+        $this->assertSame('redirect-issue.example.com', data_get($redirectIssue, 'canonical_origin.host'));
+        $this->assertSame('https://redirect-issue.example.com', data_get($redirectIssue, 'canonical_origin.base_url'));
+        $this->assertSame('known', data_get($redirectIssue, 'canonical_origin.policy'));
+        $this->assertSame('property_only', data_get($redirectIssue, 'canonical_origin.scope'));
+        $this->assertTrue((bool) data_get($redirectIssue, 'canonical_origin.enforcement_eligible'));
+        $this->assertSame(
+            ['quotes.redirect-issue.example.com'],
+            data_get($redirectIssue, 'canonical_origin.owned_subdomains')
+        );
+        $this->assertSame(
+            ['cartransport.redirect-issue.example.com'],
+            data_get($redirectIssue, 'canonical_origin.excluded_subdomains')
+        );
+        $this->assertTrue((bool) data_get($redirectIssue, 'canonical_origin.sitemap_policy_known'));
         $this->assertSame(['Search Console reports page with redirect (7 URLs)'], $redirectIssue['evidence']['primary_reasons']);
         $this->assertSame(
             ['https://redirect-issue.example.com/', 'http://redirect-issue.example.com/'],
@@ -385,6 +421,8 @@ class DetectedIssueApiTest extends TestCase
             ->assertJsonPath('issue_id', $redirectIssue['issue_id'])
             ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
             ->assertJsonPath('conversion_links.target.moveroo_subdomain', 'https://redirect-issue.moveroo.com.au')
+            ->assertJsonPath('canonical_origin.host', 'redirect-issue.example.com')
+            ->assertJsonPath('canonical_origin.enforcement_eligible', true)
             ->assertJsonPath('conversion_links.target.contact_us_page', 'https://redirect-issue.example.com/contact-us')
             ->assertJsonPath('conversion_links.target.legacy_bookings_replacement', 'https://removalist.net/booking/create')
             ->assertJsonPath('conversion_links.legacy_endpoints.legacy_payment_endpoint.resolved_url', 'https://redirect-issue.moveroo.com.au/contact')

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -54,6 +54,12 @@ class WebPropertyApiTest extends TestCase
             'platform' => 'Astro',
             'primary_domain_id' => $primaryDomain->id,
             'production_url' => 'https://moveroo.com.au',
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'moveroo.com.au',
+            'canonical_origin_policy' => 'known',
+            'canonical_origin_enforcement_eligible' => true,
+            'canonical_origin_excluded_subdomains' => ['cartransport.moveroo.com.au'],
+            'canonical_origin_sitemap_policy_known' => true,
             'current_household_quote_url' => 'https://removalists.moveroo.com.au/quote/household',
             'current_household_booking_url' => 'https://removalists.moveroo.com.au/booking/create',
             'current_vehicle_quote_url' => 'https://cars.moveroo.com.au/quote/v2',
@@ -95,6 +101,19 @@ class WebPropertyApiTest extends TestCase
             'web_property_id' => $property->id,
             'domain_id' => $redirectDomain->id,
             'usage_type' => 'redirect',
+            'is_canonical' => false,
+        ]);
+
+        $ownedSubdomain = Domain::factory()->create([
+            'domain' => 'quotes.moveroo.com.au',
+            'platform' => 'Astro',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $ownedSubdomain->id,
+            'usage_type' => 'subdomain',
             'is_canonical' => false,
         ]);
 
@@ -194,6 +213,14 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('contract_version', 1)
             ->assertJsonPath('web_properties.0.slug', 'moveroo-website')
             ->assertJsonPath('web_properties.0.primary_domain', 'moveroo.com.au')
+            ->assertJsonPath('web_properties.0.canonical_origin.scheme', 'https')
+            ->assertJsonPath('web_properties.0.canonical_origin.host', 'moveroo.com.au')
+            ->assertJsonPath('web_properties.0.canonical_origin.base_url', 'https://moveroo.com.au')
+            ->assertJsonPath('web_properties.0.canonical_origin.policy', 'known')
+            ->assertJsonPath('web_properties.0.canonical_origin.scope', 'property_only')
+            ->assertJsonPath('web_properties.0.canonical_origin.enforcement_eligible', true)
+            ->assertJsonPath('web_properties.0.canonical_origin.excluded_subdomains.0', 'cartransport.moveroo.com.au')
+            ->assertJsonPath('web_properties.0.canonical_origin.sitemap_policy_known', true)
             ->assertJsonPath('web_properties.0.repositories.0.repo_name', 'moveroo/moveroo-website-astro')
             ->assertJsonPath('web_properties.0.analytics_sources.0.external_id', '6')
             ->assertJsonPath('web_properties.0.analytics_sources.0.install_audit.install_verdict', 'installed_match')
@@ -233,6 +260,12 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.api_snapshot_count', 0)
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_api_captured_at', null)
             ->assertJsonPath('web_properties.0.health_summary.active_alerts_count', 1);
+
+        $ownedSubdomains = $response->json('web_properties.0.canonical_origin.owned_subdomains');
+
+        $this->assertIsArray($ownedSubdomains);
+        $this->assertContains('www.moveroo.com.au', $ownedSubdomains);
+        $this->assertContains('quotes.moveroo.com.au', $ownedSubdomains);
     }
 
     public function test_web_properties_summary_can_filter_to_fleet_focus_properties(): void

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\WebPropertyDetail;
+use App\Models\Domain;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class WebPropertyCanonicalOriginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_property_detail_can_save_canonical_origin_policy(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $subdomain = Domain::factory()->create([
+            'domain' => 'quotes.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $subdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('canonicalOriginPolicy', 'known')
+            ->set('canonicalOriginScheme', 'https')
+            ->set('canonicalOriginHost', 'movingagain.com.au')
+            ->set('canonicalOriginEnforcementEligible', true)
+            ->set('canonicalOriginExcludedSubdomainsText', "cartransport.movingagain.com.au\nquotesbookings.movingagain.com.au")
+            ->set('canonicalOriginSitemapPolicyKnown', true)
+            ->call('saveCanonicalOriginPolicy')
+            ->assertHasNoErrors()
+            ->assertSee('property_only')
+            ->assertSee('quotes.movingagain.com.au');
+
+        $property->refresh();
+
+        $this->assertSame('https', $property->canonical_origin_scheme);
+        $this->assertSame('movingagain.com.au', $property->canonical_origin_host);
+        $this->assertSame('known', $property->canonical_origin_policy);
+        $this->assertTrue($property->canonical_origin_enforcement_eligible);
+        $this->assertSame(
+            ['cartransport.movingagain.com.au', 'quotesbookings.movingagain.com.au'],
+            $property->canonical_origin_excluded_subdomains
+        );
+        $this->assertTrue($property->canonical_origin_sitemap_policy_known);
+    }
+
+    public function test_web_property_show_exposes_safe_fallback_canonical_origin_without_enabling_enforcement(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $subdomain = Domain::factory()->create([
+            'domain' => 'cartransport.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au/services',
+            'canonical_origin_policy' => 'unknown',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $subdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties/movingagain-site')
+            ->assertOk()
+            ->assertJsonPath('data.canonical_origin.scheme', 'https')
+            ->assertJsonPath('data.canonical_origin.host', 'movingagain.com.au')
+            ->assertJsonPath('data.canonical_origin.base_url', 'https://movingagain.com.au')
+            ->assertJsonPath('data.canonical_origin.policy', 'unknown')
+            ->assertJsonPath('data.canonical_origin.scope', 'property_only')
+            ->assertJsonPath('data.canonical_origin.enforcement_eligible', false)
+            ->assertJsonPath('data.canonical_origin.owned_subdomains.0', 'cartransport.movingagain.com.au')
+            ->assertJsonPath('data.canonical_origin.excluded_subdomains', [])
+            ->assertJsonPath('data.canonical_origin.sitemap_policy_known', false);
+    }
+
+    public function test_property_detail_rejects_unrelated_canonical_hosts_and_invalid_excluded_subdomains(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('canonicalOriginPolicy', 'known')
+            ->set('canonicalOriginScheme', 'https')
+            ->set('canonicalOriginHost', 'unrelated.example.com')
+            ->set('canonicalOriginEnforcementEligible', true)
+            ->set('canonicalOriginExcludedSubdomainsText', "quotes.movingagain.com.au\noutside.example.com")
+            ->call('saveCanonicalOriginPolicy')
+            ->assertHasErrors([
+                'canonicalOriginHost',
+                'canonicalOriginExcludedSubdomains',
+            ]);
+
+        $property->refresh();
+
+        $this->assertNull($property->canonical_origin_scheme);
+        $this->assertNull($property->canonical_origin_host);
+        $this->assertSame('unknown', $property->canonical_origin_policy);
+        $this->assertFalse($property->canonical_origin_enforcement_eligible);
+    }
+}

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -166,4 +166,41 @@ class WebPropertyCanonicalOriginTest extends TestCase
         $this->assertSame('unknown', $property->canonical_origin_policy);
         $this->assertFalse($property->canonical_origin_enforcement_eligible);
     }
+
+    public function test_property_detail_rejects_excluded_subdomains_without_a_canonical_host(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('canonicalOriginPolicy', 'unknown')
+            ->set('canonicalOriginScheme', null)
+            ->set('canonicalOriginHost', null)
+            ->set('canonicalOriginExcludedSubdomainsText', 'quotes.movingagain.com.au')
+            ->call('saveCanonicalOriginPolicy')
+            ->assertHasErrors(['canonicalOriginExcludedSubdomains']);
+
+        $property->refresh();
+
+        $this->assertNull($property->canonical_origin_host);
+        $this->assertNull($property->canonical_origin_excluded_subdomains);
+    }
 }

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -73,6 +73,12 @@ class WebPropertyUiTest extends TestCase
             'status' => 'active',
             'primary_domain_id' => $primaryDomain->id,
             'production_url' => 'https://movingagain.com.au',
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'movingagain.com.au',
+            'canonical_origin_policy' => 'known',
+            'canonical_origin_enforcement_eligible' => true,
+            'canonical_origin_excluded_subdomains' => ['cartransport.movingagain.com.au'],
+            'canonical_origin_sitemap_policy_known' => true,
             'notes' => 'Review alias grouping before merge.',
         ]);
 
@@ -141,6 +147,10 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('Target Links');
         $response->assertSee('Moveroo Subdomain');
         $response->assertSee('Contact Us Page');
+        $response->assertSee('Canonical Origin Policy');
+        $response->assertSee('Save Canonical Policy');
+        $response->assertSee('property_only');
+        $response->assertSee('cartransport.movingagain.com.au');
         $response->assertSee('Automation Checklist');
         $response->assertSee('Needs Matomo');
     }


### PR DESCRIPTION
## Summary
- add property-level canonical origin fields and API contract for Fleet/Paperclip
- expose canonical origin policy in property, issue, and queue payloads with property-only scope
- add admin controls and regression coverage for safe canonical origin declarations

## Verification
- php artisan test tests/Feature/WebPropertyCanonicalOriginTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/WebPropertyUiTest.php tests/Feature/WebPropertyConversionLinksTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Livewire/WebPropertyDetail.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Feature/WebPropertyCanonicalOriginTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/DetectedIssueApiTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
