### PR TITLE
Retire partial stale sitemap redirect rows

### DIFF
--- a/app/Services/SearchConsoleIssueActionabilityService.php
+++ b/app/Services/SearchConsoleIssueActionabilityService.php
@@ -136,7 +136,22 @@ class SearchConsoleIssueActionabilityService
         }
 
         if (! $this->issueEvidenceRepresentsCompleteSet($issueEvidence, $candidateUrls)) {
-            return $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+            $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+
+            if ($activeUrls !== []) {
+                return $normalizedEvidence;
+            }
+
+            $matchedUrls = array_keys($retiredUrls);
+            $normalizedEvidence['expected_exclusion'] = [
+                'state' => 'resolved_or_retired_redirect_in_sitemap',
+                'code' => 'removed_from_current_sitemap',
+                'reason' => 'current_sitemap_no_longer_contains_historical_redirect_urls',
+                'matched_urls' => array_slice($matchedUrls, 0, 10),
+                'matched_url_count' => count($matchedUrls),
+            ];
+
+            return $normalizedEvidence;
         }
 
         $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls);
@@ -181,7 +196,11 @@ class SearchConsoleIssueActionabilityService
      */
     private function normalizePageWithRedirectIssue(array $issueEvidence): array
     {
-        $candidateUrls = $this->candidateUrls($issueEvidence);
+        $candidateUrls = $this->liveCheckedSitemapUrls($issueEvidence);
+
+        if ($candidateUrls === []) {
+            $candidateUrls = $this->candidateUrls($issueEvidence);
+        }
 
         if ($candidateUrls === []) {
             return $issueEvidence;
@@ -207,7 +226,22 @@ class SearchConsoleIssueActionabilityService
         }
 
         if (! $this->issueEvidenceRepresentsCompleteSet($issueEvidence, $candidateUrls)) {
-            return $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+            $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls, true);
+
+            if ($activeUrls !== []) {
+                return $normalizedEvidence;
+            }
+
+            $matchedUrls = array_keys($retiredUrls);
+            $normalizedEvidence['expected_exclusion'] = [
+                'state' => 'resolved_or_retired_redirect_in_sitemap',
+                'code' => 'removed_from_current_sitemap',
+                'reason' => 'current_sitemap_no_longer_contains_historical_redirect_urls',
+                'matched_urls' => array_slice($matchedUrls, 0, 10),
+                'matched_url_count' => count($matchedUrls),
+            ];
+
+            return $normalizedEvidence;
         }
 
         $normalizedEvidence = $this->filterEvidenceToUrls($issueEvidence, $activeUrls);
@@ -226,6 +260,23 @@ class SearchConsoleIssueActionabilityService
         ];
 
         return $normalizedEvidence;
