### PR TITLE
Harden Search Console live recheck host resolution

### DIFF
--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -779,15 +779,17 @@ class SearchConsoleIssueLiveRecheckService
 
     private function hostResolvesPublicly(string $host): bool
     {
-        if (app()->runningUnitTests()) {
+        if ($this->shouldBypassDnsLookups()) {
             return true;
         }
 
-        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        $records = $this->dnsRecordsForHost($host);
 
-        if (! is_array($records) || $records === []) {
+        if ($records === []) {
             return false;
         }
+
+        $sawIpAddress = false;
 
         foreach ($records as $record) {
             $ipAddress = $record['ip'] ?? $record['ipv6'] ?? null;
@@ -796,16 +798,33 @@ class SearchConsoleIssueLiveRecheckService
                 continue;
             }
 
+            $sawIpAddress = true;
+
             if (filter_var(
                 $ipAddress,
                 FILTER_VALIDATE_IP,
                 FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-            ) === false) {
-                return false;
+            ) !== false) {
+                return true;
             }
         }
 
-        return true;
+        return false;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function dnsRecordsForHost(string $host): array
+    {
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+
+        return is_array($records) ? $records : [];
+    }
+
+    protected function shouldBypassDnsLookups(): bool
+    {
+        return app()->runningUnitTests();
     }
 
     /**

--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -789,16 +789,12 @@ class SearchConsoleIssueLiveRecheckService
             return false;
         }
 
-        $sawIpAddress = false;
-
         foreach ($records as $record) {
             $ipAddress = $record['ip'] ?? $record['ipv6'] ?? null;
 
             if (! is_string($ipAddress)) {
                 continue;
             }
-
-            $sawIpAddress = true;
 
             if (filter_var(
                 $ipAddress,

--- a/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
+++ b/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
@@ -24,7 +24,7 @@ class SearchConsoleIssueLiveRecheckServiceTest extends TestCase
             {
                 return [
                     ['ip' => '10.0.0.10'],
-                    ['ip' => '203.0.113.20'],
+                    ['ip' => '8.8.8.8'],
                 ];
             }
         };
@@ -71,8 +71,8 @@ class SearchConsoleIssueLiveRecheckServiceTest extends TestCase
             protected function dnsRecordsForHost(string $host): array
             {
                 return [
-                    ['ip' => '198.51.100.10'],
-                    ['ipv6' => '2001:db8::20'],
+                    ['ip' => '1.1.1.1'],
+                    ['ipv6' => '2606:4700:4700::1111'],
                 ];
             }
         };

--- a/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
+++ b/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
@@ -56,6 +56,74 @@ class SearchConsoleIssueLiveRecheckServiceTest extends TestCase
         $this->assertFalse($this->hostResolvesPublicly($service, 'private-only.example.com'));
     }
 
+    public function test_host_resolves_publicly_accepts_hosts_with_only_public_ips(): void
+    {
+        $service = new class extends SearchConsoleIssueLiveRecheckService
+        {
+            protected function shouldBypassDnsLookups(): bool
+            {
+                return false;
+            }
+
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            protected function dnsRecordsForHost(string $host): array
+            {
+                return [
+                    ['ip' => '198.51.100.10'],
+                    ['ipv6' => '2001:db8::20'],
+                ];
+            }
+        };
+
+        $this->assertTrue($this->hostResolvesPublicly($service, 'public-only.example.com'));
+    }
+
+    public function test_host_resolves_publicly_rejects_hosts_with_no_dns_records(): void
+    {
+        $service = new class extends SearchConsoleIssueLiveRecheckService
+        {
+            protected function shouldBypassDnsLookups(): bool
+            {
+                return false;
+            }
+
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            protected function dnsRecordsForHost(string $host): array
+            {
+                return [];
+            }
+        };
+
+        $this->assertFalse($this->hostResolvesPublicly($service, 'missing.example.com'));
+    }
+
+    public function test_host_resolves_publicly_rejects_hosts_with_no_ip_answers(): void
+    {
+        $service = new class extends SearchConsoleIssueLiveRecheckService
+        {
+            protected function shouldBypassDnsLookups(): bool
+            {
+                return false;
+            }
+
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            protected function dnsRecordsForHost(string $host): array
+            {
+                return [
+                    ['host' => 'alias.example.com', 'type' => 'CNAME'],
+                ];
+            }
+        };
+
+        $this->assertFalse($this->hostResolvesPublicly($service, 'cname-only.example.com'));
+    }
+
     private function hostResolvesPublicly(SearchConsoleIssueLiveRecheckService $service, string $host): bool
     {
         $method = new ReflectionMethod(SearchConsoleIssueLiveRecheckService::class, 'hostResolvesPublicly');

--- a/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
+++ b/tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\SearchConsoleIssueLiveRecheckService;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class SearchConsoleIssueLiveRecheckServiceTest extends TestCase
+{
+    public function test_host_resolves_publicly_accepts_hosts_with_at_least_one_public_ip(): void
+    {
+        $service = new class extends SearchConsoleIssueLiveRecheckService
+        {
+            protected function shouldBypassDnsLookups(): bool
+            {
+                return false;
+            }
+
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            protected function dnsRecordsForHost(string $host): array
+            {
+                return [
+                    ['ip' => '10.0.0.10'],
+                    ['ip' => '203.0.113.20'],
+                ];
+            }
+        };
+
+        $this->assertTrue($this->hostResolvesPublicly($service, 'mixed.example.com'));
+    }
+
+    public function test_host_resolves_publicly_rejects_hosts_without_any_public_ip(): void
+    {
+        $service = new class extends SearchConsoleIssueLiveRecheckService
+        {
+            protected function shouldBypassDnsLookups(): bool
+            {
+                return false;
+            }
+
+            /**
+             * @return array<int, array<string, mixed>>
+             */
+            protected function dnsRecordsForHost(string $host): array
+            {
+                return [
+                    ['ip' => '10.0.0.10'],
+                    ['ipv6' => 'fd00::10'],
+                ];
+            }
+        };
+
+        $this->assertFalse($this->hostResolvesPublicly($service, 'private-only.example.com'));
+    }
+
+    private function hostResolvesPublicly(SearchConsoleIssueLiveRecheckService $service, string $host): bool
+    {
+        $method = new ReflectionMethod(SearchConsoleIssueLiveRecheckService::class, 'hostResolvesPublicly');
+        $method->setAccessible(true);
+
+        /** @var bool $result */
+        $result = $method->invoke($service, $host);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
## Summary
- treat hosts with at least one public DNS answer as safe for Search Console live rechecks
- keep hosts with only private or reserved answers blocked
- add focused regression coverage around the host resolution decision

## Testing
- php artisan test tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php
- php artisan test tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
- ./vendor/bin/phpstan analyse app/Services/SearchConsoleIssueLiveRecheckService.php tests/Feature/SearchConsoleIssueLiveRecheckServiceTest.php tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
