### PR TITLE
Recheck stale redirect sitemap issues against live sitemap

### DIFF
--- a/app/Models/SearchConsoleIssueSnapshot.php
+++ b/app/Models/SearchConsoleIssueSnapshot.php
@@ -172,6 +172,7 @@ class SearchConsoleIssueSnapshot extends Model
             'canonical_state' => is_array($normalizedPayload['canonical_state'] ?? null) ? $normalizedPayload['canonical_state'] : null,
             'search_analytics' => is_array($normalizedPayload['search_analytics'] ?? null) ? $normalizedPayload['search_analytics'] : null,
             'live_url_checks' => is_array($normalizedPayload['live_url_checks'] ?? null) ? $normalizedPayload['live_url_checks'] : null,
+            'live_sitemap_checks' => is_array($normalizedPayload['live_sitemap_checks'] ?? null) ? $normalizedPayload['live_sitemap_checks'] : null,
         ], static fn (mixed $value): bool => $value !== null && $value !== []);
     }
 

--- a/app/Services/SearchConsoleIssueActionabilityService.php
+++ b/app/Services/SearchConsoleIssueActionabilityService.php
@@ -17,9 +17,11 @@ class SearchConsoleIssueActionabilityService
      */
     public function normalize(WebProperty $property, string $issueClass, array $issueEvidence): array
     {
-        $normalizedEvidence = $issueClass === 'not_found_404'
-            ? $this->normalizeNotFound404Issue($property, $issueEvidence)
-            : $issueEvidence;
+        $normalizedEvidence = match ($issueClass) {
+            'not_found_404' => $this->normalizeNotFound404Issue($property, $issueEvidence),
+            'page_with_redirect_in_sitemap' => $this->normalizePageWithRedirectIssue($issueEvidence),
+            default => $issueEvidence,
+        };
 
         $expectedExclusion = $this->intentionalSearchConsoleExclusionService->classify(
             $property,
@@ -175,6 +177,59 @@ class SearchConsoleIssueActionabilityService
 
     /**
      * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>
+     */
+    private function normalizePageWithRedirectIssue(array $issueEvidence): array
+    {
+        $candidateUrls = $this->candidateUrls($issueEvidence);
+
+        if ($candidateUrls === []) {
+            return $issueEvidence;
+        }
+
+        $activeUrls = [];
+        $retiredUrls = [];
+
+        foreach ($candidateUrls as $url) {
+            $sitemapCheck = $this->liveSitemapCheckForUrl($issueEvidence, $url);
+
+            if ($sitemapCheck !== null && ($sitemapCheck['present_in_current_sitemap'] ?? null) === false) {
+                $retiredUrls[$url] = 'removed_from_current_sitemap';
+
+                continue;
+            }
+
+            $activeUrls[] = $url;
+        }
+
+        if ($activeUrls === $candidateUrls) {
+            return $issueEvidence;
+        }
+
+        if (! $this->issueEvidenceRepresentsCompleteSet($issueEvidence, $candidateUrls)) {
+            return $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+        }
+
+        $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls);
+
+        if ($activeUrls !== []) {
+            return $normalizedEvidence;
+        }
+
+        $matchedUrls = array_keys($retiredUrls);
+        $normalizedEvidence['expected_exclusion'] = [
+            'state' => 'resolved_or_retired_redirect_in_sitemap',
+            'code' => 'removed_from_current_sitemap',
+            'reason' => 'current_sitemap_no_longer_contains_historical_redirect_urls',
+            'matched_urls' => array_slice($matchedUrls, 0, 10),
+            'matched_url_count' => count($matchedUrls),
+        ];
+
+        return $normalizedEvidence;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
      * @return array<int, string>
      */
     private function candidateUrls(array $issueEvidence): array
@@ -308,6 +363,21 @@ class SearchConsoleIssueActionabilityService
     }
 
     /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<string, mixed>|null
+     */
+    private function liveSitemapCheckForUrl(array $issueEvidence, string $url): ?array
+    {
+        foreach ((array) ($issueEvidence['live_sitemap_checks'] ?? []) as $check) {
+            if (is_array($check) && is_string($check['url'] ?? null) && $check['url'] === $url) {
+                return $check;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param  array<string, mixed>  $liveCheck
      */
     private function isResolvedLiveUrlCheck(array $liveCheck): bool
@@ -425,6 +495,12 @@ class SearchConsoleIssueActionabilityService
         ));
         $issueEvidence['live_url_checks'] = array_values(array_filter(
             (array) ($issueEvidence['live_url_checks'] ?? []),
+            static fn (mixed $check): bool => is_array($check)
+                && is_string($check['url'] ?? null)
+                && isset($activeUrlMap[$check['url']])
+        ));
+        $issueEvidence['live_sitemap_checks'] = array_values(array_filter(
+            (array) ($issueEvidence['live_sitemap_checks'] ?? []),
             static fn (mixed $check): bool => is_array($check)
                 && is_string($check['url'] ?? null)
                 && isset($activeUrlMap[$check['url']])

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -334,6 +334,10 @@ class SearchConsoleIssueEvidenceService
                 $evidence['live_url_checks'] = $liveEvidence['live_url_checks'];
             }
 
+            if (array_key_exists('live_sitemap_checks', $liveEvidence)) {
+                $evidence['live_sitemap_checks'] = $liveEvidence['live_sitemap_checks'];
+            }
+
             if (is_string($liveEvidence['captured_at'] ?? null) && $liveEvidence['captured_at'] !== '') {
                 $evidence['live_captured_at'] = $liveEvidence['captured_at'];
             }

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -274,21 +274,26 @@ class SearchConsoleIssueLiveRecheckService
 
     /**
      * @param  array<int, string>  $candidateUrls
-     * @return array<int, array{url:string,checked_at:string,present_in_current_sitemap:bool,matched_sitemap:string|null}>|null
+     * @return array<int, array{url:string,checked_at:string,present_in_current_sitemap:bool|null,matched_sitemap:string|null}>|null
      */
     private function probeCurrentSitemapUrls(WebProperty $property, SearchConsoleIssueSnapshot $sourceSnapshot, array $candidateUrls): ?array
     {
         $candidateMap = [];
+        $uncheckableUrls = [];
 
         foreach ($candidateUrls as $url) {
             $normalizedUrl = $this->normalizeComparableUrl($url);
 
-            if ($normalizedUrl !== null) {
-                $candidateMap[$normalizedUrl] = $url;
+            if ($normalizedUrl === null) {
+                $uncheckableUrls[$url] = true;
+
+                continue;
             }
+
+            $candidateMap[$normalizedUrl] = $url;
         }
 
-        if ($candidateMap === []) {
+        if ($candidateMap === [] && $uncheckableUrls === []) {
             return null;
         }
 
@@ -356,7 +361,9 @@ class SearchConsoleIssueLiveRecheckService
             fn (string $url): array => [
                 'url' => $url,
                 'checked_at' => $checkedAt,
-                'present_in_current_sitemap' => array_key_exists($url, $foundUrls),
+                'present_in_current_sitemap' => isset($uncheckableUrls[$url])
+                    ? null
+                    : array_key_exists($url, $foundUrls),
                 'matched_sitemap' => $foundUrls[$url] ?? null,
             ],
             $candidateUrls

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -13,7 +13,13 @@ use Illuminate\Support\Str;
 
 class SearchConsoleIssueLiveRecheckService
 {
-    private const ISSUE_CLASS = 'not_found_404';
+    /**
+     * @var array<int, string>
+     */
+    private const ISSUE_CLASSES = [
+        'not_found_404',
+        'page_with_redirect_in_sitemap',
+    ];
 
     private const REDIRECT_LIMIT = 5;
 
@@ -22,6 +28,8 @@ class SearchConsoleIssueLiveRecheckService
     private const URL_LIMIT = 10;
 
     private const TOTAL_BUDGET_SECONDS = 20;
+
+    private const SITEMAP_FILE_LIMIT = 20;
 
     /**
      * @var array<string, bool>
@@ -35,107 +43,26 @@ class SearchConsoleIssueLiveRecheckService
     {
         $property->loadMissing(['primaryDomain', 'propertyDomains.domain']);
 
-        try {
-            $sourceSnapshot = $this->latestSourceSnapshot($property);
+        $primaryDomain = $property->primaryDomainModel();
 
-            if (! $sourceSnapshot instanceof SearchConsoleIssueSnapshot) {
-                return [
-                    'status' => 'skipped',
-                    'captured_at' => null,
-                    'checked_url_count' => 0,
-                    'reason' => 'missing',
-                ];
-            }
-
-            $candidateUrls = $this->candidateUrls($sourceSnapshot->issueEvidence());
-
-            if ($candidateUrls === []) {
-                return [
-                    'status' => 'skipped',
-                    'captured_at' => null,
-                    'checked_url_count' => 0,
-                    'reason' => 'missing',
-                ];
-            }
-
-            $primaryDomain = $property->primaryDomainModel();
-
-            if (! $primaryDomain instanceof \App\Models\Domain) {
-                return [
-                    'status' => 'skipped',
-                    'captured_at' => null,
-                    'checked_url_count' => 0,
-                    'reason' => 'missing',
-                ];
-            }
-
-            $checks = [];
-            $deadline = microtime(true) + self::TOTAL_BUDGET_SECONDS;
-
-            foreach ($candidateUrls as $url) {
-                if (microtime(true) >= $deadline) {
-                    break;
-                }
-
-                $checks[] = $this->probeUrl($property, $url);
-            }
-
-            $capturedAt = now();
-
-            DB::transaction(function () use ($property, $primaryDomain, $sourceSnapshot, $capturedAt, $capturedBy, $checks): void {
-                SearchConsoleIssueSnapshot::query()
-                    ->where('web_property_id', $property->id)
-                    ->where('issue_class', self::ISSUE_CLASS)
-                    ->where('capture_method', 'gsc_live_recheck')
-                    ->delete();
-
-                SearchConsoleIssueSnapshot::query()->create([
-                    'domain_id' => $primaryDomain->id,
-                    'web_property_id' => $property->id,
-                    'property_analytics_source_id' => null,
-                    'issue_class' => self::ISSUE_CLASS,
-                    'source_issue_label' => data_get(config('domain_monitor.search_console_issue_catalog.'.self::ISSUE_CLASS), 'label'),
-                    'capture_method' => 'gsc_live_recheck',
-                    'source_report' => 'search_console_live_http_recheck',
-                    'source_property' => $property->searchConsolePropertyUri(),
-                    'artifact_path' => null,
-                    'captured_at' => $capturedAt,
-                    'captured_by' => $capturedBy ?: 'fleet_context_refresh',
-                    'first_detected_at' => $sourceSnapshot->first_detected_at,
-                    'last_updated_at' => $sourceSnapshot->last_updated_at,
-                    'property_scope' => $sourceSnapshot->property_scope,
-                    'affected_url_count' => count($checks),
-                    'sample_urls' => array_slice(array_map(
-                        static fn (array $check): string => (string) $check['url'],
-                        $checks
-                    ), 0, 10),
-                    'examples' => $sourceSnapshot->examples,
-                    'chart_points' => null,
-                    'normalized_payload' => [
-                        'affected_urls' => array_map(
-                            static fn (array $check): string => (string) $check['url'],
-                            $checks
-                        ),
-                        'live_url_checks' => $checks,
-                    ],
-                    'raw_payload' => [
-                        'source_snapshot_id' => $sourceSnapshot->id,
-                        'live_url_checks' => $checks,
-                    ],
-                ]);
-            });
-
+        if (! $primaryDomain instanceof Domain) {
             return [
-                'status' => 'refreshed',
-                'captured_at' => $capturedAt->toIso8601String(),
-                'checked_url_count' => count($checks),
-                'reason' => null,
+                'status' => 'skipped',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'missing',
             ];
+        }
+
+        try {
+            $results = collect(self::ISSUE_CLASSES)
+                ->map(fn (string $issueClass): array => $this->refreshIssueClass($property, $primaryDomain, $issueClass, $capturedBy))
+                ->values();
         } catch (\Throwable $exception) {
             Log::warning('Search Console live URL recheck failed', [
                 'web_property_id' => $property->id,
                 'property_slug' => $property->slug,
-                'issue_class' => self::ISSUE_CLASS,
+                'issue_classes' => self::ISSUE_CLASSES,
                 'exception' => $exception->getMessage(),
             ]);
 
@@ -146,13 +73,153 @@ class SearchConsoleIssueLiveRecheckService
                 'reason' => 'live_recheck_failed',
             ];
         }
+
+        $refreshedResults = $results->where('status', 'refreshed')->values();
+
+        if ($refreshedResults->isNotEmpty()) {
+            return [
+                'status' => 'refreshed',
+                'captured_at' => $refreshedResults
+                    ->pluck('captured_at')
+                    ->filter(fn (mixed $capturedAt): bool => is_string($capturedAt) && $capturedAt !== '')
+                    ->sort()
+                    ->last(),
+                'checked_url_count' => (int) $refreshedResults->sum('checked_url_count'),
+                'reason' => null,
+            ];
+        }
+
+        if ($results->contains(fn (array $result): bool => $result['status'] === 'failed')) {
+            return [
+                'status' => 'failed',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'live_recheck_failed',
+            ];
+        }
+
+        return [
+            'status' => 'skipped',
+            'captured_at' => null,
+            'checked_url_count' => 0,
+            'reason' => 'missing',
+        ];
     }
 
-    private function latestSourceSnapshot(WebProperty $property): ?SearchConsoleIssueSnapshot
+    /**
+     * @return array{status:'refreshed'|'skipped'|'failed',captured_at:string|null,checked_url_count:int,reason:string|null}
+     */
+    private function refreshIssueClass(WebProperty $property, Domain $primaryDomain, string $issueClass, ?string $capturedBy): array
+    {
+        $sourceSnapshot = $this->latestSourceSnapshot($property, $issueClass);
+
+        if (! $sourceSnapshot instanceof SearchConsoleIssueSnapshot) {
+            return [
+                'status' => 'skipped',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'missing',
+            ];
+        }
+
+        $candidateUrls = $this->candidateUrls($sourceSnapshot->issueEvidence());
+
+        if ($candidateUrls === []) {
+            return [
+                'status' => 'skipped',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'missing',
+            ];
+        }
+
+        $checks = match ($issueClass) {
+            'not_found_404' => $this->probeLiveUrls($property, $candidateUrls),
+            'page_with_redirect_in_sitemap' => $this->probeCurrentSitemapUrls($property, $sourceSnapshot, $candidateUrls),
+            default => null,
+        };
+
+        if (! is_array($checks) || $checks === []) {
+            return [
+                'status' => 'skipped',
+                'captured_at' => null,
+                'checked_url_count' => 0,
+                'reason' => 'missing',
+            ];
+        }
+
+        $capturedAt = now();
+
+        DB::transaction(function () use ($property, $primaryDomain, $sourceSnapshot, $issueClass, $capturedAt, $capturedBy, $checks): void {
+            SearchConsoleIssueSnapshot::query()
+                ->where('web_property_id', $property->id)
+                ->where('issue_class', $issueClass)
+                ->where('capture_method', 'gsc_live_recheck')
+                ->delete();
+
+            $normalizedPayload = [
+                'affected_urls' => array_map(
+                    static fn (array $check): string => (string) $check['url'],
+                    $checks
+                ),
+            ];
+
+            $rawPayload = [
+                'source_snapshot_id' => $sourceSnapshot->id,
+            ];
+
+            if ($issueClass === 'not_found_404') {
+                $normalizedPayload['live_url_checks'] = $checks;
+                $rawPayload['live_url_checks'] = $checks;
+            }
+
+            if ($issueClass === 'page_with_redirect_in_sitemap') {
+                $normalizedPayload['live_sitemap_checks'] = $checks;
+                $rawPayload['live_sitemap_checks'] = $checks;
+            }
+
+            SearchConsoleIssueSnapshot::query()->create([
+                'domain_id' => $primaryDomain->id,
+                'web_property_id' => $property->id,
+                'property_analytics_source_id' => null,
+                'issue_class' => $issueClass,
+                'source_issue_label' => data_get(config('domain_monitor.search_console_issue_catalog.'.$issueClass), 'label'),
+                'capture_method' => 'gsc_live_recheck',
+                'source_report' => $issueClass === 'page_with_redirect_in_sitemap'
+                    ? 'search_console_live_sitemap_recheck'
+                    : 'search_console_live_http_recheck',
+                'source_property' => $property->searchConsolePropertyUri(),
+                'artifact_path' => null,
+                'captured_at' => $capturedAt,
+                'captured_by' => $capturedBy ?: 'fleet_context_refresh',
+                'first_detected_at' => $sourceSnapshot->first_detected_at,
+                'last_updated_at' => $sourceSnapshot->last_updated_at,
+                'property_scope' => $sourceSnapshot->property_scope,
+                'affected_url_count' => count($checks),
+                'sample_urls' => array_slice(array_map(
+                    static fn (array $check): string => (string) $check['url'],
+                    $checks
+                ), 0, 10),
+                'examples' => $sourceSnapshot->examples,
+                'chart_points' => null,
+                'normalized_payload' => $normalizedPayload,
+                'raw_payload' => $rawPayload,
+            ]);
+        });
+
+        return [
+            'status' => 'refreshed',
+            'captured_at' => $capturedAt->toIso8601String(),
+            'checked_url_count' => count($checks),
+            'reason' => null,
+        ];
+    }
+
+    private function latestSourceSnapshot(WebProperty $property, string $issueClass): ?SearchConsoleIssueSnapshot
     {
         return SearchConsoleIssueSnapshot::query()
             ->where('web_property_id', $property->id)
-            ->where('issue_class', self::ISSUE_CLASS)
+            ->where('issue_class', $issueClass)
             ->whereIn('capture_method', ['gsc_drilldown_zip', 'gsc_api', 'gsc_mcp_api'])
             ->orderByRaw("case when capture_method = 'gsc_drilldown_zip' then 0 else 1 end")
             ->orderByDesc('captured_at')
@@ -183,6 +250,235 @@ class SearchConsoleIssueLiveRecheckService
         }
 
         return array_slice(array_values(array_unique($urls)), 0, self::URL_LIMIT);
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     * @return array<int, array{url:string,checked_at:string,final_url:string|null,final_status:int|null,resolved_ok:bool,host_changed:bool|null}>
+     */
+    private function probeLiveUrls(WebProperty $property, array $candidateUrls): array
+    {
+        $checks = [];
+        $deadline = microtime(true) + self::TOTAL_BUDGET_SECONDS;
+
+        foreach ($candidateUrls as $url) {
+            if (microtime(true) >= $deadline) {
+                break;
+            }
+
+            $checks[] = $this->probeUrl($property, $url);
+        }
+
+        return $checks;
+    }
+
+    /**
+     * @param  array<int, string>  $candidateUrls
+     * @return array<int, array{url:string,checked_at:string,present_in_current_sitemap:bool,matched_sitemap:string|null}>|null
+     */
+    private function probeCurrentSitemapUrls(WebProperty $property, SearchConsoleIssueSnapshot $sourceSnapshot, array $candidateUrls): ?array
+    {
+        $candidateMap = [];
+
+        foreach ($candidateUrls as $url) {
+            $normalizedUrl = $this->normalizeComparableUrl($url);
+
+            if ($normalizedUrl !== null) {
+                $candidateMap[$normalizedUrl] = $url;
+            }
+        }
+
+        if ($candidateMap === []) {
+            return null;
+        }
+
+        $queue = $this->candidateSitemapUrls($property, $sourceSnapshot);
+
+        if ($queue === []) {
+            return null;
+        }
+
+        $foundUrls = [];
+        $visitedUrls = [];
+        $fetchedAnySitemap = false;
+
+        while ($queue !== [] && count($visitedUrls) < self::SITEMAP_FILE_LIMIT) {
+            $sitemapUrl = array_shift($queue);
+            $normalizedSitemapUrl = $this->normalizeComparableUrl($sitemapUrl);
+
+            if ($normalizedSitemapUrl === null || isset($visitedUrls[$normalizedSitemapUrl])) {
+                continue;
+            }
+
+            $visitedUrls[$normalizedSitemapUrl] = true;
+
+            $body = $this->fetchSitemapBody($property, $sitemapUrl);
+
+            if ($body === null) {
+                continue;
+            }
+
+            $fetchedAnySitemap = true;
+            $document = $this->parseSitemapDocument($body);
+
+            if ($document === null) {
+                continue;
+            }
+
+            foreach ($document['urls'] as $url) {
+                $normalizedUrl = $this->normalizeComparableUrl($url);
+
+                if ($normalizedUrl === null || ! isset($candidateMap[$normalizedUrl])) {
+                    continue;
+                }
+
+                $foundUrls[$candidateMap[$normalizedUrl]] = $sitemapUrl;
+            }
+
+            if (count($foundUrls) === count($candidateMap)) {
+                break;
+            }
+
+            foreach ($document['sitemaps'] as $childSitemapUrl) {
+                if ($this->isSafeSitemapUrl($property, $childSitemapUrl)) {
+                    $queue[] = $childSitemapUrl;
+                }
+            }
+        }
+
+        if (! $fetchedAnySitemap) {
+            return null;
+        }
+
+        $checkedAt = now()->toIso8601String();
+
+        return array_map(
+            fn (string $url): array => [
+                'url' => $url,
+                'checked_at' => $checkedAt,
+                'present_in_current_sitemap' => array_key_exists($url, $foundUrls),
+                'matched_sitemap' => $foundUrls[$url] ?? null,
+            ],
+            $candidateUrls
+        );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function candidateSitemapUrls(WebProperty $property, SearchConsoleIssueSnapshot $sourceSnapshot): array
+    {
+        $urls = [];
+        $sourceEvidence = $sourceSnapshot->issueEvidence();
+
+        foreach ((array) ($sourceEvidence['sitemaps'] ?? []) as $sitemap) {
+            $path = is_array($sitemap) ? ($sitemap['path'] ?? null) : null;
+
+            if (is_string($path) && $path !== '' && $this->isSafeSitemapUrl($property, $path)) {
+                $urls[] = $path;
+            }
+        }
+
+        $baseUrl = $this->propertyBaseUrl($property);
+
+        if ($baseUrl !== null) {
+            foreach (['/sitemap.xml', '/sitemap_index.xml', '/sitemaps.xml'] as $path) {
+                $urls[] = $baseUrl.$path;
+            }
+        }
+
+        return array_values(array_unique($urls));
+    }
+
+    private function propertyBaseUrl(WebProperty $property): ?string
+    {
+        $scheme = is_string($property->canonical_origin_scheme) && $property->canonical_origin_scheme !== ''
+            ? Str::lower($property->canonical_origin_scheme)
+            : null;
+        $host = is_string($property->canonical_origin_host) && $property->canonical_origin_host !== ''
+            ? Str::lower($property->canonical_origin_host)
+            : null;
+
+        if ($scheme !== null && $host !== null) {
+            return $scheme.'://'.$host;
+        }
+
+        $productionUrl = is_string($property->production_url) && $property->production_url !== ''
+            ? $property->production_url
+            : null;
+
+        if ($productionUrl !== null) {
+            $productionParts = parse_url($productionUrl);
+
+            if (is_array($productionParts) && isset($productionParts['scheme'], $productionParts['host'])) {
+                return Str::lower((string) $productionParts['scheme']).'://'.Str::lower((string) $productionParts['host']);
+            }
+        }
+
+        $primaryDomain = $property->primaryDomainModel();
+
+        if ($primaryDomain instanceof Domain && $primaryDomain->domain !== '') {
+            return 'https://'.Str::lower($primaryDomain->domain);
+        }
+
+        return null;
+    }
+
+    private function fetchSitemapBody(WebProperty $property, string $url): ?string
+    {
+        if (! $this->isSafeSitemapUrl($property, $url)) {
+            return null;
+        }
+
+        try {
+            $response = Http::timeout(self::TIMEOUT_SECONDS)
+                ->withHeaders([
+                    'Accept' => 'application/xml,text/xml,text/plain,*/*',
+                    'User-Agent' => 'DomainMonitorSearchConsoleRecheck/1.0 (+https://monitor.again.com.au)',
+                ])
+                ->get($url);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        $body = $response->body();
+
+        return trim($body) !== '' ? $body : null;
+    }
+
+    /**
+     * @return array{urls: array<int, string>, sitemaps: array<int, string>}|null
+     */
+    private function parseSitemapDocument(string $body): ?array
+    {
+        $previousInternalErrors = libxml_use_internal_errors(true);
+        $document = simplexml_load_string($body);
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousInternalErrors);
+
+        if (! $document instanceof \SimpleXMLElement) {
+            return null;
+        }
+
+        $urlNodes = $document->xpath('//*[local-name()="url"]/*[local-name()="loc"]');
+        $sitemapNodes = $document->xpath('//*[local-name()="sitemap"]/*[local-name()="loc"]');
+
+        return [
+            'urls' => collect(is_array($urlNodes) ? $urlNodes : [])
+                ->map(fn (mixed $node): string => trim((string) $node))
+                ->filter(fn (string $url): bool => $url !== '')
+                ->values()
+                ->all(),
+            'sitemaps' => collect(is_array($sitemapNodes) ? $sitemapNodes : [])
+                ->map(fn (mixed $node): string => trim((string) $node))
+                ->filter(fn (string $url): bool => $url !== '')
+                ->values()
+                ->all(),
+        ];
     }
 
     /**
@@ -277,6 +573,24 @@ class SearchConsoleIssueLiveRecheckService
             && $this->hostResolvesPublicly($host);
     }
 
+    private function isSafeSitemapUrl(WebProperty $property, string $url): bool
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+
+        $scheme = Str::lower((string) $parts['scheme']);
+        $host = Str::lower((string) $parts['host']);
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return false;
+        }
+
+        return in_array($host, $this->knownHosts($property), true) && $this->hostResolvesPublicly($host);
+    }
+
     private function normalizeUrl(string $url, string $baseUrl): ?string
     {
         if (preg_match('#^https?://#i', $url) === 1) {
@@ -327,6 +641,29 @@ class SearchConsoleIssueLiveRecheckService
         return $sanitizedUrl.($path !== '' ? $path : '/');
     }
 
+    private function normalizeComparableUrl(?string $url): ?string
+    {
+        if (! is_string($url) || $url === '') {
+            return null;
+        }
+
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $normalizedUrl = Str::lower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $normalizedUrl .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $normalizedUrl.($path !== '' ? $path : '/');
+    }
+
     private function hostResolvesPublicly(string $host): bool
     {
         if (app()->runningUnitTests()) {
@@ -365,12 +702,12 @@ class SearchConsoleIssueLiveRecheckService
     {
         $hosts = [];
 
-        if ($property->primaryDomain instanceof \App\Models\Domain && $property->primaryDomain->domain !== '') {
+        if ($property->primaryDomain instanceof Domain && $property->primaryDomain->domain !== '') {
             $hosts[] = Str::lower($property->primaryDomain->domain);
         }
 
         foreach ($property->propertyDomains as $link) {
-            if ($link->domain instanceof \App\Models\Domain && $link->domain->domain !== '') {
+            if ($link->domain instanceof Domain && $link->domain->domain !== '') {
                 $hosts[] = Str::lower($link->domain->domain);
             }
         }

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -1140,6 +1140,142 @@ class DetectedIssueApiTest extends TestCase
             ->assertJsonPath('evidence.expected_exclusion.state', 'retired_wordpress_author_archive');
     }
 
+    public function test_issues_endpoint_suppresses_page_with_redirect_rows_removed_from_current_sitemap(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'stale-redirects.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'stale-redirects-site',
+            'name' => 'Stale Redirects Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '304',
+            'search_console_property_uri' => 'sc-domain:stale-redirects.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'pages_with_redirect' => 2,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Page with redirect', 'count' => 2],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:stale-redirects.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'http://stale-redirects.example.com/index.php',
+                'https://stale-redirects.example.com/old-faq/',
+            ],
+            'examples' => [
+                ['url' => 'http://stale-redirects.example.com/index.php', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://stale-redirects.example.com/old-faq/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'http://stale-redirects.example.com/index.php',
+                    'https://stale-redirects.example.com/old-faq/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_sitemap_recheck',
+            'source_property' => 'sc-domain:stale-redirects.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'http://stale-redirects.example.com/index.php',
+                'https://stale-redirects.example.com/old-faq/',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'http://stale-redirects.example.com/index.php',
+                    'https://stale-redirects.example.com/old-faq/',
+                ],
+                'live_sitemap_checks' => [
+                    [
+                        'url' => 'http://stale-redirects.example.com/index.php',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => false,
+                        'matched_sitemap' => null,
+                    ],
+                    [
+                        'url' => 'https://stale-redirects.example.com/old-faq/',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => false,
+                        'matched_sitemap' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.page_with_redirect_in_sitemap');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'stale-redirects-site'
+                && ($issue['issue_class'] ?? null) === 'page_with_redirect_in_sitemap';
+        }));
+
+        $identity = app(\App\Services\DetectedIssueIdentityService::class);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($identity->makeIssueId($domain->id, $property->slug, 'page_with_redirect_in_sitemap')))
+            ->assertOk()
+            ->assertJsonPath('evidence.expected_exclusion.state', 'resolved_or_retired_redirect_in_sitemap')
+            ->assertJsonPath('evidence.expected_exclusion.code', 'removed_from_current_sitemap');
+    }
+
     public function test_issues_endpoint_keeps_only_still_failing_404_examples_after_live_rechecks(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -1276,6 +1276,129 @@ class DetectedIssueApiTest extends TestCase
             ->assertJsonPath('evidence.expected_exclusion.code', 'removed_from_current_sitemap');
     }
 
+    public function test_issues_endpoint_keeps_page_with_redirect_rows_when_live_sitemap_check_is_unchecked(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'unchecked-redirects.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'unchecked-redirects-site',
+            'name' => 'Unchecked Redirects Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '305',
+            'search_console_property_uri' => 'sc-domain:unchecked-redirects.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'pages_with_redirect' => 1,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Page with redirect', 'count' => 1],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:unchecked-redirects.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'not-a-valid-url',
+            ],
+            'examples' => [
+                ['url' => 'not-a-valid-url', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'not-a-valid-url',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_sitemap_recheck',
+            'source_property' => 'sc-domain:unchecked-redirects.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'not-a-valid-url',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'not-a-valid-url',
+                ],
+                'live_sitemap_checks' => [
+                    [
+                        'url' => 'not-a-valid-url',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => null,
+                        'matched_sitemap' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonPath('stats.issue_class_counts.page_with_redirect_in_sitemap', 1);
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $issue = collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'unchecked-redirects-site'
+                && ($issue['issue_class'] ?? null) === 'page_with_redirect_in_sitemap';
+        });
+
+        $this->assertIsArray($issue);
+        $this->assertNull(data_get($issue, 'evidence.expected_exclusion'));
+        $this->assertSame(
+            null,
+            data_get($issue, 'evidence.live_sitemap_checks.0.present_in_current_sitemap')
+        );
+    }
+
     public function test_issues_endpoint_keeps_only_still_failing_404_examples_after_live_rechecks(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/FleetPropertyContextRefreshTest.php
+++ b/tests/Feature/FleetPropertyContextRefreshTest.php
@@ -190,7 +190,7 @@ class FleetPropertyContextRefreshTest extends TestCase
             ->assertJsonPath('refreshed.search_console_api_enrichment.status', 'skipped')
             ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'fresh');
 
-        Http::assertNothingSent();
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'googleapis.com'));
     }
 
     public function test_search_console_refresh_is_skipped_for_manually_excluded_properties(): void
@@ -226,7 +226,7 @@ class FleetPropertyContextRefreshTest extends TestCase
             ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'ineligible')
             ->assertJsonPath('refreshed.search_console_api_enrichment.message', 'Property is not eligible for Fleet context refresh.');
 
-        Http::assertNothingSent();
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'googleapis.com'));
     }
 
     public function test_search_console_refresh_runs_when_stale(): void
@@ -507,7 +507,7 @@ class FleetPropertyContextRefreshTest extends TestCase
             ->assertJsonPath('refreshed.search_console_api_enrichment.reason', 'missing')
             ->assertJsonPath('refreshed.search_console_api_enrichment.message', 'No Search Console issue detail evidence is available for enrichment.');
 
-        Http::assertNothingSent();
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'googleapis.com'));
     }
 
     public function test_health_checks_refresh_the_canonical_domain_used_by_api_rollups(): void
@@ -743,6 +743,138 @@ class FleetPropertyContextRefreshTest extends TestCase
                 ->values()
                 ->all()
         );
+    }
+
+    public function test_refresh_rechecks_current_sitemap_membership_and_hides_stale_redirect_rows(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        config()->set('services.domain_monitor.fleet_control_api_key', 'fleet-token');
+
+        $property = $this->makeProperty('stale-redirect-sitemap-site', 'stale-redirect-sitemap.example.com');
+
+        DomainSeoBaseline::create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '557',
+            'search_console_property_uri' => 'sc-domain:stale-redirect-sitemap.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'pages_with_redirect' => 2,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $property->primary_domain_id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:stale-redirect-sitemap.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'https://stale-redirect-sitemap.example.com/removals-insurance/',
+                'http://stale-redirect-sitemap.example.com/index.php',
+            ],
+            'examples' => [
+                ['url' => 'https://stale-redirect-sitemap.example.com/removals-insurance/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'http://stale-redirect-sitemap.example.com/index.php', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://stale-redirect-sitemap.example.com/removals-insurance/',
+                    'http://stale-redirect-sitemap.example.com/index.php',
+                ],
+            ],
+        ]);
+
+        $this->mock(PropertyConversionLinkScanner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('persistForProperty')
+                ->once()
+                ->andReturn([
+                    'current_household_quote_url' => null,
+                    'current_household_booking_url' => null,
+                    'current_vehicle_quote_url' => null,
+                    'current_vehicle_booking_url' => null,
+                    'conversion_links_scanned_at' => now(),
+                ]);
+        });
+
+        $this->mock(DomainHealthCheckRunner::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('run')
+                ->times(3)
+                ->andReturnUsing(fn (Domain $domain, string $type): array => $this->skippedHealthResult($type));
+        });
+
+        $this->mock(SearchConsoleApiEnrichmentRefresher::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('refreshProperty')
+                ->once()
+                ->andReturn([
+                    'status' => 'skipped',
+                    'captured_at' => null,
+                    'reason' => 'fresh',
+                    'message' => null,
+                ]);
+        });
+
+        Http::fake([
+            'https://stale-redirect-sitemap.example.com/sitemap.xml' => Http::response('', 404),
+            'https://stale-redirect-sitemap.example.com/sitemap_index.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <sitemap>
+                        <loc>https://stale-redirect-sitemap.example.com/page-sitemap.xml</loc>
+                    </sitemap>
+                </sitemapindex>
+            XML, 200),
+            'https://stale-redirect-sitemap.example.com/page-sitemap.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <url>
+                        <loc>https://stale-redirect-sitemap.example.com/interstate-removals/</loc>
+                    </url>
+                </urlset>
+            XML, 200),
+            'https://stale-redirect-sitemap.example.com/sitemaps.xml' => Http::response('', 404),
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer fleet-token',
+        ])->postJson('/api/web-properties/stale-redirect-sitemap-site/refresh-fleet-context')
+            ->assertOk()
+            ->assertJsonPath('refreshed.search_console_live_rechecks.status', 'refreshed')
+            ->assertJsonPath('refreshed.search_console_live_rechecks.checked_url_count', 2);
+
+        $liveRecheck = SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $property->id)
+            ->where('issue_class', 'page_with_redirect_in_sitemap')
+            ->where('capture_method', 'gsc_live_recheck')
+            ->latest('captured_at')
+            ->first();
+
+        $this->assertNotNull($liveRecheck);
+        $this->assertFalse((bool) data_get($liveRecheck->issueEvidence(), 'live_sitemap_checks.0.present_in_current_sitemap'));
+        $this->assertFalse((bool) data_get($liveRecheck->issueEvidence(), 'live_sitemap_checks.1.present_in_current_sitemap'));
+
+        $issuesResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $issuesResponse->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.page_with_redirect_in_sitemap');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $issuesResponse->json('issues') ?? [];
+        $issue = collect($payloadIssues)->firstWhere('property_slug', 'stale-redirect-sitemap-site');
+
+        $this->assertNull($issue);
     }
 
     public function test_refresh_rechecks_subdomain_property_examples_on_other_managed_hosts_and_hides_resolved_404_issue(): void


### PR DESCRIPTION
## Summary
- recheck `page_with_redirect_in_sitemap` rows against the current live sitemap during property refresh
- suppress stale redirect-in-sitemap issues when the exact example URLs are no longer present in today’s sitemap
- add regression coverage for both the live actionability path and the Fleet refresh path

## Verification
- `php artisan test tests/Feature/DetectedIssueApiTest.php --filter=test_issues_endpoint_suppresses_page_with_redirect_rows_removed_from_current_sitemap`
- `php artisan test tests/Feature/FleetPropertyContextRefreshTest.php --filter=test_refresh_rechecks_current_sitemap_membership_and_hides_stale_redirect_rows`
- `./vendor/bin/phpstan analyse app/Models/SearchConsoleIssueSnapshot.php app/Services/SearchConsoleIssueActionabilityService.php app/Services/SearchConsoleIssueEvidenceService.php app/Services/SearchConsoleIssueLiveRecheckService.php --memory-limit=2G`
- `composer pr:preflight`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
