### PR TITLE
Derive vehicle quote link from moveroo subdomain

### DIFF
--- a/app/Livewire/WebPropertyDetail.php
+++ b/app/Livewire/WebPropertyDetail.php
@@ -132,7 +132,7 @@ class WebPropertyDetail extends Component
 
         $this->targetHouseholdQuoteUrl = $this->property->target_household_quote_url;
         $this->targetHouseholdBookingUrl = $this->property->target_household_booking_url;
-        $this->targetVehicleQuoteUrl = $this->property->target_vehicle_quote_url;
+        $this->targetVehicleQuoteUrl = data_get($this->property->conversionLinkSummary(), 'target.vehicle_quote');
         $this->targetVehicleBookingUrl = $this->property->target_vehicle_booking_url;
         $this->targetMoverooSubdomainUrl = $this->property->target_moveroo_subdomain_url;
         $this->targetContactUsPageUrl = $this->property->target_contact_us_page_url;

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -637,13 +637,38 @@ class WebProperty extends Model
         return [
             'household_quote' => $this->target_household_quote_url,
             'household_booking' => $this->target_household_booking_url,
-            'vehicle_quote' => $this->target_vehicle_quote_url,
+            'vehicle_quote' => $this->targetVehicleQuoteTargetUrl(),
             'vehicle_booking' => $this->target_vehicle_booking_url,
             'moveroo_subdomain' => $this->target_moveroo_subdomain_url,
             'contact_us_page' => $this->target_contact_us_page_url,
             'legacy_bookings_replacement' => $this->target_legacy_bookings_replacement_url,
             'legacy_payments_replacement' => $this->target_legacy_payments_replacement_url,
         ];
+    }
+
+    private function targetVehicleQuoteTargetUrl(): ?string
+    {
+        if (is_string($this->target_vehicle_quote_url) && trim($this->target_vehicle_quote_url) !== '') {
+            return $this->target_vehicle_quote_url;
+        }
+
+        if (! is_string($this->target_moveroo_subdomain_url) || trim($this->target_moveroo_subdomain_url) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($this->target_moveroo_subdomain_url));
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $origin = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $origin .= ':'.$parts['port'];
+        }
+
+        return $origin.'/quote/vehicle';
     }
 
     /**

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -524,6 +524,48 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.conversion_links.legacy_endpoints.legacy_payment_endpoint', null);
     }
 
+    public function test_property_apis_derive_vehicle_quote_target_from_moveroo_subdomain_when_missing(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'wemove.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'wemove-website',
+            'name' => 'WeMove Website',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://wemove.com.au',
+            'target_vehicle_quote_url' => null,
+            'target_moveroo_subdomain_url' => 'https://quotes.wemove.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $headers = [
+            'Authorization' => 'Bearer test-api-key',
+        ];
+
+        $this->withHeaders($headers)
+            ->getJson('/api/web-properties-summary')
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.conversion_links.target.moveroo_subdomain', 'https://quotes.wemove.com.au')
+            ->assertJsonPath('web_properties.0.conversion_links.target.vehicle_quote', 'https://quotes.wemove.com.au/quote/vehicle');
+
+        $this->withHeaders($headers)
+            ->getJson('/api/web-properties/wemove-website')
+            ->assertOk()
+            ->assertJsonPath('data.conversion_links.target.moveroo_subdomain', 'https://quotes.wemove.com.au')
+            ->assertJsonPath('data.conversion_links.target.vehicle_quote', 'https://quotes.wemove.com.au/quote/vehicle');
+    }
+
     public function test_property_apis_surface_latest_external_link_inventory_for_linked_domains(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -95,6 +95,39 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertNull($property->fresh()->target_household_quote_url);
     }
 
+    public function test_property_detail_prefills_vehicle_quote_from_moveroo_subdomain_when_missing(): void
+    {
+        $user = User::factory()->create();
+        $domain = Domain::factory()->create([
+            'domain' => 'movingagain.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'movingagain-website',
+            'name' => 'Moving Again Website',
+            'primary_domain_id' => $domain->id,
+            'target_vehicle_quote_url' => null,
+            'target_moveroo_subdomain_url' => 'https://quotes.movingagain.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $this->assertSame(
+            'https://quotes.movingagain.com.au/quote/vehicle',
+            $property->conversionLinkSummary()['target']['vehicle_quote']
+        );
+
+        Livewire::actingAs($user)
+            ->test(WebPropertyDetail::class, ['propertySlug' => 'movingagain-website'])
+            ->assertSet('targetVehicleQuoteUrl', 'https://quotes.movingagain.com.au/quote/vehicle');
+    }
+
     public function test_property_detail_can_refresh_current_conversion_links_from_live_navigation(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- derive `conversion_links.target.vehicle_quote` from `target_moveroo_subdomain_url` when the explicit vehicle quote target is empty
- prefill the web property conversion-links form with the same derived vehicle quote value
- add API and property-detail regression coverage for the derived Fleet-facing link

## Testing
- php artisan test tests/Feature/WebPropertyConversionLinksTest.php --filter=test_property_detail_prefills_vehicle_quote_from_moveroo_subdomain_when_missing
- php artisan test tests/Feature/WebPropertyApiTest.php --filter=test_property_apis_derive_vehicle_quote_target_from_moveroo_subdomain_when_missing
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Livewire/WebPropertyDetail.php tests/Feature/WebPropertyApiTest.php tests/Feature/WebPropertyConversionLinksTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight