### PR TITLE
Add stable site identity property contract

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Services\PropertyExecutionReadinessResolver;
 use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
 use App\Services\WebPropertyGscEvidenceSummaryBuilder;
+use App\Services\WebPropertySiteIdentitySummaryBuilder;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -19,6 +20,8 @@ use Illuminate\Support\Str;
  * @property string $id
  * @property string $slug
  * @property string $name
+ * @property string|null $site_identity_site_name
+ * @property string|null $site_identity_legal_name
  * @property string $property_type
  * @property string $status
  * @property string|null $primary_domain_id
@@ -66,6 +69,8 @@ class WebProperty extends Model
     protected $fillable = [
         'slug',
         'name',
+        'site_identity_site_name',
+        'site_identity_legal_name',
         'property_type',
         'status',
         'primary_domain_id',
@@ -740,6 +745,7 @@ class WebProperty extends Model
             'property_type' => $this->property_type,
             'status' => $this->status,
             'primary_domain' => $this->primaryDomainName(),
+            'site_identity' => $this->siteIdentitySummary(),
             'production_url' => $this->production_url,
             'staging_url' => $this->staging_url,
             'canonical_origin' => $this->canonicalOriginSummary(),
@@ -770,6 +776,20 @@ class WebProperty extends Model
             'gsc_evidence_summary' => $this->gscEvidenceSummary(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
+    }
+
+    /**
+     * @return array{
+     *   site_name: string|null,
+     *   legal_name: string|null,
+     *   primary_domain: string|null,
+     *   quote_portal: string|null,
+     *   contact_page: string|null
+     * }
+     */
+    public function siteIdentitySummary(): array
+    {
+        return app(WebPropertySiteIdentitySummaryBuilder::class)->build($this);
     }
 
     /**

--- a/app/Services/DashboardIssueQueueService.php
+++ b/app/Services/DashboardIssueQueueService.php
@@ -46,7 +46,7 @@ class DashboardIssueQueueService
             ->where('is_active', true)
             ->with([
                 'platform',
-                'webProperties:id,slug,name,property_type,status,production_url,canonical_origin_scheme,canonical_origin_host,canonical_origin_policy,canonical_origin_enforcement_eligible,canonical_origin_excluded_subdomains,canonical_origin_sitemap_policy_known,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,target_legacy_bookings_replacement_url,target_legacy_payments_replacement_url,conversion_links_scanned_at,legacy_moveroo_endpoint_scan',
+                'webProperties:id,slug,name,site_identity_site_name,site_identity_legal_name,property_type,status,production_url,canonical_origin_scheme,canonical_origin_host,canonical_origin_policy,canonical_origin_enforcement_eligible,canonical_origin_excluded_subdomains,canonical_origin_sitemap_policy_known,current_household_quote_url,current_household_booking_url,current_vehicle_quote_url,current_vehicle_booking_url,target_household_quote_url,target_household_booking_url,target_vehicle_quote_url,target_vehicle_booking_url,target_moveroo_subdomain_url,target_contact_us_page_url,target_legacy_bookings_replacement_url,target_legacy_payments_replacement_url,conversion_links_scanned_at,legacy_moveroo_endpoint_scan',
                 'webProperties.propertyDomains.domain:id,domain',
                 'webProperties.repositories:id,web_property_id,repo_name,repo_url,local_path,framework,repo_provider,deployment_provider,deployment_project_name,deployment_project_id,is_primary,is_controller',
                 'webProperties.latestSeoBaselineForProperty',
@@ -866,6 +866,7 @@ class DashboardIssueQueueService
         $item['deployment_project_id'] = $executionReadiness['deployment_project_id'];
         $item['conversion_links'] = $property?->conversionLinkSummary();
         $item['canonical_origin'] = $property?->canonicalOriginSummary();
+        $item['site_identity'] = $property?->siteIdentitySummary();
 
         return $item;
     }

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -116,6 +116,7 @@ class DetectedIssueSummaryService
         $propertyName = null;
         $conversionLinks = null;
         $canonicalOrigin = null;
+        $siteIdentity = null;
         $platformProfile = null;
         $baselineSurface = null;
 
@@ -126,6 +127,8 @@ class DetectedIssueSummaryService
                     'id',
                     'slug',
                     'name',
+                    'site_identity_site_name',
+                    'site_identity_legal_name',
                     'property_type',
                     'production_url',
                     'canonical_origin_scheme',
@@ -156,6 +159,7 @@ class DetectedIssueSummaryService
                 $propertyName = $property->name;
                 $conversionLinks = $property->conversionLinkSummary();
                 $canonicalOrigin = $property->canonicalOriginSummary();
+                $siteIdentity = $property->siteIdentitySummary();
             }
         }
 
@@ -188,6 +192,7 @@ class DetectedIssueSummaryService
             'controller_repo_url' => null,
             'conversion_links' => $conversionLinks,
             'canonical_origin' => $canonicalOrigin,
+            'site_identity' => $siteIdentity,
             'evidence' => [
                 'primary_reasons' => [],
                 'secondary_reasons' => [],
@@ -273,6 +278,7 @@ class DetectedIssueSummaryService
                 'controller_repo_url' => is_string($item['controller_repo_url'] ?? null) ? $item['controller_repo_url'] : null,
                 'conversion_links' => is_array($item['conversion_links'] ?? null) ? $item['conversion_links'] : null,
                 'canonical_origin' => is_array($item['canonical_origin'] ?? null) ? $item['canonical_origin'] : null,
+                'site_identity' => is_array($item['site_identity'] ?? null) ? $item['site_identity'] : null,
                 'evidence' => [
                     'primary_reasons' => [$issueEntry['reason']],
                     'secondary_reasons' => array_values(array_filter(

--- a/app/Services/WebPropertySiteIdentitySummaryBuilder.php
+++ b/app/Services/WebPropertySiteIdentitySummaryBuilder.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use Illuminate\Support\Str;
+
+class WebPropertySiteIdentitySummaryBuilder
+{
+    /**
+     * @return array{
+     *   site_name: string|null,
+     *   legal_name: string|null,
+     *   primary_domain: string|null,
+     *   quote_portal: string|null,
+     *   contact_page: string|null
+     * }
+     */
+    public function build(WebProperty $property): array
+    {
+        return [
+            'site_name' => $this->siteName($property),
+            'legal_name' => $this->normalizedText($property->site_identity_legal_name),
+            'primary_domain' => $this->normalizedOriginUrl(
+                data_get($property->canonicalOriginSummary(), 'base_url')
+                    ?? $property->production_url
+            ),
+            'quote_portal' => $this->quotePortal($property),
+            'contact_page' => $this->normalizedPageUrl($property->target_contact_us_page_url),
+        ];
+    }
+
+    private function siteName(WebProperty $property): ?string
+    {
+        $explicit = $this->normalizedText($property->site_identity_site_name);
+
+        if ($explicit !== null) {
+            return $explicit;
+        }
+
+        $fallback = $this->normalizedText($property->name);
+
+        if ($fallback === null) {
+            return null;
+        }
+
+        return preg_replace('/\s+(website|site)$/i', '', $fallback) ?: $fallback;
+    }
+
+    private function quotePortal(WebProperty $property): ?string
+    {
+        $candidate = $property->target_moveroo_subdomain_url
+            ?? $property->target_household_quote_url
+            ?? $property->target_household_booking_url
+            ?? $property->target_vehicle_quote_url
+            ?? $property->target_vehicle_booking_url;
+
+        return $this->normalizedOriginUrl($candidate);
+    }
+
+    private function normalizedText(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizedOriginUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($value));
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $origin = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $origin .= ':'.$parts['port'];
+        }
+
+        return $origin.'/';
+    }
+
+    private function normalizedPageUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($value));
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $normalized = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $normalized .= ':'.$parts['port'];
+        }
+
+        $path = (string) ($parts['path'] ?? '/');
+
+        return $normalized.($path !== '' ? $path : '/');
+    }
+}

