### PR TITLE
Prune resolved subdomain 404 examples on managed hosts

### DIFF
--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services;
 
+use App\Models\Domain;
 use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\Subdomain;
 use App\Models\WebProperty;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -20,6 +22,11 @@ class SearchConsoleIssueLiveRecheckService
     private const URL_LIMIT = 10;
 
     private const TOTAL_BUDGET_SECONDS = 20;
+
+    /**
+     * @var array<string, bool>
+     */
+    private array $managedHostCache = [];
 
     /**
      * @return array{status:'refreshed'|'skipped'|'failed',captured_at:string|null,checked_url_count:int,reason:string|null}
@@ -266,7 +273,7 @@ class SearchConsoleIssueLiveRecheckService
             return false;
         }
 
-        return in_array($host, $this->knownHosts($property), true)
+        return (in_array($host, $this->knownHosts($property), true) || $this->isManagedHost($host))
             && $this->hostResolvesPublicly($host);
     }
 
@@ -377,5 +384,29 @@ class SearchConsoleIssueLiveRecheckService
         }
 
         return array_values(array_unique($hosts));
+    }
+
+    private function isManagedHost(string $host): bool
+    {
+        if (array_key_exists($host, $this->managedHostCache)) {
+            return $this->managedHostCache[$host];
+        }
+
+        $domainExists = Domain::query()
+            ->where('domain', $host)
+            ->where('is_active', true)
+            ->exists();
+
+        if ($domainExists) {
+            return $this->managedHostCache[$host] = true;
+        }
+
+        $subdomain = Subdomain::query()
+            ->where('full_domain', $host)
+            ->where('is_active', true)
+            ->first();
+
+        return $this->managedHostCache[$host] = $subdomain instanceof Subdomain
+            && $subdomain->expectsIpResolution();
     }
 }

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -393,7 +393,7 @@ class SearchConsoleIssueLiveRecheckService
         }
 
         $domainExists = Domain::query()
-            ->where('domain', $host)
+            ->whereRaw('LOWER(domain) = ?', [$host])
             ->where('is_active', true)
             ->exists();
 
@@ -402,7 +402,7 @@ class SearchConsoleIssueLiveRecheckService
         }
 
         $subdomain = Subdomain::query()
-            ->where('full_domain', $host)
+            ->whereRaw('LOWER(full_domain) = ?', [$host])
             ->where('is_active', true)
             ->first();
 

--- a/tests/Feature/FleetPropertyContextRefreshTest.php
+++ b/tests/Feature/FleetPropertyContextRefreshTest.php
@@ -744,6 +744,126 @@ class FleetPropertyContextRefreshTest extends TestCase
         );
     }
 
+    public function test_refresh_rechecks_subdomain_property_examples_on_other_managed_hosts_and_hides_resolved_404_issue(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $targetProperty = $this->makeProperty('vehicles-backloadingremovals-site', 'vehicles.backloadingremovals.com.au');
+        $managedSiblingProperty = $this->makeProperty('removalist-backloadingremovals-site', 'removalist.backloadingremovals.com.au');
+
+        DomainSeoBaseline::create([
+            'domain_id' => $targetProperty->primary_domain_id,
+            'web_property_id' => $targetProperty->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '556',
+            'search_console_property_uri' => 'sc-domain:vehicles.backloadingremovals.com.au',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 1,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $targetProperty->primary_domain_id,
+            'web_property_id' => $targetProperty->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:vehicles.backloadingremovals.com.au',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://removalist.backloadingremovals.com.au/payments',
+            ],
+            'examples' => [
+                ['url' => 'https://removalist.backloadingremovals.com.au/payments', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://removalist.backloadingremovals.com.au/payments',
+                ],
+            ],
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => $this->skippedHealthResult($type));
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'fresh',
+                    'message' => null,
+                ]);
+        });
+
+        Http::fake([
+            'https://removalist.backloadingremovals.com.au/payments' => Http::response('', 302, [
+                'Location' => 'https://removalist.backloadingremovals.com.au/contact',
+            ]),
+            'https://removalist.backloadingremovals.com.au/contact' => Http::response('<html>Contact</html>', 200),
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/vehicles-backloadingremovals-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('refreshed.search_console_live_rechecks.status', 'refreshed')
+            ->assertJsonPath('refreshed.search_console_live_rechecks.checked_url_count', 1);
+
+        $liveRecheck = SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $targetProperty->id)
+            ->where('issue_class', 'not_found_404')
+            ->where('capture_method', 'gsc_live_recheck')
+            ->latest('captured_at')
+            ->first();
+
+        $this->assertNotNull($liveRecheck);
+        $this->assertSame(
+            'https://removalist.backloadingremovals.com.au/contact',
+            data_get($liveRecheck->issueEvidence(), 'live_url_checks.0.final_url')
+        );
+        $this->assertTrue((bool) data_get($liveRecheck->issueEvidence(), 'live_url_checks.0.resolved_ok'));
+
+        $issuesResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $issuesResponse->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.not_found_404');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $issuesResponse->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('property_slug', 'vehicles-backloadingremovals-site');
+
+        $this->assertNull($issue);
+        $this->assertSame('removalist-backloadingremovals-site', $managedSiblingProperty->slug);
+    }
+
     public function test_refresh_only_updates_the_requested_property_scope(): void
     {
         $targetProperty = $this->makeProperty('target-scope-site', 'target-scope.example.com');

--- a/tests/Feature/FleetPropertyContextRefreshTest.php
+++ b/tests/Feature/FleetPropertyContextRefreshTest.php
@@ -11,6 +11,7 @@ use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
 use App\Models\SearchConsoleCoverageStatus;
 use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\Subdomain;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use App\Services\DetectedIssueIdentityService;
@@ -750,7 +751,22 @@ class FleetPropertyContextRefreshTest extends TestCase
         config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
 
         $targetProperty = $this->makeProperty('vehicles-backloadingremovals-site', 'vehicles.backloadingremovals.com.au');
-        $managedSiblingProperty = $this->makeProperty('removalist-backloadingremovals-site', 'removalist.backloadingremovals.com.au');
+        $rootDomain = Domain::factory()->create([
+            'domain' => 'backloadingremovals.com.au',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'Vercel',
+        ]);
+
+        Subdomain::create([
+            'domain_id' => $rootDomain->id,
+            'subdomain' => 'Removalist',
+            'full_domain' => 'Removalist.BackloadingRemovals.com.au',
+            'ip_address' => '170.64.144.64',
+            'ip_checked_at' => now(),
+            'is_active' => true,
+        ]);
 
         DomainSeoBaseline::create([
             'domain_id' => $targetProperty->primary_domain_id,
@@ -861,7 +877,6 @@ class FleetPropertyContextRefreshTest extends TestCase
         $issue = collect($payloadIssues)->firstWhere('property_slug', 'vehicles-backloadingremovals-site');
 
         $this->assertNull($issue);
-        $this->assertSame('removalist-backloadingremovals-site', $managedSiblingProperty->slug);
     }
 
     public function test_refresh_only_updates_the_requested_property_scope(): void


### PR DESCRIPTION
## Summary
- allow Search Console live rechecks to probe other managed Domain Monitor hosts, not just the current property's linked hosts
- prune stale subdomain-property `not_found_404` rows when the example URL now resolves to a final `200` on another managed host
- add regression coverage for a subdomain property whose stale 404 example now resolves on a managed sibling subdomain

## Testing
- php artisan test tests/Feature/FleetPropertyContextRefreshTest.php
- php artisan test tests/Feature/FleetPropertyContextRefreshTest.php --filter=test_refresh_rechecks_subdomain_property_examples_on_other_managed_hosts_and_hides_resolved_404_issue
- php artisan test tests/Feature/DetectedIssueApiTest.php --filter='not_found_404|legacy_payment_404'
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueLiveRecheckService.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
