### PR TITLE
Add search console snapshot lookup index

### DIFF
--- a/database/migrations/2026_04_09_103330_add_latest_bucket_lookup_index_to_search_console_issue_snapshots_table.php
+++ b/database/migrations/2026_04_09_103330_add_latest_bucket_lookup_index_to_search_console_issue_snapshots_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('search_console_issue_snapshots', function (Blueprint $table) {
+            $table->index(
+                [
+                    'web_property_id',
+                    'issue_class',
+                    'capture_method',
+                    'captured_at',
+                    'created_at',
+                    'updated_at',
+                ],
+                'sc_issue_snapshot_latest_bucket_lookup_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('search_console_issue_snapshots', function (Blueprint $table) {
+            $table->dropIndex('sc_issue_snapshot_latest_bucket_lookup_idx');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a composite index to support the latest-per-bucket Search Console snapshot lookup query
- align the index columns with the `web_property_id / issue_class / capture_method / captured_at / created_at / updated_at` access path
- keep the rollback clean with an explicit index name

## Testing
- `php artisan test tests/Feature/SearchConsoleIssueEvidenceServiceTest.php`
- `vendor/bin/pint --dirty`
- `composer pr:preflight`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
