### PR TITLE
Allow owned subdomains to be linked from properties

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire;
 
+use App\Models\Domain;
 use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
 use App\Services\PropertyConversionLinkScanner;
 use App\Services\SearchConsoleIssueEvidenceService;
 use App\Services\SearchConsoleIssueSnapshotImporter;
@@ -53,6 +55,10 @@ class WebPropertyDetail extends Component
 
     public bool $canonicalOriginSitemapPolicyKnown = false;
 
+    public ?string $linkedSubdomainHost = null;
+
+    public ?string $linkedSubdomainNotes = null;
+
     public function mount(): void
     {
         $this->loadProperty();
@@ -99,6 +105,8 @@ class WebPropertyDetail extends Component
             $this->property->canonical_origin_excluded_subdomains
         ));
         $this->canonicalOriginSitemapPolicyKnown = (bool) $this->property->canonical_origin_sitemap_policy_known;
+        $this->linkedSubdomainHost = null;
+        $this->linkedSubdomainNotes = null;
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -295,6 +303,85 @@ class WebPropertyDetail extends Component
         $this->loadProperty();
 
         session()->flash('message', 'Canonical origin policy updated.');
+    }
+
+    public function saveLinkedSubdomain(): void
+    {
+        if (! $this->property instanceof WebProperty) {
+            session()->flash('error', 'Property not found.');
+
+            return;
+        }
+
+        $this->authorizePropertyMutation();
+
+        $normalizedHost = $this->normalizeCanonicalOriginHost($this->linkedSubdomainHost);
+        $productionUrlHost = parse_url((string) $this->property->production_url, PHP_URL_HOST);
+        $allowedParentHosts = collect([
+            $this->normalizeCanonicalOriginHost($this->property->canonical_origin_host),
+            $this->normalizeCanonicalOriginHost($this->property->primaryDomainName()),
+            $this->normalizeCanonicalOriginHost(is_string($productionUrlHost) ? $productionUrlHost : null),
+        ])
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->values()
+            ->all();
+
+        $this->resetValidation();
+
+        $validated = Validator::make(
+            [
+                'linkedSubdomainHost' => $normalizedHost,
+                'linkedSubdomainNotes' => is_string($this->linkedSubdomainNotes) ? trim($this->linkedSubdomainNotes) : null,
+            ],
+            [
+                'linkedSubdomainHost' => ['required', 'string', 'max:255', 'regex:/^(?=.{1,255}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)(?:\\.([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?))*$/i'],
+                'linkedSubdomainNotes' => ['nullable', 'string', 'max:1000'],
+            ],
+            [
+                'linkedSubdomainHost.required' => 'Owned subdomain host is required.',
+                'linkedSubdomainHost.regex' => 'Owned subdomain host must be a valid hostname.',
+            ]
+        )->after(function ($validator) use ($normalizedHost, $allowedParentHosts): void {
+            if ($normalizedHost === null) {
+                return;
+            }
+
+            if (! collect($allowedParentHosts)->contains(
+                fn (string $parentHost): bool => str_ends_with($normalizedHost, '.'.$parentHost)
+            )) {
+                $validator->errors()->add(
+                    'linkedSubdomainHost',
+                    'Owned subdomain host must be a strict subdomain of this property’s declared host surface.'
+                );
+            }
+        })->validate();
+
+        $domain = Domain::query()->firstOrCreate(
+            ['domain' => $validated['linkedSubdomainHost']],
+            [
+                'platform' => $this->property->platform,
+                'hosting_provider' => $this->property->primaryDomain?->hosting_provider,
+                'check_frequency_minutes' => 60,
+                'is_active' => true,
+            ]
+        );
+
+        WebPropertyDomain::query()->updateOrCreate(
+            [
+                'web_property_id' => $this->property->id,
+                'domain_id' => $domain->id,
+            ],
+            [
+                'usage_type' => 'subdomain',
+                'is_canonical' => false,
+                'notes' => $validated['linkedSubdomainNotes'] !== '' ? $validated['linkedSubdomainNotes'] : null,
+            ]
+        );
+
+        $this->loadProperty();
+
+        session()->flash('message', 'Owned subdomain linked successfully.');
     }
 
     public function refreshCurrentConversionLinks(PropertyConversionLinkScanner $scanner): void

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -347,6 +347,15 @@ class WebPropertyDetail extends Component
                 return;
             }
 
+            if ($allowedParentHosts === []) {
+                $validator->errors()->add(
+                    'linkedSubdomainHost',
+                    'This property does not yet have a declared host surface for owned subdomain linking.'
+                );
+
+                return;
+            }
+
             if (! collect($allowedParentHosts)->contains(
                 fn (string $parentHost): bool => str_ends_with($normalizedHost, '.'.$parentHost)
             )) {
@@ -367,17 +376,30 @@ class WebPropertyDetail extends Component
             ]
         );
 
