### PR TITLE
Fix PostgreSQL latest SEO check loading

### DIFF
--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -202,12 +202,9 @@ class Domain extends Model
     public function latestSeoCheck(): HasOne
     {
         return $this->hasOne(DomainCheck::class)
-            ->ofMany([
-                'finished_at' => 'max',
-                'created_at' => 'max',
-            ], function (Builder $query): void {
-                $query->where('check_type', 'seo');
-            });
+            ->where('check_type', 'seo')
+            ->orderByDesc('finished_at')
+            ->orderByDesc('created_at');
     }
 
     /**

--- a/tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php
+++ b/tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php
@@ -75,6 +75,88 @@ class IntentionalSearchConsoleExclusionServiceTest extends TestCase
         $this->assertNull($classification);
     }
 
+    public function test_it_uses_the_latest_seo_check_when_multiple_records_exist(): void
+    {
+        $domainName = 'service-latest-admin.example.com';
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => 'Intentional Search Console Exclusion Test',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinutes(10),
+            'finished_at' => now()->subMinutes(9),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => sprintf('https://%s/robots.txt', $domainName),
+                        'has_standard_wordpress_admin_rule' => false,
+                        'allow_admin_ajax' => false,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        DomainCheck::create([
+            'domain_id' => $domain->id,
+            'check_type' => 'seo',
+            'status' => 'ok',
+            'started_at' => now()->subMinute(),
+            'finished_at' => now(),
+            'duration_ms' => 100,
+            'payload' => [
+                'results' => [
+                    'robots' => [
+                        'url' => sprintf('https://%s/robots.txt', $domainName),
+                        'has_standard_wordpress_admin_rule' => true,
+                        'allow_admin_ajax' => true,
+                    ],
+                ],
+            ],
+            'retry_count' => 0,
+        ]);
+
+        $property = $property->fresh(['primaryDomain.latestSeoCheck', 'propertyDomains.domain.latestSeoCheck']);
+
+        $classification = app(IntentionalSearchConsoleExclusionService::class)->classify(
+            $property,
+            'blocked_by_robots_in_indexing',
+            [
+                'affected_urls' => [sprintf('https://%s/wp-admin/', $domainName)],
+                'affected_url_count' => 1,
+                'exact_example_count' => 1,
+                'examples' => [
+                    ['url' => sprintf('https://%s/wp-admin/', $domainName)],
+                ],
+            ]
+        );
+
+        $this->assertIsArray($classification);
+        $this->assertSame('expected_robots_exclusion', $classification['state']);
+    }
+
     private function makePropertyWithSeoRobotsRule(string $domainName): WebProperty
     {
         $domain = Domain::factory()->create([


### PR DESCRIPTION
## Summary
- replace the PostgreSQL-incompatible one-of-many latest SEO check relation that was generating MAX(uuid)
- keep the latest stored SEO robots state available for Search Console exclusion logic and queue rendering
- add regression coverage that proves the newest SEO check still wins when multiple records exist

## Production root cause
Dashboard and queue rendering were crashing in production because the latest SEO check eager load generated a PostgreSQL query using  on a UUID primary key.

## Verification
- php artisan test tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Models/Domain.php tests/Feature/IntentionalSearchConsoleExclusionServiceTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
