### PR TITLE
Fix domain subdomain management UI

### DIFF
--- a/app/Livewire/DomainDetail.php
+++ b/app/Livewire/DomainDetail.php
@@ -97,6 +97,9 @@ class DomainDetail extends Component
             'subdomains' => function ($query) {
                 $query->where('is_active', true)->orderBy('subdomain');
             },
+            'webProperties' => function ($query) {
+                $query->orderBy('name');
+            },
             'contacts' => function ($query) {
                 $query->latest('synced_at')->limit(4); // Get latest contacts (one per type)
             },

--- a/resources/views/livewire/domain-detail.blade.php
+++ b/resources/views/livewire/domain-detail.blade.php
@@ -219,6 +219,11 @@
         <!-- Subdomains -->
         <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
             <div class="p-6">
+                @php
+                    $ownedSubdomainProperty = $domain->webProperties
+                        ->sortByDesc(fn ($property) => (int) ($property->pivot?->is_canonical ?? false))
+                        ->first();
+                @endphp
                 <div class="flex justify-between items-center mb-4">
                     <div class="flex items-center gap-2 cursor-pointer" wire:click="$toggle('showSubdomains')">
                         <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Subdomains</h3>
@@ -248,6 +253,14 @@
                         @endif
                     </div>
                 </div>
+                @if($ownedSubdomainProperty)
+                    <div class="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-100">
+                        Owned subdomains for this domain’s property surface are managed from the web property page.
+                        <a href="{{ route('web-properties.show', $ownedSubdomainProperty->slug) }}#linked-domains" wire:navigate class="ml-1 font-semibold underline decoration-blue-400 underline-offset-2 hover:text-blue-700 dark:hover:text-blue-200">
+                            Manage Owned Subdomains
+                        </a>
+                    </div>
+                @endif
                 @if($showSubdomains)
                     @if($domain->subdomains && $domain->subdomains->count() > 0)
                     <div class="overflow-x-auto">
@@ -663,12 +676,14 @@
                         @endif
                     </p>
                 @endif
+                @endif
             </div>
         </div>
 
         @include('livewire.domain-detail.sections.email-security')
 
         @include('livewire.domain-detail.sections.analysis-panels')
+        @include('livewire.domain-detail.sections.modals')
     @else
         <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
             <div class="p-6 text-center">
@@ -678,8 +693,5 @@
                 </a>
             </div>
         </div>
-    @endif
-
-    @include('livewire.domain-detail.sections.modals')
     @endif
 </div>

--- a/resources/views/livewire/domain-detail.blade.php
+++ b/resources/views/livewire/domain-detail.blade.php
@@ -256,7 +256,7 @@
                 @if($ownedSubdomainProperty)
                     <div class="mb-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-100">
                         Owned subdomains for this domain’s property surface are managed from the web property page.
-                        <a href="{{ route('web-properties.show', $ownedSubdomainProperty->slug) }}#linked-domains" wire:navigate class="ml-1 font-semibold underline decoration-blue-400 underline-offset-2 hover:text-blue-700 dark:hover:text-blue-200">
+                        <a href="{{ route('web-properties.show', $ownedSubdomainProperty->slug) }}#linked-domains" class="ml-1 font-semibold underline decoration-blue-400 underline-offset-2 hover:text-blue-700 dark:hover:text-blue-200">
                             Manage Owned Subdomains
                         </a>
                     </div>

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -59,7 +59,7 @@
             </a>
         </div>
 
-        <div id="linked-domains" class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
             <div class="p-6">
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
                     <div>
@@ -171,7 +171,7 @@
             </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+        <div id="linked-domains" class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
             <div class="p-6">
                 <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <div>

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -59,7 +59,7 @@
             </a>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
+        <div id="linked-domains" class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg mb-6">
             <div class="p-6">
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
                     <div>

--- a/tests/Feature/DomainDetailActionsTest.php
+++ b/tests/Feature/DomainDetailActionsTest.php
@@ -44,7 +44,7 @@ class DomainDetailActionsTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Manage Owned Subdomains');
-        $response->assertSee(route('web-properties.show', $property->slug), false);
+        $response->assertSee(route('web-properties.show', $property->slug).'#linked-domains', false);
     }
 
     public function test_opening_add_dns_record_modal_resets_the_form_state(): void

--- a/tests/Feature/DomainDetailActionsTest.php
+++ b/tests/Feature/DomainDetailActionsTest.php
@@ -7,6 +7,9 @@ use App\Models\DnsRecord;
 use App\Models\Domain;
 use App\Models\Subdomain;
 use App\Models\SynergyCredential;
+use App\Models\User;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
@@ -16,6 +19,33 @@ use Tests\TestCase;
 class DomainDetailActionsTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_domain_detail_links_to_owned_subdomain_management_on_web_property_page(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'backloading-au.com.au',
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloading-au-com-au',
+            'name' => 'Backloading AU',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://backloading-au.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('domains.show', $domain->id));
+
+        $response->assertOk();
+        $response->assertSee('Manage Owned Subdomains');
+        $response->assertSee(route('web-properties.show', $property->slug), false);
+    }
 
     public function test_opening_add_dns_record_modal_resets_the_form_state(): void
     {


### PR DESCRIPTION
## Summary
- fix the domain detail Blade structure so subdomain edit and add actions stop breaking Livewire morphing
- add a direct Manage Owned Subdomains link from the domain detail page to the linked web property
- add a linked-domains anchor on the web property page and cover the domain-page link in tests

## Testing
- php artisan test tests/Feature/DomainDetailActionsTest.php tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Livewire/DomainDetail.php tests/Feature/DomainDetailActionsTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
