### PR TITLE
Fix domain detail modal Alpine error

### DIFF
--- a/resources/views/livewire/web-property-detail.blade.php
+++ b/resources/views/livewire/web-property-detail.blade.php
@@ -881,10 +881,9 @@
 
         @if($showExternalLinksModal)
             <div
-                x-data
-                x-on:keydown.escape.window="$wire.closeExternalLinksModal()"
                 class="fixed inset-0 z-50 overflow-y-auto bg-gray-900/60"
                 wire:click="closeExternalLinksModal"
+                wire:keydown.escape.window="closeExternalLinksModal"
             >
                 <div
                     class="relative mx-auto mt-10 w-full max-w-5xl px-4 pb-10"


### PR DESCRIPTION
## Summary
- replace the external links modal Alpine escape handler with a Livewire handler
- remove the brittle raw  expression that could break after Livewire morphing
- keep the domain and property modal flows working without the browser syntax error

## Testing
- php artisan test tests/Feature/WebPropertyUiTest.php --filter='external_link|External Link|owned_subdomain|authenticated_user_can_view_web_property_detail'
- ./vendor/bin/phpstan analyse app/Livewire/WebPropertyDetail.php tests/Feature/WebPropertyUiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
