### PR TITLE
Refresh Search Console live rechecks daily

### DIFF
--- a/app/Console/Commands/RefreshSearchConsoleLiveRechecksCommand.php
+++ b/app/Console/Commands/RefreshSearchConsoleLiveRechecksCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\SearchConsoleIssueLiveRecheckService;
+use Illuminate\Console\Command;
+
+class RefreshSearchConsoleLiveRechecksCommand extends Command
+{
+    protected $signature = 'analytics:refresh-search-console-live-rechecks
+                            {--property= : Refresh one property slug only}
+                            {--limit= : Max properties to refresh in one run}
+                            {--captured-by= : Optional captured_by value}
+                            {--dry-run : Only list the properties that would refresh}';
+
+    protected $description = 'Refresh live Search Console sitemap and URL rechecks for eligible properties';
+
+    public function handle(SearchConsoleIssueLiveRecheckService $service): int
+    {
+        $limit = $this->validatedLimit();
+
+        if ($this->option('limit') !== null && $limit === null) {
+            $this->error('The --limit option must be a positive integer.');
+
+            return self::INVALID;
+        }
+
+        $result = $service->run(
+            is_string($this->option('property')) ? $this->option('property') : null,
+            $limit,
+            is_string($this->option('captured-by')) && $this->option('captured-by') !== ''
+                ? $this->option('captured-by')
+                : null,
+            (bool) $this->option('dry-run'),
+        );
+
+        if ($result['candidate_count'] === 0) {
+            $this->info('No eligible properties currently need Search Console live rechecks.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($result['properties'] as $propertyResult) {
+            if ($result['dry_run']) {
+                $this->line(sprintf(
+                    '[dry-run] %s (latest live recheck: %s)',
+                    $propertyResult['property_slug'],
+                    $propertyResult['latest_live_captured_at'] ?? 'never'
+                ));
+
+                continue;
+            }
+
+            $this->line(sprintf(
+                '%s %s (%d URLs checked)%s',
+                ucfirst((string) ($propertyResult['status'] ?? 'skipped')),
+                $propertyResult['property_slug'],
+                (int) ($propertyResult['checked_url_count'] ?? 0),
+                ($propertyResult['reason'] ?? null) ? ' ['.$propertyResult['reason'].']' : ''
+            ));
+        }
+
+        foreach ($result['errors'] as $error) {
+            $this->warn(sprintf('%s: %s', $error['property_slug'], $error['message']));
+        }
+
+        $this->info(sprintf(
+            '%s %d of %d candidate properties for Search Console live rechecks.',
+            $result['dry_run'] ? 'Listed' : 'Processed',
+            $result['processed_count'],
+            $result['candidate_count']
+        ));
+
+        if ($result['errors'] !== []) {
+            return self::FAILURE;
+        }
+
+        $hasFailure = collect($result['properties'])->contains(
+            fn (array $propertyResult): bool => ($propertyResult['status'] ?? null) === 'failed'
+        );
+
+        return $hasFailure ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function validatedLimit(): ?int
+    {
+        $value = $this->option('limit');
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (filter_var($value, FILTER_VALIDATE_INT) === false) {
+            return null;
+        }
+
+        $limit = (int) $value;
+
+        return $limit > 0 ? $limit : null;
+    }
+}

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -6,6 +6,8 @@ use App\Models\Domain;
 use App\Models\SearchConsoleIssueSnapshot;
 use App\Models\Subdomain;
 use App\Models\WebProperty;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -35,6 +37,95 @@ class SearchConsoleIssueLiveRecheckService
      * @var array<string, bool>
      */
     private array $managedHostCache = [];
+
+    /**
+     * @return array{
+     *   dry_run: bool,
+     *   candidate_count: int,
+     *   processed_count: int,
+     *   refreshed_count: int,
+     *   properties: array<int, array<string, mixed>>,
+     *   errors: array<int, array{property_slug:string,message:string}>
+     * }
+     */
+    public function run(?string $propertySlug = null, ?int $batchLimit = null, ?string $capturedBy = null, bool $dryRun = false): array
+    {
+        $candidates = $this->candidateProperties($propertySlug, $batchLimit);
+        $results = [];
+        $errors = [];
+
+        foreach ($candidates as $property) {
+            if ($dryRun) {
+                $results[] = [
+                    'property_slug' => $property->slug,
+                    'primary_domain' => $property->primaryDomainName(),
+                    'latest_live_captured_at' => SearchConsoleIssueSnapshot::query()
+                        ->where('web_property_id', $property->id)
+                        ->where('capture_method', 'gsc_live_recheck')
+                        ->max('captured_at'),
+                ];
+
+                continue;
+            }
+
+            try {
+                $summary = $this->refreshProperty(
+                    $property,
+                    $capturedBy ?: 'scheduled_search_console_live_recheck'
+                );
+
+                $results[] = [
+                    'property_slug' => $property->slug,
+                    'primary_domain' => $property->primaryDomainName(),
+                    ...$summary,
+                ];
+            } catch (\Throwable $exception) {
+                $errors[] = [
+                    'property_slug' => $property->slug,
+                    'message' => $exception->getMessage(),
+                ];
+            }
+        }
+
+        return [
+            'dry_run' => $dryRun,
+            'candidate_count' => $candidates->count(),
+            'processed_count' => count($results),
+            'refreshed_count' => $dryRun
+                ? 0
+                : count(array_filter($results, fn (array $result): bool => ($result['status'] ?? null) === 'refreshed')),
+            'properties' => $results,
+            'errors' => $errors,
+        ];
+    }
+
+    /**
+     * @return Collection<int, WebProperty>
+     */
+    public function candidateProperties(?string $propertySlug = null, ?int $batchLimit = null): Collection
+    {
+        $query = $this->eligibleProperties()
+            ->with([
+                'primaryDomain.tags',
+                'propertyDomains.domain',
+            ])
+            ->orderBy('name');
+
+        if (is_string($propertySlug) && trim($propertySlug) !== '') {
+            $query->where('slug', trim($propertySlug));
+        }
+
+        /** @var Collection<int, WebProperty> $properties */
+        $properties = $query->get()
+            ->filter(fn (WebProperty $property): bool => $property->coverageEligibility()['eligible'])
+            ->values();
+
+        if ($batchLimit !== null) {
+            return $properties->take(max(1, $batchLimit))->values();
+        }
+
+        return $properties;
+    }
 
     /**
      * @return array{status:'refreshed'|'skipped'|'failed',captured_at:string|null,checked_url_count:int,reason:string|null}
@@ -225,6 +316,21 @@ class SearchConsoleIssueLiveRecheckService
             ->orderByDesc('captured_at')
             ->orderByDesc('created_at')
             ->first();
+    }
+
+    /**
+     * @return Builder<WebProperty>
+     */
+    private function eligibleProperties(): Builder
+    {
+        return WebProperty::query()
+            ->where('status', 'active')
+            ->where('property_type', '!=', 'domain_asset')
+            ->whereHas('searchConsoleIssueSnapshots', function ($query): void {
+                $query
+                    ->whereIn('issue_class', self::ISSUE_CLASSES)
+                    ->whereIn('capture_method', ['gsc_drilldown_zip', 'gsc_api', 'gsc_mcp_api']);
+            });
     }
 
     /**

--- a/routes/console.php
+++ b/routes/console.php
@@ -725,6 +725,12 @@ if ($googleSearchConsoleConfigured) {
         ->timezone('UTC');
 }
 
+// Refresh live Search Console URL/sitemap rechecks daily so stale redirect and 404 rows retire without waiting for Fleet to touch each property.
+Schedule::command('analytics:refresh-search-console-live-rechecks')
+    ->daily()
+    ->at('09:25')
+    ->timezone('UTC');
+
 // Prune failed queue jobs older than 14 days (336 hours)
 Schedule::command('queue:prune-failed --hours=336')
     ->daily()

--- a/tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
+++ b/tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class RefreshSearchConsoleLiveRechecksCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_refreshes_live_sitemap_rechecks_for_eligible_properties(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('discountbackloading-site', 'discountbackloading.example.au');
+        $domain = $property->primaryDomainModel();
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:discountbackloading.example.au',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 2,
+            'sample_urls' => [
+                'http://www.discountbackloading.example.au/',
+                'https://discountbackloading.example.au/author/admin/',
+            ],
+            'examples' => [
+                ['url' => 'http://www.discountbackloading.example.au/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://discountbackloading.example.au/author/admin/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'http://www.discountbackloading.example.au/',
+                    'https://discountbackloading.example.au/author/admin/',
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://discountbackloading.example.au/sitemap.xml' => Http::response('', 404),
+            'https://discountbackloading.example.au/sitemaps.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <sitemap><loc>https://discountbackloading.example.au/post-sitemap.xml</loc></sitemap>
+                    <sitemap><loc>https://discountbackloading.example.au/page-sitemap.xml</loc></sitemap>
+                </sitemapindex>
+            XML, 200),
+            'https://discountbackloading.example.au/sitemap_index.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <sitemap><loc>https://discountbackloading.example.au/post-sitemap.xml</loc></sitemap>
+                    <sitemap><loc>https://discountbackloading.example.au/page-sitemap.xml</loc></sitemap>
+                </sitemapindex>
+            XML, 200),
+            'https://discountbackloading.example.au/post-sitemap.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <url><loc>https://discountbackloading.example.au/</loc></url>
+                </urlset>
+            XML, 200),
+            'https://discountbackloading.example.au/page-sitemap.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <url><loc>https://discountbackloading.example.au/contact/</loc></url>
+                </urlset>
+            XML, 200),
+        ]);
+
+        $exitCode = Artisan::call('analytics:refresh-search-console-live-rechecks');
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Refreshed discountbackloading-site (2 URLs checked)', Artisan::output());
+
+        $liveSnapshot = SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $property->id)
+            ->where('issue_class', 'page_with_redirect_in_sitemap')
+            ->where('capture_method', 'gsc_live_recheck')
+            ->latest('captured_at')
+            ->first();
+
+        $this->assertInstanceOf(SearchConsoleIssueSnapshot::class, $liveSnapshot);
+        $this->assertSame(false, data_get($liveSnapshot->issueEvidence(), 'live_sitemap_checks.0.present_in_current_sitemap'));
+        $this->assertSame(false, data_get($liveSnapshot->issueEvidence(), 'live_sitemap_checks.1.present_in_current_sitemap'));
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.page_with_redirect_in_sitemap');
+
+        /** @var array<int, array<string, mixed>> $issues */
+        $issues = $response->json('issues') ?? [];
+        $matchingIssue = null;
+
+        foreach ($issues as $issue) {
+            if (($issue['property_slug'] ?? null) === 'discountbackloading-site'
+                && ($issue['issue_class'] ?? null) === 'page_with_redirect_in_sitemap') {
+                $matchingIssue = $issue;
+                break;
+            }
+        }
+
+        $this->assertNull($matchingIssue);
+    }
+
+    public function test_it_supports_dry_run_without_hitting_live_sitemaps(): void
+    {
+        $property = $this->makeProperty('dry-run-live-rechecks-site', 'dry-run-live-rechecks.example.au');
+        $domain = $property->primaryDomainModel();
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_drilldown_zip',
+            'affected_url_count' => 1,
+            'sample_urls' => ['https://dry-run-live-rechecks.example.au/old-page/'],
+            'normalized_payload' => [
+                'affected_urls' => ['https://dry-run-live-rechecks.example.au/old-page/'],
+            ],
+        ]);
+
+        Http::fake();
+
+        $exitCode = Artisan::call('analytics:refresh-search-console-live-rechecks', [
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Listed 1 of 1 candidate properties', Artisan::output());
+        $this->assertSame(0, SearchConsoleIssueSnapshot::query()->where('capture_method', 'gsc_live_recheck')->count());
+        Http::assertNothingSent();
+    }
+
+    private function makeProperty(string $slug, string $domainName): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => $slug,
+            'name' => Str::of($slug)->replace('-', ' ')->title()->toString(),
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://'.$domainName,
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => $domainName,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+}


### PR DESCRIPTION
## Summary
- add a scheduled Search Console live recheck command for eligible properties with redirect/404 issue evidence
- run those rechecks daily so stale page-with-redirect rows can retire without waiting for a targeted Fleet refresh
- add regression coverage for stale sitemap redirect suppression through the new command

## Testing
- php artisan test tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php tests/Feature/FleetPropertyContextRefreshTest.php --filter='page_with_redirect_rows_removed_from_current_sitemap|page_with_redirect_rows_when_live_sitemap_check_is_unchecked|current_sitemap_membership_and_hides_stale_redirect_rows'
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueLiveRecheckService.php app/Console/Commands/RefreshSearchConsoleLiveRechecksCommand.php tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
