### PR TITLE
Hide linked subdomains from dashboard queue

### DIFF
--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -398,6 +398,10 @@ class DashboardIssueQueueService
                 continue;
             }
 
+            if ($this->shouldSkipLinkedSubdomainDomain($domain)) {
+                continue;
+            }
+
             $property = $this->primaryProperty($domain);
             $coverageStatus = $this->controlCoverageStatus($domain, $property);
             [$mustFixReasons, $shouldFixReasons, $mustFixIssueRecords, $shouldFixIssueRecords] = $this->issueReasonsForDomain(
@@ -443,6 +447,26 @@ class DashboardIssueQueueService
             $mustFixDomains->sort($sorter)->values(),
             $shouldFixDomains->sort($sorter)->values(),
         ];
+    }
+
+    private function shouldSkipLinkedSubdomainDomain(Domain $domain): bool
+    {
+        if (! $domain->relationLoaded('webProperties')) {
+            return false;
+        }
+
+        if ($domain->webProperties->isEmpty()) {
+            return false;
+        }
+
+        return $domain->webProperties->every(function (WebProperty $property): bool {
+            $usageType = is_string(data_get($property, 'pivot.usage_type'))
+                ? data_get($property, 'pivot.usage_type')
+                : null;
+            $isCanonical = (bool) data_get($property, 'pivot.is_canonical', false);
+
+            return $usageType === 'subdomain' && ! $isCanonical;
+        });
     }
 
     /**

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -432,6 +432,97 @@ class DashboardPriorityQueueApiTest extends TestCase
         ));
     }
 
+    public function test_priority_queue_skips_domains_linked_only_as_subdomains(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'backloadingremovals.com.au',
+            'is_active' => true,
+            'platform' => 'WordPress',
+        ]);
+
+        $linkedSubdomain = Domain::factory()->create([
+            'domain' => 'vehicles.backloadingremovals.com.au',
+            'is_active' => true,
+            'platform' => 'WordPress',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloadingremovals-com-au',
+            'name' => 'Backloading Removals',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $primaryDomain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $linkedSubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'backloadingremovals',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/backloadingremovals',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $linkedSubdomain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '15',
+            'search_console_property_uri' => 'sc-domain:vehicles.backloadingremovals.com.au',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'clicks' => 0,
+            'impressions' => 0,
+            'ctr' => 0,
+            'average_position' => 0,
+            'pages_with_redirect' => 56,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Page with redirect', 'count' => 56],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/dashboard/priority-queue');
+
+        $response->assertOk();
+
+        /** @var array<int, array<string, mixed>> $mustFixPayload */
+        $mustFixPayload = $response->json('must_fix') ?? [];
+        /** @var array<int, array<string, mixed>> $shouldFixPayload */
+        $shouldFixPayload = $response->json('should_fix') ?? [];
+
+        $this->assertFalse(collect($mustFixPayload)->contains(
+            fn (array $item): bool => ($item['domain'] ?? null) === 'vehicles.backloadingremovals.com.au'
+        ));
+        $this->assertFalse(collect($shouldFixPayload)->contains(
+            fn (array $item): bool => ($item['domain'] ?? null) === 'vehicles.backloadingremovals.com.au'
+        ));
+    }
+
     public function test_priority_queue_promotes_page_with_redirect_baseline_issue_into_fleet_standard_gap(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');


### PR DESCRIPTION
## Summary
- stop the dashboard priority queue from surfacing domains that are only linked to a property as usage_type=subdomain
- keep standalone or canonical/primary property surfaces unchanged
- add a regression test for linked subdomain Search Console noise

## Testing
- php artisan test tests/Feature/DashboardPriorityQueueApiTest.php --filter='test_priority_queue_skips_email_security_issues_for_web_only_subdomains|test_priority_queue_skips_domains_linked_only_as_subdomains'
- ./vendor/bin/phpstan analyse app/Services/DashboardIssueQueueService.php tests/Feature/DashboardPriorityQueueApiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
