### PR TITLE
Optimize Search Console evidence snapshot loading

### DIFF
--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -9,6 +9,15 @@ use Illuminate\Support\Collection;
 
 class SearchConsoleIssueEvidenceService
 {
+    /**
+     * @var array<string, array<int, string>>
+     */
+    private const SNAPSHOT_BUCKET_METHODS = [
+        'detail' => ['gsc_drilldown_zip'],
+        'api' => ['gsc_api', 'gsc_mcp_api'],
+        'live' => ['gsc_live_recheck'],
+    ];
+
     public function __construct(
         private readonly DetectedIssueIdentityService $issueIdentityService,
         private readonly DetectedIssueVerificationService $issueVerificationService,
@@ -223,23 +232,54 @@ class SearchConsoleIssueEvidenceService
         /** @var array<string, array<string, array{detail:?SearchConsoleIssueSnapshot, api:?SearchConsoleIssueSnapshot, live:?SearchConsoleIssueSnapshot}>> $grouped */
         $grouped = [];
 
-        SearchConsoleIssueSnapshot::query()
-            ->whereIn('web_property_id', $propertyIds)
-            ->orderByDesc('captured_at')
-            ->orderByDesc('created_at')
-            ->get()
-            ->each(function (SearchConsoleIssueSnapshot $snapshot) use (&$grouped): void {
-                $bucket = match ($snapshot->capture_method) {
-                    'gsc_drilldown_zip' => 'detail',
-                    'gsc_live_recheck' => 'live',
-                    default => 'api',
-                };
-                $grouped[$snapshot->web_property_id] ??= [];
-                $grouped[$snapshot->web_property_id][$snapshot->issue_class] ??= ['detail' => null, 'api' => null, 'live' => null];
-                $grouped[$snapshot->web_property_id][$snapshot->issue_class][$bucket] ??= $snapshot;
-            });
+        foreach (self::SNAPSHOT_BUCKET_METHODS as $bucket => $captureMethods) {
+            $this->latestSnapshotsForBucket($propertyIds, $captureMethods)
+                ->each(function (SearchConsoleIssueSnapshot $snapshot) use (&$grouped, $bucket): void {
+                    $grouped[$snapshot->web_property_id] ??= [];
+                    $grouped[$snapshot->web_property_id][$snapshot->issue_class] ??= ['detail' => null, 'api' => null, 'live' => null];
+                    $grouped[$snapshot->web_property_id][$snapshot->issue_class][$bucket] = $snapshot;
+                });
+        }
 
         return $grouped;
+    }
+
+    /**
+     * @param  array<int, string>  $propertyIds
+     * @param  array<int, string>  $captureMethods
+     * @return Collection<int, SearchConsoleIssueSnapshot>
+     */
+    private function latestSnapshotsForBucket(array $propertyIds, array $captureMethods): Collection
+    {
+        return SearchConsoleIssueSnapshot::query()
+            ->whereIn('web_property_id', $propertyIds)
+            ->whereIn('capture_method', $captureMethods)
+            ->whereNotExists(function ($query) use ($captureMethods): void {
+                $query
+                    ->selectRaw('1')
+                    ->from('search_console_issue_snapshots as newer')
+                    ->whereColumn('newer.web_property_id', 'search_console_issue_snapshots.web_property_id')
+                    ->whereColumn('newer.issue_class', 'search_console_issue_snapshots.issue_class')
+                    ->whereIn('newer.capture_method', $captureMethods)
+                    ->where(function ($newerQuery): void {
+                        $newerQuery
+                            ->whereColumn('newer.captured_at', '>', 'search_console_issue_snapshots.captured_at')
+                            ->orWhere(function ($sameCaptureQuery): void {
+                                $sameCaptureQuery
+                                    ->whereColumn('newer.captured_at', 'search_console_issue_snapshots.captured_at')
+                                    ->where(function ($sameCreatedQuery): void {
+                                        $sameCreatedQuery
+                                            ->whereColumn('newer.created_at', '>', 'search_console_issue_snapshots.created_at')
+                                            ->orWhere(function ($sameCreatedAndCaptureQuery): void {
+                                                $sameCreatedAndCaptureQuery
+                                                    ->whereColumn('newer.created_at', 'search_console_issue_snapshots.created_at')
+                                                    ->whereColumn('newer.id', '>', 'search_console_issue_snapshots.id');
+                                            });
+                                    });
+                            });
+                    });
+            })
+            ->get();
     }
 
     /**

--- a/app/Services/SearchConsoleIssueEvidenceService.php
+++ b/app/Services/SearchConsoleIssueEvidenceService.php
@@ -237,7 +237,7 @@ class SearchConsoleIssueEvidenceService
                 ->each(function (SearchConsoleIssueSnapshot $snapshot) use (&$grouped, $bucket): void {
                     $grouped[$snapshot->web_property_id] ??= [];
                     $grouped[$snapshot->web_property_id][$snapshot->issue_class] ??= ['detail' => null, 'api' => null, 'live' => null];
-                    $grouped[$snapshot->web_property_id][$snapshot->issue_class][$bucket] = $snapshot;
+                    $grouped[$snapshot->web_property_id][$snapshot->issue_class][$bucket] ??= $snapshot;
                 });
         }
 
@@ -273,12 +273,16 @@ class SearchConsoleIssueEvidenceService
                                             ->orWhere(function ($sameCreatedAndCaptureQuery): void {
                                                 $sameCreatedAndCaptureQuery
                                                     ->whereColumn('newer.created_at', 'search_console_issue_snapshots.created_at')
-                                                    ->whereColumn('newer.id', '>', 'search_console_issue_snapshots.id');
+                                                    ->whereColumn('newer.updated_at', '>', 'search_console_issue_snapshots.updated_at');
                                             });
                                     });
                             });
                     });
             })
+            ->orderByDesc('captured_at')
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->orderByDesc('id')
             ->get();
     }
 

--- a/tests/Feature/SearchConsoleIssueEvidenceServiceTest.php
+++ b/tests/Feature/SearchConsoleIssueEvidenceServiceTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\SearchConsoleIssueSnapshot;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use App\Services\SearchConsoleIssueEvidenceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class SearchConsoleIssueEvidenceServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_uses_the_latest_snapshot_from_each_bucket_per_issue(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'evidence-example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'evidence-example',
+            'name' => 'Evidence Example',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'evidence-example.com',
+            'canonical_origin_policy' => 'known',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_drilldown_zip',
+            'captured_at' => Carbon::parse('2026-04-08 08:00:00', 'UTC'),
+            'sample_urls' => ['https://evidence-example.com/old-missing'],
+            'examples' => [['url' => 'https://evidence-example.com/old-missing', 'last_crawled' => '2026-04-07']],
+            'normalized_payload' => [
+                'affected_urls' => ['https://evidence-example.com/old-missing'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_drilldown_zip',
+            'captured_at' => Carbon::parse('2026-04-08 09:00:00', 'UTC'),
+            'sample_urls' => ['https://evidence-example.com/new-missing'],
+            'examples' => [['url' => 'https://evidence-example.com/new-missing', 'last_crawled' => '2026-04-08']],
+            'normalized_payload' => [
+                'affected_urls' => ['https://evidence-example.com/new-missing'],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_api',
+            'source_report' => 'search_console_api_bundle_old',
+            'captured_at' => Carbon::parse('2026-04-08 08:10:00', 'UTC'),
+            'normalized_payload' => [
+                'url_inspection' => [
+                    'inspected_urls' => [
+                        ['url' => 'https://evidence-example.com/old-missing', 'coverage_state' => 'Not found (404)'],
+                    ],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_mcp_api',
+            'source_report' => 'search_console_api_bundle_new',
+            'captured_at' => Carbon::parse('2026-04-08 09:10:00', 'UTC'),
+            'normalized_payload' => [
+                'url_inspection' => [
+                    'inspected_urls' => [
+                        ['url' => 'https://evidence-example.com/new-missing', 'coverage_state' => 'Not found (404)'],
+                    ],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'captured_at' => Carbon::parse('2026-04-08 08:20:00', 'UTC'),
+            'normalized_payload' => [
+                'affected_urls' => ['https://evidence-example.com/old-missing'],
+                'live_url_checks' => [[
+                    'url' => 'https://evidence-example.com/old-missing',
+                    'checked_at' => '2026-04-08T08:20:00+00:00',
+                    'final_url' => 'https://evidence-example.com/old-missing',
+                    'final_status' => 404,
+                    'resolved_ok' => false,
+                    'host_changed' => false,
+                ]],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'not_found_404',
+            'capture_method' => 'gsc_live_recheck',
+            'source_report' => 'search_console_live_http_recheck',
+            'captured_at' => Carbon::parse('2026-04-08 09:20:00', 'UTC'),
+            'normalized_payload' => [
+                'affected_urls' => ['https://evidence-example.com/new-missing'],
+                'live_url_checks' => [[
+                    'url' => 'https://evidence-example.com/new-missing',
+                    'checked_at' => '2026-04-08T09:20:00+00:00',
+                    'final_url' => 'https://evidence-example.com/new-missing',
+                    'final_status' => 404,
+                    'resolved_ok' => false,
+                    'host_changed' => false,
+                ]],
+            ],
+        ]);
+
+        $evidence = app(SearchConsoleIssueEvidenceService::class)
+            ->evidenceMapForProperties(collect([$property->fresh(['primaryDomain', 'propertyDomains.domain'])]));
+
+        $issueEvidence = $evidence['evidence-example']['not_found_404'];
+
+        $this->assertSame(['https://evidence-example.com/new-missing'], $issueEvidence['affected_urls']);
+        $this->assertSame('gsc_drilldown_zip', $issueEvidence['source_capture_method']);
+        $this->assertSame('search_console_page_indexing_drilldown', $issueEvidence['source_report']);
+        $this->assertSame('gsc_mcp_api', $issueEvidence['api_source_capture_method']);
+        $this->assertSame('search_console_api_bundle_new', $issueEvidence['api_source_report']);
+        $this->assertSame('https://evidence-example.com/new-missing', $issueEvidence['live_url_checks'][0]['url']);
+        $this->assertNotNull($issueEvidence['live_captured_at']);
+    }
+
+    public function test_it_breaks_same_timestamp_ties_with_newer_created_at_within_a_bucket(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'tie-break-example.com',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'tie-break-example',
+            'name' => 'Tie Break Example',
+            'status' => 'active',
+            'primary_domain_id' => $domain->id,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $capturedAt = Carbon::parse('2026-04-08 10:00:00', 'UTC');
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_api',
+            'source_report' => 'search_console_api_bundle_first',
+            'captured_at' => $capturedAt,
+            'created_at' => Carbon::parse('2026-04-08 10:00:01', 'UTC'),
+            'updated_at' => Carbon::parse('2026-04-08 10:00:01', 'UTC'),
+            'normalized_payload' => [
+                'sitemaps' => [
+                    ['path' => 'https://tie-break-example.com/old-sitemap.xml', 'warnings' => 0, 'errors' => 0],
+                ],
+            ],
+        ]);
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'capture_method' => 'gsc_mcp_api',
+            'source_report' => 'search_console_api_bundle_second',
+            'captured_at' => $capturedAt,
+            'created_at' => Carbon::parse('2026-04-08 10:00:02', 'UTC'),
+            'updated_at' => Carbon::parse('2026-04-08 10:00:02', 'UTC'),
+            'normalized_payload' => [
+                'sitemaps' => [
+                    ['path' => 'https://tie-break-example.com/new-sitemap.xml', 'warnings' => 0, 'errors' => 0],
+                ],
+            ],
+        ]);
+
+        $evidence = app(SearchConsoleIssueEvidenceService::class)
+            ->evidenceMapForProperties(collect([$property->fresh(['primaryDomain', 'propertyDomains.domain'])]));
+
+        $issueEvidence = $evidence['tie-break-example']['page_with_redirect_in_sitemap'];
+
+        $this->assertSame('gsc_mcp_api', $issueEvidence['source_capture_method']);
+        $this->assertSame('search_console_api_bundle_second', $issueEvidence['source_report']);
+        $this->assertSame('https://tie-break-example.com/new-sitemap.xml', $issueEvidence['sitemaps'][0]['path']);
+    }
+}

--- a/tests/Feature/SearchConsoleIssueEvidenceServiceTest.php
+++ b/tests/Feature/SearchConsoleIssueEvidenceServiceTest.php
@@ -151,7 +151,7 @@ class SearchConsoleIssueEvidenceServiceTest extends TestCase
         $this->assertNotNull($issueEvidence['live_captured_at']);
     }
 
-    public function test_it_breaks_same_timestamp_ties_with_newer_created_at_within_a_bucket(): void
+    public function test_it_breaks_same_timestamp_ties_with_newer_updated_at_within_a_bucket(): void
     {
         $domain = Domain::factory()->create([
             'domain' => 'tie-break-example.com',
@@ -197,7 +197,7 @@ class SearchConsoleIssueEvidenceServiceTest extends TestCase
             'capture_method' => 'gsc_mcp_api',
             'source_report' => 'search_console_api_bundle_second',
             'captured_at' => $capturedAt,
-            'created_at' => Carbon::parse('2026-04-08 10:00:02', 'UTC'),
+            'created_at' => Carbon::parse('2026-04-08 10:00:01', 'UTC'),
             'updated_at' => Carbon::parse('2026-04-08 10:00:02', 'UTC'),
             'normalized_payload' => [
                 'sitemaps' => [


### PR DESCRIPTION
## Summary
- replace full historical snapshot scans with latest-per-bucket snapshot queries for Search Console evidence
- keep detail, api, and live evidence selection behavior stable while reducing hot-path query work
- add regression coverage for latest snapshot selection and same-timestamp tie breaking

## Testing
- php artisan test tests/Feature/SearchConsoleIssueEvidenceServiceTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php --filter='issues_endpoint_returns_normalized_open_issue_feed|issues_endpoint_suppresses_page_with_redirect_rows_removed_from_current_sitemap'
- php artisan test tests/Feature/WebPropertyUiTest.php --filter='web_property_detail_hides_suppressed_search_console_issue_summaries|web_property_detail_shows_only_surviving_404_examples_after_live_recheck'
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueEvidenceService.php tests/Feature/SearchConsoleIssueEvidenceServiceTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
