### PR TITLE
Suggest likely owned subdomains in linked domains

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -618,7 +618,6 @@ class WebPropertyDetail extends Component
                     'resolves' => 0,
                     'unchecked' => 1,
                     'unresolved' => 2,
-                    'not_applicable' => 3,
                 ];
 
                 $leftPriority = $priority[$left['resolution_state']] ?? 9;

--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -3,6 +3,7 @@
 namespace App\Livewire;
 
 use App\Models\Domain;
+use App\Models\Subdomain;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use App\Services\PropertyConversionLinkScanner;
@@ -59,6 +60,11 @@ class WebPropertyDetail extends Component
 
     public ?string $linkedSubdomainNotes = null;
 
+    /**
+     * @var array<int, array{host: string, resolution_label: string, resolution_state: string, source_domain: string}>
+     */
+    public array $suggestedOwnedSubdomains = [];
+
     public function mount(): void
     {
         $this->loadProperty();
@@ -78,6 +84,9 @@ class WebPropertyDetail extends Component
                         ->with([
                             'platform',
                             'tags',
+                            'subdomains' => fn ($subdomainQuery) => $subdomainQuery
+                                ->where('is_active', true)
+                                ->orderBy('full_domain'),
                             'deployments.domain',
                             'alerts' => fn ($alertQuery) => $alertQuery->whereNull('resolved_at'),
                         ]);
@@ -107,6 +116,7 @@ class WebPropertyDetail extends Component
         $this->canonicalOriginSitemapPolicyKnown = (bool) $this->property->canonical_origin_sitemap_policy_known;
         $this->linkedSubdomainHost = null;
         $this->linkedSubdomainNotes = null;
+        $this->suggestedOwnedSubdomains = $this->buildSuggestedOwnedSubdomains();
     }
 
     public function importIssueDetail(SearchConsoleIssueSnapshotImporter $importer): void
@@ -423,6 +433,11 @@ class WebPropertyDetail extends Component
         session()->flash('message', 'Owned subdomain linked successfully.');
     }
 
+    public function useSuggestedOwnedSubdomain(string $host): void
+    {
+        $this->linkedSubdomainHost = $this->normalizeCanonicalOriginHost($host);
+    }
+
     public function refreshCurrentConversionLinks(PropertyConversionLinkScanner $scanner): void
     {
         if (! $this->property instanceof WebProperty) {
@@ -555,5 +570,67 @@ class WebPropertyDetail extends Component
             in_array(mb_strtolower((string) $user->email), $allowedEmails, true),
             403
         );
+    }
+
+    /**
+     * @return array<int, array{host: string, resolution_label: string, resolution_state: string, source_domain: string}>
+     */
+    private function buildSuggestedOwnedSubdomains(): array
+    {
+        if (! $this->property instanceof WebProperty) {
+            return [];
+        }
+
+        $linkedHosts = $this->property->propertyDomains
+            ->map(fn (WebPropertyDomain $link): ?string => $this->normalizeCanonicalOriginHost($link->domain?->domain))
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->values();
+
+        return $this->property->propertyDomains
+            ->filter(fn (WebPropertyDomain $link): bool => $link->usage_type !== 'subdomain')
+            ->flatMap(function (WebPropertyDomain $link) use ($linkedHosts) {
+                $sourceDomain = $link->domain?->domain;
+
+                if (! is_string($sourceDomain) || $sourceDomain === '') {
+                    return [];
+                }
+
+                return $link->domain->subdomains
+                    ->filter(function (Subdomain $subdomain) use ($linkedHosts): bool {
+                        if (! $subdomain->expectsIpResolution()) {
+                            return false;
+                        }
+
+                        return ! $linkedHosts->contains(
+                            $this->normalizeCanonicalOriginHost($subdomain->full_domain)
+                        );
+                    })
+                    ->map(fn (Subdomain $subdomain): array => [
+                        'host' => $subdomain->full_domain,
+                        'resolution_label' => $subdomain->resolutionLabel(),
+                        'resolution_state' => $subdomain->resolutionState(),
+                        'source_domain' => $sourceDomain,
+                    ]);
+            })
+            ->unique('host')
+            ->sort(function (array $left, array $right): int {
+                $priority = [
+                    'resolves' => 0,
+                    'unchecked' => 1,
+                    'unresolved' => 2,
+                    'not_applicable' => 3,
+                ];
+
+                $leftPriority = $priority[$left['resolution_state']] ?? 9;
+                $rightPriority = $priority[$right['resolution_state']] ?? 9;
+
+                if ($leftPriority !== $rightPriority) {
+                    return $leftPriority <=> $rightPriority;
+                }
+
+                return strcmp($left['host'], $right['host']);
+            })
+            ->values()
+            ->all();
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,9 +2374,9 @@
             "license": "0BSD"
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -639,6 +639,58 @@
                             </button>
                         </div>
                     </div>
+
+                    <div class="mt-5 border-t border-gray-200 pt-4 dark:border-gray-700">
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <h6 class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Suggested Owned Subdomains</h6>
+                                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                    Likely web surfaces discovered under this property’s linked domains. Mail, auth, and service-only DNS records are excluded.
+                                </p>
+                            </div>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">{{ count($suggestedOwnedSubdomains) }} suggested</span>
+                        </div>
+
+                        @if($suggestedOwnedSubdomains === [])
+                            <p class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                                No likely web subdomains have been discovered yet.
+                            </p>
+                        @else
+                            <div class="mt-3 space-y-2">
+                                @foreach($suggestedOwnedSubdomains as $suggestion)
+                                    <div class="flex flex-col gap-3 rounded-lg border border-gray-200 px-3 py-3 dark:border-gray-700 md:flex-row md:items-center md:justify-between">
+                                        <div class="min-w-0">
+                                            <div class="flex flex-wrap items-center gap-2">
+                                                <span class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $suggestion['host'] }}</span>
+                                                <span @class([
+                                                    'inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium',
+                                                    'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' => $suggestion['resolution_state'] === 'resolves',
+                                                    'bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300' => $suggestion['resolution_state'] === 'unchecked',
+                                                    'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300' => $suggestion['resolution_state'] === 'unresolved',
+                                                    'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300' => ! in_array($suggestion['resolution_state'], ['resolves', 'unchecked', 'unresolved'], true),
+                                                ])>
+                                                    {{ $suggestion['resolution_label'] }}
+                                                </span>
+                                            </div>
+                                            <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                                Discovered under {{ $suggestion['source_domain'] }}
+                                            </div>
+                                        </div>
+
+                                        <div class="flex items-center md:justify-end">
+                                            <button
+                                                type="button"
+                                                wire:click="useSuggestedOwnedSubdomain('{{ $suggestion['host'] }}')"
+                                                class="inline-flex items-center justify-center rounded-md border border-blue-200 px-3 py-1.5 text-sm font-medium text-blue-700 hover:bg-blue-50 dark:border-blue-800 dark:text-blue-300 dark:hover:bg-blue-900/20"
+                                            >
+                                                Use Suggestion
+                                            </button>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
                 </div>
 
                 <div class="mt-6 overflow-x-auto">