-        WebPropertyDomain::query()->updateOrCreate(
-            [
+        $existingLink = WebPropertyDomain::query()
+            ->where('web_property_id', $this->property->id)
+            ->where('domain_id', $domain->id)
+            ->first();
+
+        if ($existingLink instanceof WebPropertyDomain) {
+            if ($existingLink->usage_type !== 'subdomain') {
+                $this->addError('linkedSubdomainHost', 'That hostname is already linked to this property with a different usage type.');
+
+                return;
+            }
+
+            $existingLink->update([
+                'notes' => $validated['linkedSubdomainNotes'],
+            ]);
+        } else {
+            WebPropertyDomain::query()->create([
                 'web_property_id' => $this->property->id,
                 'domain_id' => $domain->id,
-            ],
-            [
                 'usage_type' => 'subdomain',
                 'is_canonical' => false,
-                'notes' => $validated['linkedSubdomainNotes'] !== '' ? $validated['linkedSubdomainNotes'] : null,
-            ]
-        );
+                'notes' => $validated['linkedSubdomainNotes'],
+            ]);
+        }
 
         $this->loadProperty();
 

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -366,15 +366,32 @@ class WebPropertyDetail extends Component
             }
         })->validate();
 
-        $domain = Domain::query()->firstOrCreate(
-            ['domain' => $validated['linkedSubdomainHost']],
-            [
+        $domain = Domain::withTrashed()->firstWhere('domain', $validated['linkedSubdomainHost']);
+
+        if (! $domain instanceof Domain) {
+            $domain = Domain::query()->create([
+                'domain' => $validated['linkedSubdomainHost'],
                 'platform' => $this->property->platform,
                 'hosting_provider' => $this->property->primaryDomain?->hosting_provider,
                 'check_frequency_minutes' => 60,
                 'is_active' => true,
-            ]
-        );
+            ]);
+        } else {
+            $domain->fill([
+                'platform' => $domain->platform ?? $this->property->platform,
+                'hosting_provider' => $domain->hosting_provider ?? $this->property->primaryDomain?->hosting_provider,
+                'check_frequency_minutes' => $domain->check_frequency_minutes ?: 60,
+                'is_active' => true,
+            ]);
+
+            if ($domain->trashed()) {
+                $domain->restore();
+            }
+
+            if ($domain->isDirty()) {
+                $domain->save();
+            }
+        }
 
         $existingLink = WebPropertyDomain::query()
             ->where('web_property_id', $this->property->id)

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -608,6 +608,39 @@
                     <span class="text-sm text-gray-500 dark:text-gray-400">{{ $domains->count() }} linked</span>
                 </div>
 
+                <div class="mt-6 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+                    <h5 class="text-sm font-semibold text-gray-900 dark:text-gray-100">Add Owned Subdomain</h5>
+                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                        Link a real subdomain surface to this property so it appears under owned subdomains and can be safely excluded from apex normalization when needed.
+                    </p>
+
+                    <div class="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1fr),minmax(0,1fr),auto]">
+                        <div>
+                            <label for="linked_subdomain_host" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Subdomain Host</label>
+                            <input id="linked_subdomain_host" type="text" wire:model="linkedSubdomainHost" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="quoting.backloading-au.com.au" />
+                            @error('linkedSubdomainHost') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                        </div>
+
+                        <div>
+                            <label for="linked_subdomain_notes" class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Notes</label>
+                            <input id="linked_subdomain_notes" type="text" wire:model="linkedSubdomainNotes" class="mt-1 block w-full rounded-md border-gray-300 text-sm shadow-xs focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100" placeholder="Separate quoting surface" />
+                            @error('linkedSubdomainNotes') <div class="mt-1 text-xs text-red-600 dark:text-red-400">{{ $message }}</div> @enderror
+                        </div>
+
+                        <div class="flex items-end">
+                            <button
+                                type="button"
+                                wire:click="saveLinkedSubdomain"
+                                wire:loading.attr="disabled"
+                                wire:target="saveLinkedSubdomain"
+                                class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                Add Owned Subdomain
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="mt-6 overflow-x-auto">
                     <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                         <thead class="bg-gray-50 dark:bg-gray-700/50">

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -318,4 +318,70 @@ class WebPropertyCanonicalOriginTest extends TestCase
             'usage_type' => 'subdomain',
         ]);
     }
+
+    public function test_property_detail_rejects_linking_when_hostname_is_already_attached_with_a_different_usage(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $existingSubdomain = Domain::factory()->create([
+            'domain' => 'quoting.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $existingSubdomain->id,
+            'usage_type' => 'alias',
+            'is_canonical' => false,
+            'notes' => 'Existing alias mapping',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('linkedSubdomainHost', 'quoting.movingagain.com.au')
+            ->call('saveLinkedSubdomain')
+            ->assertHasErrors(['linkedSubdomainHost']);
+
+        $this->assertDatabaseHas('web_property_domains', [
+            'web_property_id' => $property->id,
+            'domain_id' => $existingSubdomain->id,
+            'usage_type' => 'alias',
+            'notes' => 'Existing alias mapping',
+        ]);
+    }
+
+    public function test_property_detail_rejects_linking_without_a_declared_host_surface(): void
+    {
+        $user = User::factory()->create();
+        $property = WebProperty::factory()->create([
+            'slug' => 'hostless-site',
+            'name' => 'Hostless Site',
+            'primary_domain_id' => null,
+            'production_url' => null,
+            'canonical_origin_host' => null,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'hostless-site'])
+            ->set('linkedSubdomainHost', 'quoting.hostless-site.example.com')
+            ->call('saveLinkedSubdomain')
+            ->assertHasErrors(['linkedSubdomainHost']);
+    }
 }

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -319,6 +319,55 @@ class WebPropertyCanonicalOriginTest extends TestCase
         ]);
     }
 
