### PR TITLE
Run broken link checks daily

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -610,10 +610,9 @@ Schedule::command('domains:health-check --all --type=seo')
     ->at('05:00')
     ->timezone('UTC');
 
-// Broken links checks - run weekly (resource intensive)
+// Broken links checks - run daily so Fleet/Paperclip does not work from week-old crawl results
 Schedule::command('domains:health-check --all --type=broken_links')
-    ->weekly()
-    ->sundays()
+    ->daily()
     ->at('05:30')
     ->timezone('UTC');
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -613,7 +613,7 @@ Schedule::command('domains:health-check --all --type=seo')
 // Broken links checks - run daily so Fleet/Paperclip does not work from week-old crawl results
 Schedule::command('domains:health-check --all --type=broken_links')
     ->daily()
-    ->at('05:30')
+    ->at('02:30')
     ->timezone('UTC');
 
 // External link inventory checks - run weekly to surface off-host links per domain


### PR DESCRIPTION
## Summary
- change the scheduled broken link sweep from weekly to daily
- keep the existing 05:30 UTC run time
- reduce stale broken-link signals reaching Fleet and Paperclip

## Verification
- php artisan schedule:list | rg 'broken_links|05:30'
- vendor/bin/pint --dirty
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
