### PR TITLE
Stabilize conversion links API contract

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -626,33 +626,74 @@ class WebProperty extends Model
     public function conversionLinkSummary(): array
     {
         return [
-            'current' => [
-                'household_quote' => $this->current_household_quote_url,
-                'household_booking' => $this->current_household_booking_url,
-                'vehicle_quote' => $this->current_vehicle_quote_url,
-                'vehicle_booking' => $this->current_vehicle_booking_url,
-            ],
-            'target' => [
-                'household_quote' => $this->target_household_quote_url,
-                'household_booking' => $this->target_household_booking_url,
-                'vehicle_quote' => $this->target_vehicle_quote_url,
-                'vehicle_booking' => $this->target_vehicle_booking_url,
-                'moveroo_subdomain' => $this->target_moveroo_subdomain_url,
-                'contact_us_page' => $this->target_contact_us_page_url,
-                'legacy_bookings_replacement' => $this->target_legacy_bookings_replacement_url,
-                'legacy_payments_replacement' => $this->target_legacy_payments_replacement_url,
-            ],
-            'legacy_endpoints' => [
-                'legacy_booking_endpoint' => $this->legacyMoverooEndpointSummary(
-                    'legacy_booking_endpoint',
-                    $this->target_legacy_bookings_replacement_url,
-                ),
-                'legacy_payment_endpoint' => $this->legacyMoverooEndpointSummary(
-                    'legacy_payment_endpoint',
-                    $this->target_legacy_payments_replacement_url,
-                ),
-            ],
+            'current' => $this->currentConversionLinkSummary(),
+            'target' => $this->targetConversionLinkSummary(),
+            'legacy_endpoints' => $this->legacyEndpointConversionLinkSummary(),
             'scanned_at' => $this->conversion_links_scanned_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   household_quote: string|null,
+     *   household_booking: string|null,
+     *   vehicle_quote: string|null,
+     *   vehicle_booking: string|null
+     * }
+     */
+    private function currentConversionLinkSummary(): array
+    {
+        return [
+            'household_quote' => $this->current_household_quote_url,
+            'household_booking' => $this->current_household_booking_url,
+            'vehicle_quote' => $this->current_vehicle_quote_url,
+            'vehicle_booking' => $this->current_vehicle_booking_url,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   household_quote: string|null,
+     *   household_booking: string|null,
+     *   vehicle_quote: string|null,
+     *   vehicle_booking: string|null,
+     *   moveroo_subdomain: string|null,
+     *   contact_us_page: string|null,
+     *   legacy_bookings_replacement: string|null,
+     *   legacy_payments_replacement: string|null
+     * }
+     */
+    private function targetConversionLinkSummary(): array
+    {
+        return [
+            'household_quote' => $this->target_household_quote_url,
+            'household_booking' => $this->target_household_booking_url,
+            'vehicle_quote' => $this->target_vehicle_quote_url,
+            'vehicle_booking' => $this->target_vehicle_booking_url,
+            'moveroo_subdomain' => $this->target_moveroo_subdomain_url,
+            'contact_us_page' => $this->target_contact_us_page_url,
+            'legacy_bookings_replacement' => $this->target_legacy_bookings_replacement_url,
+            'legacy_payments_replacement' => $this->target_legacy_payments_replacement_url,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   legacy_booking_endpoint: array<string, mixed>|null,
+     *   legacy_payment_endpoint: array<string, mixed>|null
+     * }
+     */
+    private function legacyEndpointConversionLinkSummary(): array
+    {
+        return [
+            'legacy_booking_endpoint' => $this->legacyMoverooEndpointSummary(
+                'legacy_booking_endpoint',
+                $this->target_legacy_bookings_replacement_url,
+            ),
+            'legacy_payment_endpoint' => $this->legacyMoverooEndpointSummary(
+                'legacy_payment_endpoint',
+                $this->target_legacy_payments_replacement_url,
+            ),
         ];
     }
 

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -358,6 +358,145 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.0.slug', 'fleet-focus-site');
     }
 
+    public function test_property_apis_always_expose_fully_shaped_conversion_links_contract(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'stable-links.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'stable-links-site',
+            'name' => 'Stable Links Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'conversion_links_scanned_at' => null,
+            'current_household_quote_url' => null,
+            'current_household_booking_url' => null,
+            'current_vehicle_quote_url' => null,
+            'current_vehicle_booking_url' => null,
+            'target_household_quote_url' => null,
+            'target_household_booking_url' => null,
+            'target_vehicle_quote_url' => null,
+            'target_vehicle_booking_url' => null,
+            'target_moveroo_subdomain_url' => null,
+            'target_contact_us_page_url' => null,
+            'target_legacy_bookings_replacement_url' => null,
+            'target_legacy_payments_replacement_url' => null,
+            'legacy_moveroo_endpoint_scan' => null,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $headers = [
+            'Authorization' => 'Bearer test-api-key',
+        ];
+
+        $summaryResponse = $this->withHeaders($headers)->getJson('/api/web-properties-summary');
+
+        $summaryResponse
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.slug', 'stable-links-site')
+            ->assertJsonStructure([
+                'web_properties' => [[
+                    'conversion_links' => [
+                        'scanned_at',
+                        'current' => [
+                            'household_quote',
+                            'household_booking',
+                            'vehicle_quote',
+                            'vehicle_booking',
+                        ],
+                        'target' => [
+                            'household_quote',
+                            'household_booking',
+                            'vehicle_quote',
+                            'vehicle_booking',
+                            'moveroo_subdomain',
+                            'contact_us_page',
+                            'legacy_bookings_replacement',
+                            'legacy_payments_replacement',
+                        ],
+                        'legacy_endpoints' => [
+                            'legacy_booking_endpoint',
+                            'legacy_payment_endpoint',
+                        ],
+                    ],
+                ]],
+            ])
+            ->assertJsonPath('web_properties.0.conversion_links.scanned_at', null)
+            ->assertJsonPath('web_properties.0.conversion_links.current.household_quote', null)
+            ->assertJsonPath('web_properties.0.conversion_links.current.household_booking', null)
+            ->assertJsonPath('web_properties.0.conversion_links.current.vehicle_quote', null)
+            ->assertJsonPath('web_properties.0.conversion_links.current.vehicle_booking', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.household_quote', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.household_booking', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_quote', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_booking', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.moveroo_subdomain', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.contact_us_page', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.legacy_bookings_replacement', null)
+            ->assertJsonPath('web_properties.0.conversion_links.target.legacy_payments_replacement', null)
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_booking_endpoint', null)
+            ->assertJsonPath('web_properties.0.conversion_links.legacy_endpoints.legacy_payment_endpoint', null);
+
+        $detailResponse = $this->withHeaders($headers)->getJson('/api/web-properties/stable-links-site');
+
+        $detailResponse
+            ->assertOk()
+            ->assertJsonPath('data.slug', 'stable-links-site')
+            ->assertJsonStructure([
+                'data' => [
+                    'conversion_links' => [
+                        'scanned_at',
+                        'current' => [
+                            'household_quote',
+                            'household_booking',
+                            'vehicle_quote',
+                            'vehicle_booking',
+                        ],
+                        'target' => [
+                            'household_quote',
+                            'household_booking',
+                            'vehicle_quote',
+                            'vehicle_booking',
+                            'moveroo_subdomain',
+                            'contact_us_page',
+                            'legacy_bookings_replacement',
+                            'legacy_payments_replacement',
+                        ],
+                        'legacy_endpoints' => [
+                            'legacy_booking_endpoint',
+                            'legacy_payment_endpoint',
+                        ],
+                    ],
+                ],
+            ])
+            ->assertJsonPath('data.conversion_links.scanned_at', null)
+            ->assertJsonPath('data.conversion_links.current.household_quote', null)
+            ->assertJsonPath('data.conversion_links.current.household_booking', null)
+            ->assertJsonPath('data.conversion_links.current.vehicle_quote', null)
+            ->assertJsonPath('data.conversion_links.current.vehicle_booking', null)
+            ->assertJsonPath('data.conversion_links.target.household_quote', null)
+            ->assertJsonPath('data.conversion_links.target.household_booking', null)
+            ->assertJsonPath('data.conversion_links.target.vehicle_quote', null)
+            ->assertJsonPath('data.conversion_links.target.vehicle_booking', null)
+            ->assertJsonPath('data.conversion_links.target.moveroo_subdomain', null)
+            ->assertJsonPath('data.conversion_links.target.contact_us_page', null)
+            ->assertJsonPath('data.conversion_links.target.legacy_bookings_replacement', null)
+            ->assertJsonPath('data.conversion_links.target.legacy_payments_replacement', null)
+            ->assertJsonPath('data.conversion_links.legacy_endpoints.legacy_booking_endpoint', null)
+            ->assertJsonPath('data.conversion_links.legacy_endpoints.legacy_payment_endpoint', null);
+    }
+
     public function test_web_properties_summary_ignores_empty_fleet_focus_filter(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- make `conversion_links` use explicit stable current/target/legacy endpoint summary builders
- guarantee the full `conversion_links` key set is serialized even when every value is null
- add property summary and property detail API tests that lock the null-key contract in place

## Testing
- php artisan test tests/Feature/WebPropertyApiTest.php --filter=test_property_apis_always_expose_fully_shaped_conversion_links_contract
- php artisan test tests/Feature/WebPropertyApiTest.php --filter=test_web_properties_summary_returns_contract_v1_payload
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
