### PR TITLE
Fix zero-issue should-fix dashboard cards

### DIFF
--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -258,6 +258,12 @@
                 @if($shouldFixDomains->isNotEmpty())
                     <div class="space-y-4">
                         @foreach($shouldFixDomains as $item)
+                            @php
+                                $visibleReasons = $item['primary_reasons'] !== []
+                                    ? $item['primary_reasons']
+                                    : $item['secondary_reasons'];
+                                $visibleReasonCount = count($visibleReasons);
+                            @endphp
                             <div class="border border-amber-200 dark:border-amber-900/60 rounded-lg p-4 bg-amber-50/50 dark:bg-amber-950/20">
                                 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
                                     <div>
@@ -269,12 +275,12 @@
                                         @endif
                                     </div>
                                     <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
-                                        {{ $item['primary_reason_count'] }} issue{{ $item['primary_reason_count'] === 1 ? '' : 's' }}
+                                        {{ $visibleReasonCount }} issue{{ $visibleReasonCount === 1 ? '' : 's' }}
                                     </span>
                                 </div>
 
                                 <ul class="mt-4 space-y-2">
-                                    @foreach($item['primary_reasons'] as $reason)
+                                    @foreach($visibleReasons as $reason)
                                         <li class="text-sm text-gray-700 dark:text-gray-300 flex items-start gap-2">
                                             <span class="mt-1 h-2 w-2 rounded-full bg-amber-500 shrink-0"></span>
                                             <span>{{ $reason }}</span>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -16,6 +16,7 @@ use App\Models\Subdomain;
 use App\Models\User;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
+use App\Services\DashboardIssueQueueService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Livewire\Livewire;
@@ -86,6 +87,44 @@ class DashboardTest extends TestCase
             ->assertSee('Security headers need review')
             ->assertSee('Email security needs review')
             ->assertSee('Domain expires in 14 days');
+    }
+
+    public function test_dashboard_should_fix_cards_fall_back_to_secondary_reasons_when_primary_reasons_are_empty(): void
+    {
+        $user = User::factory()->create();
+
+        $this->instance(DashboardIssueQueueService::class, new class extends DashboardIssueQueueService
+        {
+            public function __construct() {}
+
+            public function snapshot(bool $includeExpectedExclusions = false): array
+            {
+                return [
+                    'stats' => [
+                        'must_fix' => 0,
+                        'should_fix' => 1,
+                    ],
+                    'must_fix' => [],
+                    'should_fix' => [[
+                        'id' => 123,
+                        'domain' => 'downgraded-queue.example.com',
+                        'hosting_provider' => 'DreamIT Host',
+                        'primary_reasons' => [],
+                        'secondary_reasons' => ['Broken links need review'],
+                        'primary_reason_count' => 0,
+                        'secondary_reason_count' => 1,
+                        'updated_at_human' => '5 minutes ago',
+                    ]],
+                ];
+            }
+        });
+
+        $this->actingAs($user)->get('/dashboard')
+            ->assertOk()
+            ->assertSee('downgraded-queue.example.com')
+            ->assertSee('Broken links need review')
+            ->assertSee('1 issue')
+            ->assertDontSee('0 issues');
     }
 
     public function test_dashboard_excludes_domains_marked_as_parked_in_synergy(): void

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -93,9 +93,21 @@ class DashboardTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->instance(DashboardIssueQueueService::class, new class extends DashboardIssueQueueService
+        $this->instance(DashboardIssueQueueService::class, new class(app(\App\Services\DetectedIssueIdentityService::class), app(\App\Services\DetectedIssueVerificationService::class), app(\App\Services\SearchConsoleIssueEvidenceService::class), app(\App\Services\SearchConsoleIssueActionabilityService::class)) extends DashboardIssueQueueService
         {
-            public function __construct() {}
+            public function __construct(
+                \App\Services\DetectedIssueIdentityService $issueIdentityService,
+                \App\Services\DetectedIssueVerificationService $issueVerificationService,
+                \App\Services\SearchConsoleIssueEvidenceService $issueEvidenceService,
+                \App\Services\SearchConsoleIssueActionabilityService $issueActionabilityService,
+            ) {
+                parent::__construct(
+                    $issueIdentityService,
+                    $issueVerificationService,
+                    $issueEvidenceService,
+                    $issueActionabilityService,
+                );
+            }
 
             public function snapshot(bool $includeExpectedExclusions = false): array
             {


### PR DESCRIPTION
## Summary
- show secondary should-fix reasons when a queue item has been downgraded from must-fix
- render the visible reason count instead of a misleading zero-issue badge
- add a dashboard regression test for the downgraded queue case

## Testing
- php artisan test tests/Feature/DashboardTest.php --filter='dashboard_shows_must_fix_and_should_fix_domain_queues|dashboard_should_fix_cards_fall_back_to_secondary_reasons_when_primary_reasons_are_empty'
- ./vendor/bin/phpstan analyse app/Livewire/Dashboard.php tests/Feature/DashboardTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