--- a/database/migrations/2026_04_12_084259_add_site_identity_fields_to_web_properties_table.php
+++ b/database/migrations/2026_04_12_084259_add_site_identity_fields_to_web_properties_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table) {
+            $table->string('site_identity_site_name')->nullable()->after('name');
+            $table->string('site_identity_legal_name')->nullable()->after('site_identity_site_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_properties', function (Blueprint $table) {
+            $table->dropColumn([
+                'site_identity_site_name',
+                'site_identity_legal_name',
+            ]);
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.11",
                 "@tailwindcss/vite": "^4.1.18",
-                "axios": "^1.11.0",
+                "axios": "^1.15.0",
                 "concurrently": "^9.0.1",
                 "laravel-vite-plugin": "^2.1.0",
                 "tailwindcss": "^4.1.18",
@@ -1257,15 +1257,15 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/call-bind-apply-helpers": {
@@ -2149,11 +2149,14 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/require-directory": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "devDependencies": {
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/vite": "^4.1.18",
-        "axios": "^1.11.0",
+        "axios": "^1.15.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.1.0",
         "tailwindcss": "^4.1.18",

--- a/tests/Feature/DashboardPriorityQueueApiTest.php
+++ b/tests/Feature/DashboardPriorityQueueApiTest.php
@@ -31,6 +31,8 @@ class DashboardPriorityQueueApiTest extends TestCase
         $mustFixProperty = WebProperty::factory()->create([
             'slug' => 'must-fix-site',
             'name' => 'Must Fix Site',
+            'site_identity_site_name' => 'Must Fix',
+            'site_identity_legal_name' => 'Must Fix Australia',
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $mustFixDomain->id,
@@ -230,6 +232,11 @@ class DashboardPriorityQueueApiTest extends TestCase
             ->assertJsonPath('must_fix.0.canonical_origin.policy', 'known')
             ->assertJsonPath('must_fix.0.canonical_origin.scope', 'property_only')
             ->assertJsonPath('must_fix.0.canonical_origin.enforcement_eligible', true)
+            ->assertJsonPath('must_fix.0.site_identity.site_name', 'Must Fix')
+            ->assertJsonPath('must_fix.0.site_identity.legal_name', 'Must Fix Australia')
+            ->assertJsonPath('must_fix.0.site_identity.primary_domain', 'https://must-fix.example.com/')
+            ->assertJsonPath('must_fix.0.site_identity.quote_portal', 'https://must-fix.moveroo.com.au/')
+            ->assertJsonPath('must_fix.0.site_identity.contact_page', 'https://must-fix.example.com/contact-us')
             ->assertJsonPath('must_fix.0.conversion_links.target.household_quote', 'https://quote.must-fix.example.com/household')
             ->assertJsonPath('must_fix.0.conversion_links.target.moveroo_subdomain', 'https://must-fix.moveroo.com.au')
             ->assertJsonPath('must_fix.0.conversion_links.target.contact_us_page', 'https://must-fix.example.com/contact-us')

--- a/tests/Feature/DetectedIssueApiTest.php
+++ b/tests/Feature/DetectedIssueApiTest.php
@@ -31,6 +31,8 @@ class DetectedIssueApiTest extends TestCase
         $redirectProperty = WebProperty::factory()->create([
             'slug' => 'redirect-issue-site',
             'name' => 'Redirect Issue Site',
+            'site_identity_site_name' => 'Redirect Issue',
+            'site_identity_legal_name' => 'Redirect Issue Australia',
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $redirectDomain->id,
@@ -358,6 +360,11 @@ class DetectedIssueApiTest extends TestCase
         $this->assertSame('https://redirect-issue.moveroo.com.au/bookings', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.url'));
         $this->assertSame('https://removalist.net/booking/create', data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_url'));
         $this->assertTrue((bool) data_get($redirectIssue, 'conversion_links.legacy_endpoints.legacy_booking_endpoint.resolved_host_changed'));
+        $this->assertSame('Redirect Issue', data_get($redirectIssue, 'site_identity.site_name'));
+        $this->assertSame('Redirect Issue Australia', data_get($redirectIssue, 'site_identity.legal_name'));
+        $this->assertSame('https://redirect-issue.example.com/', data_get($redirectIssue, 'site_identity.primary_domain'));
+        $this->assertSame('https://redirect-issue.moveroo.com.au/', data_get($redirectIssue, 'site_identity.quote_portal'));
+        $this->assertSame('https://redirect-issue.example.com/contact-us', data_get($redirectIssue, 'site_identity.contact_page'));
         $this->assertSame('https', data_get($redirectIssue, 'canonical_origin.scheme'));
         $this->assertSame('redirect-issue.example.com', data_get($redirectIssue, 'canonical_origin.host'));
         $this->assertSame('https://redirect-issue.example.com', data_get($redirectIssue, 'canonical_origin.base_url'));
@@ -421,6 +428,11 @@ class DetectedIssueApiTest extends TestCase
             ->assertJsonPath('issue_id', $redirectIssue['issue_id'])
             ->assertJsonPath('issue_class', 'page_with_redirect_in_sitemap')
             ->assertJsonPath('conversion_links.target.moveroo_subdomain', 'https://redirect-issue.moveroo.com.au')
+            ->assertJsonPath('site_identity.site_name', 'Redirect Issue')
+            ->assertJsonPath('site_identity.legal_name', 'Redirect Issue Australia')
+            ->assertJsonPath('site_identity.primary_domain', 'https://redirect-issue.example.com/')
+            ->assertJsonPath('site_identity.quote_portal', 'https://redirect-issue.moveroo.com.au/')
+            ->assertJsonPath('site_identity.contact_page', 'https://redirect-issue.example.com/contact-us')
             ->assertJsonPath('canonical_origin.host', 'redirect-issue.example.com')
             ->assertJsonPath('canonical_origin.enforcement_eligible', true)
             ->assertJsonPath('conversion_links.target.contact_us_page', 'https://redirect-issue.example.com/contact-us')

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -48,6 +48,8 @@ class WebPropertyApiTest extends TestCase
         $property = WebProperty::factory()->create([
             'slug' => 'moveroo-website',
             'name' => 'Moveroo Website',
+            'site_identity_site_name' => 'Moveroo',
+            'site_identity_legal_name' => 'Moveroo Australia',
             'property_type' => 'marketing_site',
             'status' => 'active',
             'platform' => 'Astro',
@@ -206,6 +208,11 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('contract_version', 1)
             ->assertJsonPath('web_properties.0.slug', 'moveroo-website')
             ->assertJsonPath('web_properties.0.primary_domain', 'moveroo.com.au')
+            ->assertJsonPath('web_properties.0.site_identity.site_name', 'Moveroo')
+            ->assertJsonPath('web_properties.0.site_identity.legal_name', 'Moveroo Australia')
+            ->assertJsonPath('web_properties.0.site_identity.primary_domain', 'https://moveroo.com.au/')
+            ->assertJsonPath('web_properties.0.site_identity.quote_portal', 'https://wemove.moveroo.com.au/')
+            ->assertJsonPath('web_properties.0.site_identity.contact_page', 'https://moveroo.com.au/contact-us')
             ->assertJsonPath('web_properties.0.canonical_origin.scheme', 'https')
             ->assertJsonPath('web_properties.0.canonical_origin.host', 'moveroo.com.au')
             ->assertJsonPath('web_properties.0.canonical_origin.base_url', 'https://moveroo.com.au')
@@ -366,6 +373,9 @@ class WebPropertyApiTest extends TestCase
             'property_type' => 'website',
             'status' => 'active',
             'primary_domain_id' => $domain->id,
+            'production_url' => 'https://stable-links.example.com/some-page',
+            'site_identity_site_name' => null,
+            'site_identity_legal_name' => null,
             'conversion_links_scanned_at' => null,
             'current_household_quote_url' => null,
             'current_household_booking_url' => null,
@@ -400,6 +410,13 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.slug', 'stable-links-site')
             ->assertJsonStructure([
                 'web_properties' => [[
+                    'site_identity' => [
+                        'site_name',
+                        'legal_name',
+                        'primary_domain',
+                        'quote_portal',
+                        'contact_page',
+                    ],
                     'conversion_links' => [
                         'scanned_at',
                         'current' => [
@@ -425,6 +442,11 @@ class WebPropertyApiTest extends TestCase
                     ],
                 ]],
             ])
+            ->assertJsonPath('web_properties.0.site_identity.site_name', 'Stable Links')
+            ->assertJsonPath('web_properties.0.site_identity.legal_name', null)
+            ->assertJsonPath('web_properties.0.site_identity.primary_domain', 'https://stable-links.example.com/')
+            ->assertJsonPath('web_properties.0.site_identity.quote_portal', null)
+            ->assertJsonPath('web_properties.0.site_identity.contact_page', null)
             ->assertJsonPath('web_properties.0.conversion_links.scanned_at', null)
             ->assertJsonPath('web_properties.0.conversion_links.current.household_quote', null)
             ->assertJsonPath('web_properties.0.conversion_links.current.household_booking', null)
@@ -448,6 +470,13 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.slug', 'stable-links-site')
             ->assertJsonStructure([
                 'data' => [
+                    'site_identity' => [
+                        'site_name',
+                        'legal_name',
+                        'primary_domain',
+                        'quote_portal',
+                        'contact_page',
+                    ],
                     'conversion_links' => [
                         'scanned_at',
                         'current' => [
@@ -473,6 +502,11 @@ class WebPropertyApiTest extends TestCase
                     ],
                 ],
             ])
+            ->assertJsonPath('data.site_identity.site_name', 'Stable Links')
+            ->assertJsonPath('data.site_identity.legal_name', null)
+            ->assertJsonPath('data.site_identity.primary_domain', 'https://stable-links.example.com/')
+            ->assertJsonPath('data.site_identity.quote_portal', null)
+            ->assertJsonPath('data.site_identity.contact_page', null)
             ->assertJsonPath('data.conversion_links.scanned_at', null)
             ->assertJsonPath('data.conversion_links.current.household_quote', null)
             ->assertJsonPath('data.conversion_links.current.household_booking', null)

--- a/tests/Unit/WebPropertySummaryBuildersTest.php
+++ b/tests/Unit/WebPropertySummaryBuildersTest.php
@@ -7,6 +7,7 @@ use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
 use App\Services\WebPropertyGscEvidenceSummaryBuilder;
+use App\Services\WebPropertySiteIdentitySummaryBuilder;
 use Carbon\CarbonImmutable;
 use PHPUnit\Framework\TestCase;
 
@@ -106,6 +107,52 @@ class WebPropertySummaryBuildersTest extends TestCase
             'has_api_enrichment' => false,
             'api_snapshot_count' => 0,
             'latest_api_captured_at' => null,
+        ], $summary);
+    }
+
+    public function test_site_identity_builder_uses_explicit_fields_and_aligned_targets(): void
+    {
+        $property = new WebProperty([
+            'name' => 'WeMove Website',
+            'site_identity_site_name' => 'WeMove',
+            'site_identity_legal_name' => 'WeMove Australia',
+            'production_url' => 'https://wemove.com.au/services',
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'wemove.com.au',
+            'canonical_origin_policy' => 'known',
+            'target_moveroo_subdomain_url' => 'https://quotes.wemove.com.au',
+            'target_contact_us_page_url' => 'https://quotes.wemove.com.au/contact?from=footer',
+        ]);
+        $property->setRelation('propertyDomains', collect([
+            $this->domainLink('wemove.com.au', 'primary', true),
+        ]));
+
+        $summary = (new WebPropertySiteIdentitySummaryBuilder)->build($property);
+
+        $this->assertSame([
+            'site_name' => 'WeMove',
+            'legal_name' => 'WeMove Australia',
+            'primary_domain' => 'https://wemove.com.au/',
+            'quote_portal' => 'https://quotes.wemove.com.au/',
+            'contact_page' => 'https://quotes.wemove.com.au/contact',
+        ], $summary);
+    }
+
+    public function test_site_identity_builder_returns_stable_nulls_and_infers_site_name(): void
+    {
+        $property = new WebProperty([
+            'name' => 'Moveroo Website',
+        ]);
+        $property->setRelation('propertyDomains', collect());
+
+        $summary = (new WebPropertySiteIdentitySummaryBuilder)->build($property);
+
+        $this->assertSame([
+            'site_name' => 'Moveroo',
+            'legal_name' => null,
+            'primary_domain' => null,
+            'quote_portal' => null,
+            'contact_page' => null,
         ], $summary);
     }
 


### PR DESCRIPTION
## Summary
- add a stable top-level `site_identity` block to web property payloads and Fleet-adjacent issue/queue payloads
- persist explicit `site_identity_site_name` and `site_identity_legal_name` fields on `web_properties`
- derive `primary_domain`, `quote_portal`, and `contact_page` from canonical/conversion-link targets with stable null keys

## Testing
- php artisan test tests/Unit/WebPropertySummaryBuildersTest.php
- php artisan test tests/Feature/WebPropertyApiTest.php --filter='test_web_properties_summary_returns_contract_v1_payload|test_property_apis_always_expose_fully_shaped_conversion_links_contract'
- php artisan test tests/Feature/DashboardPriorityQueueApiTest.php --filter=test_priority_queue_endpoint_returns_actionable_domains_only
- php artisan test tests/Feature/DetectedIssueApiTest.php --filter=test_issues_endpoint_returns_normalized_open_issue_feed
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Services/WebPropertySiteIdentitySummaryBuilder.php app/Services/DashboardIssueQueueService.php app/Services/DetectedIssueSummaryService.php tests/Unit/WebPropertySummaryBuildersTest.php tests/Feature/WebPropertyApiTest.php tests/Feature/DashboardPriorityQueueApiTest.php tests/Feature/DetectedIssueApiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
