### PR TITLE
Expose external links inventory to Fleet

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -63,9 +63,12 @@ class WebPropertyController extends Controller
     {
         $validated = $request->validate([
             'fleet_focus' => 'nullable|boolean',
+            'include_external_links' => 'nullable|boolean',
         ]);
 
-        $query = $this->baseQuery(includeExternalLinkDetails: false)->orderBy('name');
+        $includeExternalLinks = (bool) ($validated['include_external_links'] ?? false);
+
+        $query = $this->baseQuery(includeExternalLinkDetails: $includeExternalLinks)->orderBy('name');
         $this->applyFleetFocusFilter($query, $validated);
 
         $properties = $query->get();

--- a/app/Http/Resources/WebPropertySummaryResource.php
+++ b/app/Http/Resources/WebPropertySummaryResource.php
@@ -14,6 +14,8 @@ class WebPropertySummaryResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        return $this->resource->brainSummary(includeFullExternalLinks: false);
+        return $this->resource->brainSummary(
+            includeFullExternalLinks: $request->boolean('include_external_links')
+        );
     }
 }

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -894,6 +894,68 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.domains.0.external_links_scan.external_links', []);
     }
 
+    public function test_web_properties_summary_can_include_external_link_inventory_when_requested(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'summary-inventory.example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'summary-inventory-site',
+            'name' => 'Summary Inventory Site',
+            'property_type' => 'marketing_site',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://summary-inventory.example.com',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainCheck::withoutEvents(function () use ($domain): void {
+            DomainCheck::factory()->create([
+                'id' => (string) Str::uuid(),
+                'domain_id' => $domain->id,
+                'check_type' => 'external_links',
+                'status' => 'ok',
+                'started_at' => now()->subMinute(),
+                'finished_at' => now(),
+                'duration_ms' => 900,
+                'payload' => [
+                    'domain' => 'summary-inventory.example.com',
+                    'pages_scanned' => 2,
+                    'external_links_count' => 1,
+                    'unique_hosts_count' => 1,
+                    'external_links' => [
+                        [
+                            'url' => 'https://portal.summary-inventory.example.com/start',
+                            'host' => 'portal.summary-inventory.example.com',
+                            'relationship' => 'subdomain',
+                            'found_on' => 'https://summary-inventory.example.com/',
+                            'found_on_pages' => ['https://summary-inventory.example.com/'],
+                        ],
+                    ],
+                ],
+                'retry_count' => 0,
+            ]);
+        });
+
+        $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
+            ->getJson('/api/web-properties-summary?include_external_links=1')
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.domains.0.external_links_scan.status', 'ok')
+            ->assertJsonPath('web_properties.0.domains.0.external_links_scan.pages_scanned', 2)
+            ->assertJsonPath('web_properties.0.domains.0.external_links_scan.external_links_count', 1)
+            ->assertJsonPath('web_properties.0.domains.0.external_links_scan.external_links.0.url', 'https://portal.summary-inventory.example.com/start');
+    }
+
     public function test_web_properties_summary_ignores_empty_fleet_focus_filter(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- add an opt-in summary API flag to include external link inventory for linked domains
- keep the summary lean by default and only include the heavy per-domain payload when requested
- add coverage for the new Fleet-facing summary contract

## Testing
- php artisan test tests/Feature/WebPropertyApiTest.php --filter='test_property_apis_surface_latest_external_link_inventory_for_linked_domains|test_property_detail_api_exposes_empty_external_link_inventory_shape_before_first_scan|test_web_properties_summary_can_include_external_link_inventory_when_requested'
- ./vendor/bin/phpstan analyse app/Http/Controllers/Api/WebPropertyController.php app/Http/Resources/WebPropertySummaryResource.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
