### PR TITLE
Consolidate property execution readiness logic

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\PropertyExecutionReadinessResolver;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -322,23 +323,7 @@ class WebProperty extends Model
 
     public function controllerRepository(): ?PropertyRepository
     {
-        $repositories = $this->relationLoaded('repositories') ? $this->repositories : $this->repositories()->get();
-        $orderedRepositories = $repositories
-            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_controller)
-            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
-            ->values();
-
-        $explicitController = $orderedRepositories->first(
-            fn (PropertyRepository $repository) => $repository->is_controller
-        );
-
-        if ($explicitController instanceof PropertyRepository) {
-            return $explicitController;
-        }
-
-        return $orderedRepositories->first(
-            fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
-        ) ?? $orderedRepositories->first();
+        return app(PropertyExecutionReadinessResolver::class)->controllerRepository($this);
     }
 
     /**
@@ -356,36 +341,7 @@ class WebProperty extends Model
      */
     public function executionReadinessSummary(): array
     {
-        $eligibility = $this->coverageEligibility();
-        $controllerRepository = $this->controllerRepository();
-        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
-
-        if (! $eligibility['eligible']) {
-            return [
-                'control_state' => 'not_applicable',
-                'execution_surface' => null,
-                'fleet_managed' => false,
-                ...$controllerRepositorySummary,
-            ];
-        }
-
-        if (! $controllerRepository instanceof PropertyRepository || ! $this->repositoryHasControllerPath($controllerRepository)) {
-            return [
-                'control_state' => 'uncontrolled',
-                'execution_surface' => null,
-                'fleet_managed' => false,
-                ...$controllerRepositorySummary,
-            ];
-        }
-
-        $executionSurface = $this->executionSurfaceForRepository($controllerRepository);
-
-        return [
-            'control_state' => 'controlled',
-            'execution_surface' => $executionSurface,
-            'fleet_managed' => $this->isFleetManagedExecutionSurface($executionSurface),
-            ...$controllerRepositorySummary,
-        ];
+        return app(PropertyExecutionReadinessResolver::class)->executionReadinessForProperty($this);
     }
 
     public function isFleetManagedExecutionSurface(?string $executionSurface): bool
@@ -1504,48 +1460,6 @@ class WebProperty extends Model
             1 => 'ok',
             default => 'unknown',
         };