+    public function test_property_detail_restores_soft_deleted_domain_when_linking_owned_subdomain(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $deletedSubdomain = Domain::factory()->create([
+            'domain' => 'quoting.movingagain.com.au',
+            'is_active' => false,
+        ]);
+        $deletedSubdomain->delete();
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('linkedSubdomainHost', 'quoting.movingagain.com.au')
+            ->set('linkedSubdomainNotes', 'Restored quoting surface')
+            ->call('saveLinkedSubdomain')
+            ->assertHasNoErrors();
+
+        $restoredSubdomain = Domain::withTrashed()->where('domain', 'quoting.movingagain.com.au')->first();
+
+        $this->assertNotNull($restoredSubdomain);
+        $this->assertNull($restoredSubdomain->deleted_at);
+        $this->assertTrue($restoredSubdomain->is_active);
+        $this->assertSame($deletedSubdomain->id, $restoredSubdomain->id);
+        $this->assertSame(1, Domain::withTrashed()->where('domain', 'quoting.movingagain.com.au')->count());
+        $this->assertDatabaseHas('web_property_domains', [
+            'web_property_id' => $property->id,
+            'domain_id' => $deletedSubdomain->id,
+            'usage_type' => 'subdomain',
+            'notes' => 'Restored quoting surface',
+        ]);
+    }
+
     public function test_property_detail_rejects_linking_when_hostname_is_already_attached_with_a_different_usage(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -203,4 +203,119 @@ class WebPropertyCanonicalOriginTest extends TestCase
         $this->assertNull($property->canonical_origin_host);
         $this->assertNull($property->canonical_origin_excluded_subdomains);
     }
+
+    public function test_property_detail_can_link_an_owned_subdomain(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('linkedSubdomainHost', 'quoting.movingagain.com.au')
+            ->set('linkedSubdomainNotes', 'Separate quoting surface')
+            ->call('saveLinkedSubdomain')
+            ->assertHasNoErrors()
+            ->assertSee('quoting.movingagain.com.au');
+
+        $linkedDomain = Domain::query()->where('domain', 'quoting.movingagain.com.au')->first();
+
+        $this->assertNotNull($linkedDomain);
+        $this->assertDatabaseHas('web_property_domains', [
+            'web_property_id' => $property->id,
+            'domain_id' => $linkedDomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+            'notes' => 'Separate quoting surface',
+        ]);
+    }
+
+    public function test_property_detail_rejects_owned_subdomain_outside_property_surface(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('linkedSubdomainHost', 'quoting.otherbrand.com.au')
+            ->call('saveLinkedSubdomain')
+            ->assertHasErrors(['linkedSubdomainHost']);
+
+        $this->assertDatabaseMissing('domains', [
+            'domain' => 'quoting.otherbrand.com.au',
+        ]);
+    }
+
+    public function test_property_detail_reuses_existing_domain_when_linking_owned_subdomain(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $existingSubdomain = Domain::factory()->create([
+            'domain' => 'quoting.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->set('linkedSubdomainHost', 'quoting.movingagain.com.au')
+            ->call('saveLinkedSubdomain')
+            ->assertHasNoErrors();
+
+        $this->assertSame(1, Domain::query()->where('domain', 'quoting.movingagain.com.au')->count());
+        $this->assertDatabaseHas('web_property_domains', [
+            'web_property_id' => $property->id,
+            'domain_id' => $existingSubdomain->id,
+            'usage_type' => 'subdomain',
+        ]);
+    }
 }

--- a/tests/Feature/WebPropertyUiTest.php
+++ b/tests/Feature/WebPropertyUiTest.php
@@ -151,6 +151,7 @@ class WebPropertyUiTest extends TestCase
         $response->assertSee('Save Canonical Policy');
         $response->assertSee('property_only');
         $response->assertSee('cartransport.movingagain.com.au');
+        $response->assertSee('Add Owned Subdomain');
         $response->assertSee('Automation Checklist');
         $response->assertSee('Needs Matomo');
     }


### PR DESCRIPTION
## Summary
- add an owned-subdomain link action to the web property detail page
- create or reuse the underlying domain row and attach it to the property as a subdomain
- keep the flow safe by only accepting strict subdomains of the property's main host surface

## Verification
- php artisan test tests/Feature/WebPropertyCanonicalOriginTest.php tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Livewire/WebPropertyDetail.php tests/Feature/WebPropertyCanonicalOriginTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