+    }
+
+    /**
+     * @param  array<string, mixed>  $issueEvidence
+     * @return array<int, string>
+     */
+    private function liveCheckedSitemapUrls(array $issueEvidence): array
+    {
+        $urls = [];
+
+        foreach ((array) ($issueEvidence['live_sitemap_checks'] ?? []) as $check) {
+            if (is_array($check) && is_string($check['url'] ?? null) && $check['url'] !== '') {
+                $urls[] = $check['url'];
+            }
+        }
+
+        return array_values(array_unique($urls));
     }
 
     /**

--- a/app/Services/SearchConsoleIssueActionabilityService.php
+++ b/app/Services/SearchConsoleIssueActionabilityService.php
@@ -144,9 +144,9 @@ class SearchConsoleIssueActionabilityService
 
             $matchedUrls = array_keys($retiredUrls);
             $normalizedEvidence['expected_exclusion'] = [
-                'state' => 'resolved_or_retired_redirect_in_sitemap',
-                'code' => 'removed_from_current_sitemap',
-                'reason' => 'current_sitemap_no_longer_contains_historical_redirect_urls',
+                'state' => 'resolved_or_retired_404',
+                'code' => 'resolved_or_retired_404',
+                'reason' => 'all_checked_historical_404_urls_are_non_actionable_or_already_resolved',
                 'matched_urls' => array_slice($matchedUrls, 0, 10),
                 'matched_url_count' => count($matchedUrls),
             ];

--- a/tests/Feature/DetectedIssueApiPartial404SuppressionTest.php
+++ b/tests/Feature/DetectedIssueApiPartial404SuppressionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainSeoBaseline;
+use App\Models\PropertyRepository;
+use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DetectedIssueApiPartial404SuppressionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_issues_endpoint_suppresses_partial_stale_404_rows_with_404_specific_exclusion_metadata(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'partial-stale-404s.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'partial-stale-404s-site',
+            'name' => 'Partial Stale 404s Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        PropertyRepository::create([
+            'web_property_id' => $property->id,
+            'repo_name' => 'partial-stale-404s-site',
+            'repo_provider' => 'local_only',
+            'local_path' => '/Users/jasonhill/Projects/websites/partial-stale-404s-site',
+            'framework' => 'WordPress',
+            'is_primary' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '406',
+            'search_console_property_uri' => 'sc-domain:partial-stale-404s.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'not_found_404' => 19,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Not found (404)', 'count' => 19],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:partial-stale-404s.example.com',
+            'captured_at' => now()->subMinute(),
+            'captured_by' => 'test',
+            'affected_url_count' => 3,
+            'sample_urls' => [
+                'https://partial-stale-404s.example.com/old-page/',
+                'https://partial-stale-404s.example.com/author/admin/',
+                'https://partial-stale-404s.example.com/legacy/payments',
+            ],
+            'examples' => [
+                ['url' => 'https://partial-stale-404s.example.com/old-page/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://partial-stale-404s.example.com/author/admin/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://partial-stale-404s.example.com/legacy/payments', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://partial-stale-404s.example.com/old-page/',
+                    'https://partial-stale-404s.example.com/author/admin/',
+                    'https://partial-stale-404s.example.com/legacy/payments',
+                ],
+            ],
+            'raw_payload' => ['source' => 'drilldown'],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'source_issue_label' => 'Not found (404)',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_url_recheck',
+            'source_property' => 'sc-domain:partial-stale-404s.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 3,
+            'sample_urls' => [
+                'https://partial-stale-404s.example.com/old-page/',
+                'https://partial-stale-404s.example.com/author/admin/',
+                'https://partial-stale-404s.example.com/legacy/payments',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://partial-stale-404s.example.com/old-page/',
+                    'https://partial-stale-404s.example.com/author/admin/',
+                    'https://partial-stale-404s.example.com/legacy/payments',
+                ],
+                'live_url_checks' => [
+                    [
+                        'url' => 'https://partial-stale-404s.example.com/old-page/',
+                        'status_code' => 301,
+                        'final_status' => 200,
+                        'final_url' => 'https://partial-stale-404s.example.com/',
+                    ],
+                    [
+                        'url' => 'https://partial-stale-404s.example.com/author/admin/',
+                        'status_code' => 301,
+                        'final_status' => 200,
+                        'final_url' => 'https://partial-stale-404s.example.com/',
+                    ],
+                    [
+                        'url' => 'https://partial-stale-404s.example.com/legacy/payments',
+                        'status_code' => 302,
+                        'final_status' => 200,
+                        'final_url' => 'https://partial-stale-404s.example.com/contact',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        $response->assertOk()
+            ->assertJsonMissingPath('stats.issue_class_counts.not_found_404');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'partial-stale-404s-site'
+                && ($issue['issue_class'] ?? null) === 'not_found_404';
+        }));
+
+        $identity = app(\App\Services\DetectedIssueIdentityService::class);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($identity->makeIssueId($domain->id, $property->slug, 'not_found_404')))
+            ->assertOk()
+            ->assertJsonPath('evidence.expected_exclusion.state', 'resolved_or_retired_404')
+            ->assertJsonPath('evidence.expected_exclusion.code', 'resolved_or_retired_404');
+    }
+}

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -1256,9 +1256,6 @@ class DetectedIssueApiTest extends TestCase
             'Authorization' => 'Bearer test-api-key',
         ])->getJson('/api/issues');
 
-        $response->assertOk()
-            ->assertJsonMissingPath('stats.issue_class_counts.page_with_redirect_in_sitemap');
-
         /** @var array<int, array<string, mixed>> $payloadIssues */
         $payloadIssues = $response->json('issues') ?? [];
         $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
@@ -1397,6 +1394,151 @@ class DetectedIssueApiTest extends TestCase
             null,
             data_get($issue, 'evidence.live_sitemap_checks.0.present_in_current_sitemap')
         );
