### PR TITLE
Extract web property summary builders

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Services\PropertyExecutionReadinessResolver;
+use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
+use App\Services\WebPropertyGscEvidenceSummaryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -674,28 +676,7 @@ class WebProperty extends Model
      */
     public function canonicalOriginSummary(): array
     {
-        $scheme = $this->canonicalOriginSchemeValue();
-        $host = $this->canonicalOriginHostValue();
-        $baseUrl = $scheme !== null && $host !== null ? $scheme.'://'.$host : null;
-        $policy = $this->canonical_origin_policy === 'known' ? 'known' : 'unknown';
-        $hasExplicitCanonicalOrigin = is_string($this->canonical_origin_scheme)
-            && $this->canonical_origin_scheme !== ''
-            && is_string($this->canonical_origin_host)
-            && $this->canonical_origin_host !== '';
-
-        return [
-            'scheme' => $scheme,
-            'host' => $host,
-            'base_url' => $baseUrl,
-            'policy' => $policy,
-            'scope' => 'property_only',
-            'enforcement_eligible' => (bool) $this->canonical_origin_enforcement_eligible
-                && $policy === 'known'
-                && $hasExplicitCanonicalOrigin,
-            'owned_subdomains' => $this->ownedSubdomainHosts($host),
-            'excluded_subdomains' => $this->normalizedCanonicalOriginSubdomains($this->canonical_origin_excluded_subdomains),
-            'sitemap_policy_known' => (bool) $this->canonical_origin_sitemap_policy_known,
-        ];
+        return app(WebPropertyCanonicalOriginSummaryBuilder::class)->build($this);
     }
 
     /**
@@ -791,88 +772,6 @@ class WebProperty extends Model
         ];
     }
 
-    private function canonicalOriginSchemeValue(): ?string
-    {
-        if (is_string($this->canonical_origin_scheme) && $this->canonical_origin_scheme !== '') {
-            return strtolower($this->canonical_origin_scheme);
-        }
-
-        $scheme = parse_url((string) $this->production_url, PHP_URL_SCHEME);
-
-        return is_string($scheme) && $scheme !== '' ? strtolower($scheme) : null;
-    }
-
-    private function canonicalOriginHostValue(): ?string
-    {
-        if (is_string($this->canonical_origin_host) && $this->canonical_origin_host !== '') {
-            return strtolower($this->canonical_origin_host);
-        }
-
-        $host = parse_url((string) $this->production_url, PHP_URL_HOST);
-
-        return is_string($host) && $host !== '' ? strtolower($host) : null;
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function normalizedCanonicalOriginSubdomains(mixed $value): array
-    {
-        if (! is_array($value)) {
-            return [];
-        }
-
-        return collect($value)
-            ->map(fn (mixed $host): ?string => $this->normalizeCanonicalOriginHost($host))
-            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
-            ->unique()
-            ->values()
-            ->all();
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    private function ownedSubdomainHosts(?string $canonicalHost): array
-    {
-        if (! is_string($canonicalHost) || $canonicalHost === '') {
-            return [];
-        }
-
-        return $this->orderedDomainLinks()
-            ->map(fn (WebPropertyDomain $link): ?string => $this->normalizeCanonicalOriginHost($link->domain?->domain))
-            ->filter(
-                fn (?string $host): bool => is_string($host)
-                    && $host !== ''
-                    && $host !== $canonicalHost
-                    && Str::endsWith($host, '.'.$canonicalHost)
-            )
-            ->unique()
-            ->values()
-            ->all();
-    }
-
-    private function normalizeCanonicalOriginHost(mixed $value): ?string
-    {
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $trimmed = trim($value);
-
-        if ($trimmed === '') {
-            return null;
-        }
-
-        if (Str::contains($trimmed, '://')) {
-            $host = parse_url($trimmed, PHP_URL_HOST);
-
-            return is_string($host) && $host !== '' ? strtolower($host) : null;
-        }
-
-        return strtolower(rtrim($trimmed, '.'));
-    }
-
     /**
      * @return array{
      *   has_issue_detail: bool,
@@ -885,29 +784,7 @@ class WebProperty extends Model
      */
     public function gscEvidenceSummary(): array
     {
-        $hasIssueDetail = (bool) ($this->getAttribute('has_gsc_issue_detail') ?? false);
-        $snapshotCount = (int) ($this->getAttribute('gsc_issue_detail_snapshot_count') ?? 0);
-        $latestCapturedAt = $this->getAttribute('gsc_issue_detail_last_captured_at');
-        $hasApiEnrichment = (bool) ($this->getAttribute('has_gsc_api_enrichment') ?? false);
-        $apiSnapshotCount = (int) ($this->getAttribute('gsc_api_snapshot_count') ?? 0);
-        $latestApiCapturedAt = $this->getAttribute('gsc_api_last_captured_at');
-
-        return [
-            'has_issue_detail' => $hasIssueDetail,
-            'issue_detail_snapshot_count' => $snapshotCount,
-            'latest_issue_detail_captured_at' => $latestCapturedAt instanceof \DateTimeInterface
-                ? $latestCapturedAt->format(\DateTimeInterface::ATOM)
-                : (is_string($latestCapturedAt) && $latestCapturedAt !== ''
-                    ? \Illuminate\Support\Carbon::parse($latestCapturedAt, 'UTC')->utc()->toIso8601String()
-                    : null),
-            'has_api_enrichment' => $hasApiEnrichment,
-            'api_snapshot_count' => $apiSnapshotCount,
-            'latest_api_captured_at' => $latestApiCapturedAt instanceof \DateTimeInterface
-                ? $latestApiCapturedAt->format(\DateTimeInterface::ATOM)
-                : (is_string($latestApiCapturedAt) && $latestApiCapturedAt !== ''
-                    ? \Illuminate\Support\Carbon::parse($latestApiCapturedAt, 'UTC')->utc()->toIso8601String()
-                    : null),
-        ];
+        return app(WebPropertyGscEvidenceSummaryBuilder::class)->build($this);
     }
 
     /**

--- a/app/Services/WebPropertyCanonicalOriginSummaryBuilder.php
+++ b/app/Services/WebPropertyCanonicalOriginSummaryBuilder.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Support\Str;
+
+class WebPropertyCanonicalOriginSummaryBuilder
+{
+    /**
+     * @return array{
+     *   scheme: string|null,
+     *   host: string|null,
+     *   base_url: string|null,
+     *   policy: 'known'|'unknown',
+     *   scope: 'property_only',
+     *   enforcement_eligible: bool,
+     *   owned_subdomains: array<int, string>,
+     *   excluded_subdomains: array<int, string>,
+     *   sitemap_policy_known: bool
+     * }
+     */
+    public function build(WebProperty $property): array
+    {
+        $scheme = $this->canonicalOriginSchemeValue($property);
+        $host = $this->canonicalOriginHostValue($property);
+        $baseUrl = $scheme !== null && $host !== null ? $scheme.'://'.$host : null;
+        $policy = $property->canonical_origin_policy === 'known' ? 'known' : 'unknown';
+        $hasExplicitCanonicalOrigin = is_string($property->canonical_origin_scheme)
+            && $property->canonical_origin_scheme !== ''
+            && is_string($property->canonical_origin_host)
+            && $property->canonical_origin_host !== '';
+
+        return [
+            'scheme' => $scheme,
+            'host' => $host,
+            'base_url' => $baseUrl,
+            'policy' => $policy,
+            'scope' => 'property_only',
+            'enforcement_eligible' => (bool) $property->canonical_origin_enforcement_eligible
+                && $policy === 'known'
+                && $hasExplicitCanonicalOrigin,
+            'owned_subdomains' => $this->ownedSubdomainHosts($property, $host),
+            'excluded_subdomains' => $this->normalizedCanonicalOriginSubdomains($property->canonical_origin_excluded_subdomains),
+            'sitemap_policy_known' => (bool) $property->canonical_origin_sitemap_policy_known,
+        ];
+    }
+
+    private function canonicalOriginSchemeValue(WebProperty $property): ?string
+    {
+        if (is_string($property->canonical_origin_scheme) && $property->canonical_origin_scheme !== '') {
+            return strtolower($property->canonical_origin_scheme);
+        }
+
+        $scheme = parse_url((string) $property->production_url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && $scheme !== '' ? strtolower($scheme) : null;
+    }
+
+    private function canonicalOriginHostValue(WebProperty $property): ?string
+    {
+        if (is_string($property->canonical_origin_host) && $property->canonical_origin_host !== '') {
+            return strtolower($property->canonical_origin_host);
+        }
+
+        $host = parse_url((string) $property->production_url, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? strtolower($host) : null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizedCanonicalOriginSubdomains(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return collect($value)
+            ->map(fn (mixed $host): ?string => $this->normalizeCanonicalOriginHost($host))
+            ->filter(fn (?string $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function ownedSubdomainHosts(WebProperty $property, ?string $canonicalHost): array
+    {
+        if (! is_string($canonicalHost) || $canonicalHost === '') {
+            return [];
+        }
+
+        return $property->orderedDomainLinks()
+            ->map(fn (WebPropertyDomain $link): ?string => $this->normalizeCanonicalOriginHost($link->domain?->domain))
+            ->filter(
+                fn (?string $host): bool => is_string($host)
+                    && $host !== ''
+                    && $host !== $canonicalHost
+                    && Str::endsWith($host, '.'.$canonicalHost)
+            )
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function normalizeCanonicalOriginHost(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (Str::contains($trimmed, '://')) {
+            $host = parse_url($trimmed, PHP_URL_HOST);
+
+            return is_string($host) && $host !== '' ? strtolower($host) : null;
+        }
+
+        return strtolower(rtrim($trimmed, '.'));
+    }
+}

--- a/app/Services/WebPropertyGscEvidenceSummaryBuilder.php
+++ b/app/Services/WebPropertyGscEvidenceSummaryBuilder.php
@@ -3,7 +3,7 @@
 namespace App\Services;
 
 use App\Models\WebProperty;
-use Carbon\Carbon;
+use Illuminate\Support\Carbon;
 
 class WebPropertyGscEvidenceSummaryBuilder
 {

--- a/app/Services/WebPropertyGscEvidenceSummaryBuilder.php
+++ b/app/Services/WebPropertyGscEvidenceSummaryBuilder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use Carbon\Carbon;
+
+class WebPropertyGscEvidenceSummaryBuilder
+{
+    /**
+     * @return array{
+     *   has_issue_detail: bool,
+     *   issue_detail_snapshot_count: int,
+     *   latest_issue_detail_captured_at: string|null,
+     *   has_api_enrichment: bool,
+     *   api_snapshot_count: int,
+     *   latest_api_captured_at: string|null
+     * }
+     */
+    public function build(WebProperty $property): array
+    {
+        $hasIssueDetail = (bool) ($property->getAttribute('has_gsc_issue_detail') ?? false);
+        $snapshotCount = (int) ($property->getAttribute('gsc_issue_detail_snapshot_count') ?? 0);
+        $latestCapturedAt = $property->getAttribute('gsc_issue_detail_last_captured_at');
+        $hasApiEnrichment = (bool) ($property->getAttribute('has_gsc_api_enrichment') ?? false);
+        $apiSnapshotCount = (int) ($property->getAttribute('gsc_api_snapshot_count') ?? 0);
+        $latestApiCapturedAt = $property->getAttribute('gsc_api_last_captured_at');
+
+        return [
+            'has_issue_detail' => $hasIssueDetail,
+            'issue_detail_snapshot_count' => $snapshotCount,
+            'latest_issue_detail_captured_at' => $this->normalizeTimestamp($latestCapturedAt),
+            'has_api_enrichment' => $hasApiEnrichment,
+            'api_snapshot_count' => $apiSnapshotCount,
+            'latest_api_captured_at' => $this->normalizeTimestamp($latestApiCapturedAt),
+        ];
+    }
+
+    private function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::ATOM);
+        }
+
+        if (is_string($value) && $value !== '') {
+            return Carbon::parse($value, 'UTC')->utc()->toIso8601String();
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/WebPropertySummaryBuildersTest.php
+++ b/tests/Unit/WebPropertySummaryBuildersTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Domain;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
+use App\Services\WebPropertyGscEvidenceSummaryBuilder;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\TestCase;
+
+class WebPropertySummaryBuildersTest extends TestCase
+{
+    public function test_canonical_origin_builder_uses_safe_fallbacks_and_normalizes_subdomains(): void
+    {
+        $property = new WebProperty([
+            'production_url' => 'https://movingagain.com.au/services',
+            'canonical_origin_policy' => 'unknown',
+            'canonical_origin_enforcement_eligible' => false,
+            'canonical_origin_excluded_subdomains' => [
+                ' https://portal.movingagain.com.au/login ',
+                'quotes.movingagain.com.au.',
+                'quotes.movingagain.com.au',
+                '',
+            ],
+            'canonical_origin_sitemap_policy_known' => false,
+        ]);
+
+        $property->setRelation('propertyDomains', collect([
+            $this->domainLink('movingagain.com.au', 'primary', true),
+            $this->domainLink('quoting.movingagain.com.au', 'subdomain'),
+            $this->domainLink('www.movingagain.com.au', 'redirect'),
+            $this->domainLink('example.com', 'subdomain'),
+        ]));
+
+        $summary = (new WebPropertyCanonicalOriginSummaryBuilder)->build($property);
+
+        $this->assertSame('https', $summary['scheme']);
+        $this->assertSame('movingagain.com.au', $summary['host']);
+        $this->assertSame('https://movingagain.com.au', $summary['base_url']);
+        $this->assertSame('unknown', $summary['policy']);
+        $this->assertSame('property_only', $summary['scope']);
+        $this->assertFalse($summary['enforcement_eligible']);
+        $this->assertSame(
+            ['quoting.movingagain.com.au', 'www.movingagain.com.au'],
+            $summary['owned_subdomains']
+        );
+        $this->assertSame(
+            ['portal.movingagain.com.au', 'quotes.movingagain.com.au'],
+            $summary['excluded_subdomains']
+        );
+        $this->assertFalse($summary['sitemap_policy_known']);
+    }
+
+    public function test_canonical_origin_builder_requires_explicit_known_origin_for_enforcement(): void
+    {
+        $property = new WebProperty([
+            'production_url' => 'https://backloading-au.com.au',
+            'canonical_origin_policy' => 'known',
+            'canonical_origin_enforcement_eligible' => true,
+            'canonical_origin_scheme' => null,
+            'canonical_origin_host' => null,
+        ]);
+        $property->setRelation('propertyDomains', collect());
+
+        $summary = (new WebPropertyCanonicalOriginSummaryBuilder)->build($property);
+
+        $this->assertSame('https', $summary['scheme']);
+        $this->assertSame('backloading-au.com.au', $summary['host']);
+        $this->assertSame('https://backloading-au.com.au', $summary['base_url']);
+        $this->assertSame('known', $summary['policy']);
+        $this->assertFalse($summary['enforcement_eligible']);
+    }
+
+    public function test_gsc_evidence_builder_normalizes_string_and_datetime_timestamps(): void
+    {
+        $property = new WebProperty;
+        $property->forceFill([
+            'has_gsc_issue_detail' => true,
+            'gsc_issue_detail_snapshot_count' => 2,
+            'gsc_issue_detail_last_captured_at' => '2026-04-09 09:14:03',
+            'has_gsc_api_enrichment' => true,
+            'gsc_api_snapshot_count' => 3,
+            'gsc_api_last_captured_at' => CarbonImmutable::parse('2026-04-09T01:02:03+10:00'),
+        ]);
+
+        $summary = (new WebPropertyGscEvidenceSummaryBuilder)->build($property);
+
+        $this->assertTrue($summary['has_issue_detail']);
+        $this->assertSame(2, $summary['issue_detail_snapshot_count']);
+        $this->assertSame('2026-04-09T09:14:03+00:00', $summary['latest_issue_detail_captured_at']);
+        $this->assertTrue($summary['has_api_enrichment']);
+        $this->assertSame(3, $summary['api_snapshot_count']);
+        $this->assertSame('2026-04-09T01:02:03+10:00', $summary['latest_api_captured_at']);
+    }
+
+    public function test_gsc_evidence_builder_returns_stable_null_defaults(): void
+    {
+        $summary = (new WebPropertyGscEvidenceSummaryBuilder)->build(new WebProperty);
+
+        $this->assertSame([
+            'has_issue_detail' => false,
+            'issue_detail_snapshot_count' => 0,
+            'latest_issue_detail_captured_at' => null,
+            'has_api_enrichment' => false,
+            'api_snapshot_count' => 0,
+            'latest_api_captured_at' => null,
+        ], $summary);
+    }
+
+    private function domainLink(string $domainName, string $usageType, bool $isCanonical = false): WebPropertyDomain
+    {
+        $domain = new Domain([
+            'domain' => $domainName,
+        ]);
+
+        $link = new WebPropertyDomain([
+            'usage_type' => $usageType,
+            'is_canonical' => $isCanonical,
+        ]);
+        $link->setRelation('domain', $domain);
+
+        return $link;
+    }
+}


### PR DESCRIPTION
## Summary
- extract `canonical_origin` and `gsc_evidence_summary` contract building from `WebProperty` into dedicated builders
- remove the now-dead canonical-origin helper methods from the model
- add focused unit coverage to keep the extracted builder output stable

## Testing
- php artisan test tests/Unit/WebPropertySummaryBuildersTest.php
- php artisan test tests/Feature/WebPropertyCanonicalOriginTest.php
- php artisan test tests/Feature/WebPropertyApiTest.php --filter='test_web_properties_summary_returns_contract_v1_payload|test_web_properties_summary_surfaces_property_level_gsc_issue_detail_coverage|test_web_properties_summary_surfaces_property_level_gsc_api_enrichment_coverage'
- ./vendor/bin/phpstan analyse app/Services/WebPropertyCanonicalOriginSummaryBuilder.php app/Services/WebPropertyGscEvidenceSummaryBuilder.php app/Models/WebProperty.php tests/Unit/WebPropertySummaryBuildersTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