--- a/tests/Feature/WebPropertyCanonicalOriginTest.php
+++ b/tests/Feature/WebPropertyCanonicalOriginTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Livewire\WebPropertyDetail;
 use App\Models\Domain;
+use App\Models\Subdomain;
 use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
@@ -432,5 +433,133 @@ class WebPropertyCanonicalOriginTest extends TestCase
             ->set('linkedSubdomainHost', 'quoting.hostless-site.example.com')
             ->call('saveLinkedSubdomain')
             ->assertHasErrors(['linkedSubdomainHost']);
+    }
+
+    public function test_property_detail_suggests_likely_owned_web_subdomains_and_filters_dns_noise(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'backloadingremovals.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloadingremovals-com-au',
+            'name' => 'Backloading Removals',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://backloadingremovals.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 'removalist',
+            'full_domain' => 'removalist.backloadingremovals.com.au',
+            'ip_address' => '170.64.144.64',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 'mymovehub',
+            'full_domain' => 'mymovehub.backloadingremovals.com.au',
+            'ip_address' => '170.64.144.64',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 'em2057',
+            'full_domain' => 'em2057.backloadingremovals.com.au',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 's1._domainkey',
+            'full_domain' => 's1._domainkey.backloadingremovals.com.au',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'backloadingremovals-com-au'])
+            ->assertSee('Suggested Owned Subdomains')
+            ->assertSee('removalist.backloadingremovals.com.au')
+            ->assertSee('mymovehub.backloadingremovals.com.au')
+            ->assertDontSee('em2057.backloadingremovals.com.au')
+            ->assertDontSee('s1._domainkey.backloadingremovals.com.au')
+            ->call('useSuggestedOwnedSubdomain', 'removalist.backloadingremovals.com.au')
+            ->assertSet('linkedSubdomainHost', 'removalist.backloadingremovals.com.au');
+    }
+
+    public function test_property_detail_does_not_resuggest_already_linked_owned_subdomains(): void
+    {
+        $user = User::factory()->create();
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+        $existingSubdomain = Domain::factory()->create([
+            'domain' => 'quoting.movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-site',
+            'name' => 'Moving Again',
+            'primary_domain_id' => $primaryDomain->id,
+            'production_url' => 'https://movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $existingSubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 'quoting',
+            'full_domain' => 'quoting.movingagain.com.au',
+            'ip_address' => '170.64.144.64',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $primaryDomain->id,
+            'subdomain' => 'vehicles',
+            'full_domain' => 'vehicles.movingagain.com.au',
+            'ip_address' => '170.64.144.64',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-site'])
+            ->assertSee('vehicles.movingagain.com.au');
+
+        $this->assertSame(
+            ['vehicles.movingagain.com.au'],
+            array_column($component->instance()->suggestedOwnedSubdomains, 'host')
+        );
     }
 }


### PR DESCRIPTION
## Summary
- surface suggested owned subdomains in the Linked Domains card using discovered web subdomains from the property's linked domains
- filter out mail/auth/service-only DNS noise and hide suggestions for hosts already linked to the property
- add focused feature coverage for suggestion visibility and reuse behavior

## Testing
- php artisan test tests/Feature/WebPropertyCanonicalOriginTest.php
- php artisan test tests/Feature/WebPropertyUiTest.php
- ./vendor/bin/phpstan analyse app/Livewire/WebPropertyDetail.php tests/Feature/WebPropertyCanonicalOriginTest.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