-    }
-
-    private function repositoryHasControllerPath(PropertyRepository $repository): bool
-    {
-        return is_string($repository->local_path) && trim($repository->local_path) !== '';
-    }
-
-    /**
-     * @return array{
-     *   controller_repo:string|null,
-     *   controller_repo_url:string|null,
-     *   controller_local_path:string|null,
-     *   deployment_provider:string|null,
-     *   deployment_project_name:string|null,
-     *   deployment_project_id:string|null
-     * }
-     */
-    private function controllerRepositorySummary(?PropertyRepository $repository): array
-    {
-        return [
-            'controller_repo' => $repository?->repo_name,
-            'controller_repo_url' => $repository?->repo_url,
-            'controller_local_path' => $repository?->local_path,
-            'deployment_provider' => $repository?->deployment_provider,
-            'deployment_project_name' => $repository?->deployment_project_name,
-            'deployment_project_id' => $repository?->deployment_project_id,
-        ];
-    }
-
-    private function executionSurfaceForRepository(PropertyRepository $repository): string
-    {
-        $framework = strtolower((string) ($repository->framework ?? $this->platform ?? ''));
-
-        if ($repository->repo_name === '_wp-house') {
-            return 'fleet_wordpress_controlled';
-        }
-
-        if (str_contains($framework, 'astro')) {
-            return 'astro_repo_controlled';
-        }
-
-        return 'repository_controlled';
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -17,6 +17,7 @@ class DashboardIssueQueueService
         private readonly DetectedIssueVerificationService $issueVerificationService,
         private readonly SearchConsoleIssueEvidenceService $issueEvidenceService,
         private readonly SearchConsoleIssueActionabilityService $issueActionabilityService,
+        private readonly PropertyExecutionReadinessResolver $executionReadinessResolver,
     ) {}
 
     /**
@@ -903,11 +904,11 @@ class DashboardIssueQueueService
 
         $controllerRepository = $this->controllerRepositoryForProperty($property);
 
-        if (! $controllerRepository instanceof PropertyRepository) {
+        if ($controllerRepository === null) {
             return 'missing_repository';
         }
 
-        $hasControllerPath = $this->repositoryHasControllerPath($controllerRepository);
+        $hasControllerPath = $this->executionReadinessResolver->hasControllerPath($controllerRepository);
 
         return $hasControllerPath ? 'controlled' : 'missing_local_path';
     }
@@ -937,102 +938,12 @@ class DashboardIssueQueueService
      */
     private function executionReadinessForQueue(?WebProperty $property, string $coverageStatus, string $platformProfile): array
     {
-        $controllerRepository = $this->controllerRepositoryForProperty($property);
-        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
-
-        if ($coverageStatus === 'not_required') {
-            return [
-                'control_state' => 'not_applicable',
-                'execution_surface' => null,
-                'fleet_managed' => false,
-                ...$controllerRepositorySummary,
-            ];
-        }
-
-        if ($coverageStatus !== 'controlled') {
-            return [
-                'control_state' => 'uncontrolled',
-                'execution_surface' => null,
-                'fleet_managed' => false,
-                ...$controllerRepositorySummary,
-            ];
-        }
-
-        $executionSurface = $this->executionSurfaceForQueue($controllerRepository, $platformProfile);
-
-        return [
-            'control_state' => 'controlled',
-            'execution_surface' => $executionSurface,
-            'fleet_managed' => $property?->isFleetManagedExecutionSurface($executionSurface) ?? false,
-            ...$controllerRepositorySummary,
-        ];
+        return $this->executionReadinessResolver->executionReadinessForQueue($property, $coverageStatus, $platformProfile);
     }
 
     private function controllerRepositoryForProperty(?WebProperty $property): ?PropertyRepository
     {
-        if (! $property instanceof WebProperty) {
-            return null;
-        }
-
-        $repositories = $property->relationLoaded('repositories')
-            ? $property->getRelation('repositories')
-            : $property->repositories()->get();
-        $orderedRepositories = $repositories
-            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_controller)
-            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
-            ->values();
-
-        $explicitController = $orderedRepositories->first(
-            fn (PropertyRepository $repository) => $repository->is_controller
-        );
-
-        if ($explicitController instanceof PropertyRepository) {
-            return $explicitController;
-        }
-
-        return $orderedRepositories->first(
-            fn (PropertyRepository $repository) => $this->repositoryHasControllerPath($repository)
-        ) ?? $orderedRepositories->first();
-    }
-
-    /**
-     * @return array{
-     *   controller_repo:string|null,
-     *   controller_repo_url:string|null,
-     *   controller_local_path:string|null,
-     *   deployment_provider:string|null,
-     *   deployment_project_name:string|null,
-     *   deployment_project_id:string|null
-     * }
-     */
-    private function controllerRepositorySummary(?PropertyRepository $repository): array
-    {
-        return [
-            'controller_repo' => $repository?->repo_name,
-            'controller_repo_url' => $repository?->repo_url,
-            'controller_local_path' => $repository?->local_path,
-            'deployment_provider' => $repository?->deployment_provider,
-            'deployment_project_name' => $repository?->deployment_project_name,
-            'deployment_project_id' => $repository?->deployment_project_id,
-        ];
-    }
-
-    private function repositoryHasControllerPath(PropertyRepository $repository): bool
-    {
-        return is_string($repository->local_path) && trim($repository->local_path) !== '';
-    }
-
-    private function executionSurfaceForQueue(?PropertyRepository $repository, string $platformProfile): string
-    {
-        if ($repository?->repo_name === '_wp-house') {
-            return 'fleet_wordpress_controlled';
-        }
-
-        if ($platformProfile === 'astro_marketing_managed') {
-            return 'astro_repo_controlled';
-        }
-
-        return 'repository_controlled';
+        return $this->executionReadinessResolver->controllerRepository($property);
     }
 
     /**

--- a/app/Services/PropertyExecutionReadinessResolver.php
+++ b/app/Services/PropertyExecutionReadinessResolver.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PropertyRepository;
+use App\Models\WebProperty;
+
+class PropertyExecutionReadinessResolver
+{
+    public function controllerRepository(?WebProperty $property): ?PropertyRepository
+    {
+        if (! $property instanceof WebProperty) {
+            return null;
+        }
+
+        $repositories = $property->relationLoaded('repositories')
+            ? $property->getRelation('repositories')
+            : $property->repositories()->get();
+        $orderedRepositories = $repositories
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_controller)
+            ->sortByDesc(fn (PropertyRepository $repository) => $repository->is_primary)
+            ->values();
+
+        $explicitController = $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $repository->is_controller
+        );
+
+        if ($explicitController instanceof PropertyRepository) {
+            return $explicitController;
+        }
+
+        return $orderedRepositories->first(
+            fn (PropertyRepository $repository) => $this->hasControllerPath($repository)
+        ) ?? $orderedRepositories->first();
+    }
+
+    public function hasControllerPath(?PropertyRepository $repository): bool
+    {
+        return $repository instanceof PropertyRepository
+            && is_string($repository->local_path)
+            && trim($repository->local_path) !== '';
+    }
+
+    /**
+     * @return array{
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
+     * }
+     */
+    public function controllerRepositorySummary(?PropertyRepository $repository): array
+    {
+        return [
+            'controller_repo' => $repository?->repo_name,
+            'controller_repo_url' => $repository?->repo_url,
+            'controller_local_path' => $repository?->local_path,
+            'deployment_provider' => $repository?->deployment_provider,
+            'deployment_project_name' => $repository?->deployment_project_name,
+            'deployment_project_id' => $repository?->deployment_project_id,
+        ];
+    }
+
+    public function executionSurface(?PropertyRepository $repository, ?WebProperty $property = null, ?string $platformProfile = null): ?string
+    {
+        if (! $repository instanceof PropertyRepository) {
+            return null;
+        }
+
+        if ($repository->repo_name === '_wp-house') {
+            return 'fleet_wordpress_controlled';
+        }
+
+        $propertyPlatform = $property instanceof WebProperty ? $property->platform : null;
+        $framework = strtolower((string) ($repository->framework ?? $propertyPlatform ?? ''));
+
+        if (str_contains($framework, 'astro') || $platformProfile === 'astro_marketing_managed') {
+            return 'astro_repo_controlled';
+        }
+
+        return 'repository_controlled';
+    }
+
+    /**
+     * @return array{
+     *   control_state:string,
+     *   execution_surface:string|null,
+     *   fleet_managed:bool,
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
+     * }
+     */
+    public function executionReadinessForProperty(WebProperty $property): array
+    {
+        $eligibility = $property->coverageEligibility();
+        $controllerRepository = $this->controllerRepository($property);
+        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
+
+        if (! $eligibility['eligible']) {
+            return [
+                'control_state' => 'not_applicable',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                ...$controllerRepositorySummary,
+            ];
+        }
+
+        if (! $this->hasControllerPath($controllerRepository)) {
+            return [
+                'control_state' => 'uncontrolled',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                ...$controllerRepositorySummary,
+            ];
+        }
+
+        $executionSurface = $this->executionSurface($controllerRepository, $property);
+
+        return [
+            'control_state' => 'controlled',
+            'execution_surface' => $executionSurface,
+            'fleet_managed' => $property->isFleetManagedExecutionSurface($executionSurface),
+            ...$controllerRepositorySummary,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   control_state:string,
+     *   execution_surface:string|null,
+     *   fleet_managed:bool,
+     *   controller_repo:string|null,
+     *   controller_repo_url:string|null,
+     *   controller_local_path:string|null,
+     *   deployment_provider:string|null,
+     *   deployment_project_name:string|null,
+     *   deployment_project_id:string|null
+     * }
+     */
+    public function executionReadinessForQueue(?WebProperty $property, string $coverageStatus, string $platformProfile): array
+    {
+        $controllerRepository = $this->controllerRepository($property);
+        $controllerRepositorySummary = $this->controllerRepositorySummary($controllerRepository);
+
+        if ($coverageStatus === 'not_required') {
+            return [
+                'control_state' => 'not_applicable',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                ...$controllerRepositorySummary,
+            ];
+        }
+
+        if ($coverageStatus !== 'controlled') {
+            return [
+                'control_state' => 'uncontrolled',
+                'execution_surface' => null,
+                'fleet_managed' => false,
+                ...$controllerRepositorySummary,
+            ];
+        }
+
+        $executionSurface = $this->executionSurface($controllerRepository, $property, $platformProfile);
+
+        return [
+            'control_state' => 'controlled',
+            'execution_surface' => $executionSurface,
+            'fleet_managed' => $property?->isFleetManagedExecutionSurface($executionSurface) ?? false,
+            ...$controllerRepositorySummary,
+        ];
+    }
+}

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -93,19 +93,21 @@ class DashboardTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $this->instance(DashboardIssueQueueService::class, new class(app(\App\Services\DetectedIssueIdentityService::class), app(\App\Services\DetectedIssueVerificationService::class), app(\App\Services\SearchConsoleIssueEvidenceService::class), app(\App\Services\SearchConsoleIssueActionabilityService::class)) extends DashboardIssueQueueService
+        $this->instance(DashboardIssueQueueService::class, new class(app(\App\Services\DetectedIssueIdentityService::class), app(\App\Services\DetectedIssueVerificationService::class), app(\App\Services\SearchConsoleIssueEvidenceService::class), app(\App\Services\SearchConsoleIssueActionabilityService::class), app(\App\Services\PropertyExecutionReadinessResolver::class)) extends DashboardIssueQueueService
         {
             public function __construct(
                 \App\Services\DetectedIssueIdentityService $issueIdentityService,
                 \App\Services\DetectedIssueVerificationService $issueVerificationService,
                 \App\Services\SearchConsoleIssueEvidenceService $issueEvidenceService,
                 \App\Services\SearchConsoleIssueActionabilityService $issueActionabilityService,
+                \App\Services\PropertyExecutionReadinessResolver $executionReadinessResolver,
             ) {
                 parent::__construct(
                     $issueIdentityService,
                     $issueVerificationService,
                     $issueEvidenceService,
                     $issueActionabilityService,
+                    $executionReadinessResolver,
                 );
             }
 

--- a/tests/Unit/PropertyExecutionReadinessResolverTest.php
+++ b/tests/Unit/PropertyExecutionReadinessResolverTest.php
@@ -33,12 +33,13 @@ class PropertyExecutionReadinessResolverTest extends TestCase
         $resolver = new PropertyExecutionReadinessResolver;
 
         $selectedRepository = $resolver->controllerRepository($property);
+        $selectedRepositorySummary = $resolver->controllerRepositorySummary($selectedRepository);
 
         $this->assertInstanceOf(PropertyRepository::class, $selectedRepository);
         $this->assertSame('moveroo/controller-site', $selectedRepository->repo_name);
         $this->assertSame(
             'moveroo/controller-site',
-            $resolver->executionReadinessForProperty($property)['controller_repo']
+            $selectedRepositorySummary['controller_repo']
         );
     }
 

--- a/tests/Unit/PropertyExecutionReadinessResolverTest.php
+++ b/tests/Unit/PropertyExecutionReadinessResolverTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\PropertyRepository;
+use App\Models\WebProperty;
+use App\Services\PropertyExecutionReadinessResolver;
+use PHPUnit\Framework\TestCase;
+
+class PropertyExecutionReadinessResolverTest extends TestCase
+{
+    public function test_controller_repository_prefers_explicit_controller_repository(): void
+    {
+        $property = new WebProperty([
+            'platform' => 'Astro',
+        ]);
+        $primaryRepository = new PropertyRepository([
+            'repo_name' => 'marketing-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/marketing-site',
+            'framework' => 'Astro',
+            'is_primary' => true,
+            'is_controller' => false,
+        ]);
+        $controllerRepository = new PropertyRepository([
+            'repo_name' => 'moveroo/controller-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/controller-site',
+            'framework' => 'Astro',
+            'is_primary' => false,
+            'is_controller' => true,
+        ]);
+        $property->setRelation('repositories', collect([$primaryRepository, $controllerRepository]));
+
+        $resolver = new PropertyExecutionReadinessResolver;
+
+        $selectedRepository = $resolver->controllerRepository($property);
+
+        $this->assertInstanceOf(PropertyRepository::class, $selectedRepository);
+        $this->assertSame('moveroo/controller-site', $selectedRepository->repo_name);
+        $this->assertSame(
+            'moveroo/controller-site',
+            $resolver->executionReadinessForProperty($property)['controller_repo']
+        );
+    }
+
+    public function test_execution_surface_uses_platform_profile_fallback_for_queue_resolution(): void
+    {
+        $property = new WebProperty([
+            'platform' => null,
+        ]);
+        $repository = new PropertyRepository([
+            'repo_name' => 'cartransport-site',
+            'local_path' => '/Users/jasonhill/Projects/websites/cartransport-site',
+            'framework' => null,
+            'is_primary' => true,
+            'is_controller' => true,
+        ]);
+        $property->setRelation('repositories', collect([$repository]));
+
+        $resolver = new PropertyExecutionReadinessResolver;
+
+        $queueSummary = $resolver->executionReadinessForQueue($property, 'controlled', 'astro_marketing_managed');
+
+        $this->assertSame('controlled', $queueSummary['control_state']);
+        $this->assertSame('astro_repo_controlled', $queueSummary['execution_surface']);
+        $this->assertTrue($queueSummary['fleet_managed']);
+    }
+}


### PR DESCRIPTION
## Summary
- extract shared controller-repo and execution-surface resolution into a dedicated service
- move `WebProperty` and `DashboardIssueQueueService` onto that shared resolver to remove drift-prone duplicate logic
- add focused resolver coverage and update the dashboard test harness for the new dependency

## Testing
- `php artisan test tests/Unit/PropertyExecutionReadinessResolverTest.php`
- `php artisan test tests/Feature/WebPropertyApiTest.php --filter='web_properties_summary_prefers_explicit_controller_repo_for_astro_surface|web_properties_summary_prefers_any_controller_repo_with_local_path|web_properties_summary_can_mark_allowlisted_repository_controlled_property_as_fleet_managed'`
- `php artisan test tests/Feature/DashboardTest.php --filter='dashboard_should_fix_cards_fall_back_to_secondary_reasons_when_primary_reasons_are_empty|dashboard_shows_must_fix_and_should_fix_domain_queues'`
- `./vendor/bin/phpstan analyse app/Services/PropertyExecutionReadinessResolver.php app/Models/WebProperty.php app/Services/DashboardIssueQueueService.php tests/Unit/PropertyExecutionReadinessResolverTest.php --memory-limit=2G`
- `composer pr:preflight`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