+    }
+
+    public function test_issues_endpoint_suppresses_page_with_redirect_rows_when_all_checked_examples_are_gone_from_current_sitemap_even_if_historical_count_is_larger(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'partial-stale-redirects.example.com',
+            'expires_at' => null,
+            'is_active' => true,
+            'platform' => 'WordPress',
+            'hosting_provider' => 'DreamIT Host',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'partial-stale-redirects-site',
+            'name' => 'Partial Stale Redirects Site',
+            'property_type' => 'website',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        DomainSeoBaseline::create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'baseline_type' => 'search_console',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'source_provider' => 'matomo',
+            'matomo_site_id' => '306',
+            'search_console_property_uri' => 'sc-domain:partial-stale-redirects.example.com',
+            'search_type' => 'web',
+            'date_range_start' => now()->subDays(28)->toDateString(),
+            'date_range_end' => now()->toDateString(),
+            'import_method' => 'matomo_api',
+            'pages_with_redirect' => 56,
+            'raw_payload' => [
+                'issues' => [
+                    ['label' => 'Page with redirect', 'count' => 56],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:partial-stale-redirects.example.com',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 56,
+            'sample_urls' => [
+                'http://www.partial-stale-redirects.example.com/',
+                'https://partial-stale-redirects.example.com/author/admin/',
+                'https://partial-stale-redirects.example.com/2024/01/',
+            ],
+            'examples' => [
+                ['url' => 'http://www.partial-stale-redirects.example.com/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://partial-stale-redirects.example.com/author/admin/', 'last_crawled' => now()->subDays(2)->toDateString()],
+                ['url' => 'https://partial-stale-redirects.example.com/2024/01/', 'last_crawled' => now()->subDays(2)->toDateString()],
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'http://www.partial-stale-redirects.example.com/',
+                    'https://partial-stale-redirects.example.com/author/admin/',
+                    'https://partial-stale-redirects.example.com/2024/01/',
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_sitemap_recheck',
+            'source_property' => 'sc-domain:partial-stale-redirects.example.com',
+            'captured_at' => now(),
+            'captured_by' => 'test',
+            'affected_url_count' => 3,
+            'sample_urls' => [
+                'http://www.partial-stale-redirects.example.com/',
+                'https://partial-stale-redirects.example.com/author/admin/',
+                'https://partial-stale-redirects.example.com/2024/01/',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'http://www.partial-stale-redirects.example.com/',
+                    'https://partial-stale-redirects.example.com/author/admin/',
+                    'https://partial-stale-redirects.example.com/2024/01/',
+                ],
+                'live_sitemap_checks' => [
+                    [
+                        'url' => 'http://www.partial-stale-redirects.example.com/',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => false,
+                        'matched_sitemap' => null,
+                    ],
+                    [
+                        'url' => 'https://partial-stale-redirects.example.com/author/admin/',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => false,
+                        'matched_sitemap' => null,
+                    ],
+                    [
+                        'url' => 'https://partial-stale-redirects.example.com/2024/01/',
+                        'checked_at' => now()->toIso8601String(),
+                        'present_in_current_sitemap' => false,
+                        'matched_sitemap' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues');
+
+        /** @var array<int, array<string, mixed>> $payloadIssues */
+        $payloadIssues = $response->json('issues') ?? [];
+        $this->assertNull(collect($payloadIssues)->first(function (array $issue): bool {
+            return ($issue['property_slug'] ?? null) === 'partial-stale-redirects-site'
+                && ($issue['issue_class'] ?? null) === 'page_with_redirect_in_sitemap';
+        }));
+
+        $identity = app(\App\Services\DetectedIssueIdentityService::class);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues/'.urlencode($identity->makeIssueId($domain->id, $property->slug, 'page_with_redirect_in_sitemap')))
+            ->assertOk()
+            ->assertJsonPath('evidence.expected_exclusion.code', 'removed_from_current_sitemap')
+            ->assertJsonPath('evidence.active_affected_url_count', 0)
+            ->assertJsonPath('evidence.raw_affected_url_count', 56);
     }
 
     public function test_issues_endpoint_keeps_only_still_failing_404_examples_after_live_rechecks(): void


### PR DESCRIPTION
## Summary
- suppress page-with-redirect rows when every live-checked example is gone from the current sitemap, even if the historical row was only a partial sample
- prefer live-checked sitemap URLs when normalizing redirect-in-sitemap issues
- add a regression test for larger historical counts with fully retired checked examples

## Testing
- php artisan test tests/Feature/DetectedIssueApiTest.php --filter='page_with_redirect_rows_removed_from_current_sitemap|page_with_redirect_rows_when_live_sitemap_check_is_unchecked|all_checked_examples_are_gone_from_current_sitemap_even_if_historical_count_is_larger'
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueActionabilityService.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/93" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
