### PR TITLE
Add bulk vehicle quote subdomain command

### DIFF
--- a/app/Console/Commands/CreateVehicleQuoteSubdomains.php
+++ b/app/Console/Commands/CreateVehicleQuoteSubdomains.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Domain;
+use App\Services\DomainDnsRecordService;
+use App\Services\DomainSubdomainService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class CreateVehicleQuoteSubdomains extends Command
+{
+    private const string TARGET_IP = '170.64.144.64';
+
+    /**
+     * @var array<string, string>
+     */
+    private const array HOSTNAME_MAP = [
+        'cartransport.au' => 'quoting',
+        'cartransportaus.com.au' => 'quoting',
+        'cartransportwithpersonalitems.com.au' => 'quoting',
+        'interstate-car-transport.com.au' => 'quoting',
+        'interstatecarcarriers.com.au' => 'quoting',
+        'movemycar.com.au' => 'portal',
+        'movingcars.com.au' => 'quoting',
+        'supercheapcartransport.com.au' => 'portal',
+        'transportnondrivablecars.com.au' => 'quoting',
+        'vehicle.net.au' => 'quoting',
+    ];
+
+    protected $signature = 'domains:create-vehicle-quote-subdomains
+                            {--domain=* : Restrict the run to one or more configured vehicle transport domains}
+                            {--dry-run : Show what would be created without writing DNS records}';
+
+    protected $description = 'Create generic quote-portal A records for the configured vehicle transport domains';
+
+    public function handle(DomainDnsRecordService $dnsRecordService, DomainSubdomainService $subdomainService): int
+    {
+        $configuredDomains = collect(self::HOSTNAME_MAP);
+        $requestedDomains = collect($this->option('domain'))
+            ->filter(fn (mixed $domain): bool => is_string($domain) && trim($domain) !== '')
+            ->map(fn (string $domain): string => strtolower(trim($domain)))
+            ->values();
+
+        if ($requestedDomains->isNotEmpty()) {
+            $unknownDomains = $requestedDomains
+                ->reject(fn (string $domain): bool => $configuredDomains->has($domain))
+                ->values();
+
+            if ($unknownDomains->isNotEmpty()) {
+                $this->error('Unsupported domain selection: '.$unknownDomains->implode(', '));
+                $this->line('Supported domains: '.$configuredDomains->keys()->implode(', '));
+
+                return self::FAILURE;
+            }
+
+            $configuredDomains = $configuredDomains->only($requestedDomains->all());
+        }
+
+        /** @var Collection<string, Domain> $domainsByName */
+        $domainsByName = Domain::query()
+            ->with([
+                'dnsRecords' => fn ($query) => $query->select('id', 'domain_id', 'host'),
+                'subdomains' => fn ($query) => $query->select('id', 'domain_id', 'subdomain', 'full_domain')->where('is_active', true),
+            ])
+            ->whereIn('domain', $configuredDomains->keys()->all())
+            ->get()
+            ->keyBy(fn (Domain $domain): string => strtolower($domain->domain));
+
+        $dryRun = (bool) $this->option('dry-run');
+        $created = 0;
+        $existing = 0;
+        $failed = 0;
+        $missing = 0;
+
+        foreach ($configuredDomains as $domainName => $hostLabel) {
+            /** @var Domain|null $domain */
+            $domain = $domainsByName->get($domainName);
+
+            if (! $domain instanceof Domain) {
+                $missing++;
+                $this->warn("Skipping {$domainName}: domain is not present in Domain Monitor.");
+
+                continue;
+            }
+
+            $fullHostname = $hostLabel.'.'.$domain->domain;
+
+            if ($this->hostnameAlreadyExists($domain, $hostLabel, $fullHostname)) {
+                $existing++;
+                $this->line("Skipping {$fullHostname}: hostname already exists.");
+
+                continue;
+            }
+
+            if ($dryRun) {
+                $created++;
+                $this->info("Would create {$fullHostname} -> ".self::TARGET_IP);
+
+                continue;
+            }
+
+            $result = $dnsRecordService->saveRecord($domain, [
+                'host' => $hostLabel,
+                'type' => 'A',
+                'value' => self::TARGET_IP,
+                'ttl' => 300,
+                'priority' => null,
+            ]);
+
+            if ($result['ok'] === false) {
+                $failed++;
+                $error = array_key_exists('error', $result) ? $result['error'] : 'unknown error';
+                $this->error("Failed to create {$fullHostname}: {$error}");
+
+                continue;
+            }
+
+            $created++;
+            $this->info("Created {$fullHostname} -> ".self::TARGET_IP);
+
+            $syncResult = $subdomainService->syncFromDnsRecords($domain->fresh('dnsRecords', 'subdomains'));
+
+            if ($syncResult['ok'] === false) {
+                $error = array_key_exists('error', $syncResult) ? $syncResult['error'] : 'unknown error';
+                $this->warn("  DNS record created, but subdomain sync needs review: {$error}");
+            }
+        }
+
+        $verb = $dryRun ? 'Planned' : 'Created';
+        $this->newLine();
+        $this->info("{$verb}: {$created}");
+        $this->line("Existing/skipped: {$existing}");
+        $this->line("Missing from Domain Monitor: {$missing}");
+
+        if ($failed > 0) {
+            $this->line("Failed: {$failed}");
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function hostnameAlreadyExists(Domain $domain, string $hostLabel, string $fullHostname): bool
+    {
+        $hostnames = $domain->dnsRecords
+            ->pluck('host')
+            ->merge($domain->subdomains->pluck('subdomain'))
+            ->merge($domain->subdomains->pluck('full_domain'))
+            ->filter(fn (mixed $host): bool => is_string($host) && trim($host) !== '')
+            ->map(fn (string $host): string => strtolower(trim($host)))
+            ->values();
+
+        return $hostnames->contains(strtolower($hostLabel))
+            || $hostnames->contains(strtolower($fullHostname));
+    }
+}

--- a/tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
+++ b/tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DnsRecord;
+use App\Models\Domain;
+use App\Services\DomainDnsRecordService;
+use App\Services\DomainSubdomainService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class CreateVehicleQuoteSubdomainsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_reports_planned_creations_and_skips_existing_hostnames_in_dry_run(): void
+    {
+        $carTransport = Domain::factory()->create([
+            'domain' => 'cartransport.au',
+            'is_active' => true,
+        ]);
+
+        DnsRecord::create([
+            'domain_id' => $carTransport->id,
+            'host' => 'quotes.cartransport.au',
+            'type' => 'A',
+            'value' => '209.38.88.239',
+            'ttl' => 300,
+        ]);
+
+        $movingCars = Domain::factory()->create([
+            'domain' => 'movingcars.com.au',
+            'is_active' => true,
+        ]);
+
+        DnsRecord::create([
+            'domain_id' => $movingCars->id,
+            'host' => 'movingcars.com.au',
+            'type' => 'A',
+            'value' => '216.150.1.1',
+            'ttl' => 300,
+        ]);
+
+        app()->instance(DomainDnsRecordService::class, new class extends DomainDnsRecordService
+        {
+            /**
+             * @param  array{host: string, type: string, value: string, ttl: int, priority: int|null}  $recordData
+             */
+            public function saveRecord(Domain $domain, array $recordData, ?string $editingDnsRecordId = null): array
+            {
+                throw new \RuntimeException('saveRecord should not be called during dry run.');
+            }
+        });
+
+        app()->instance(DomainSubdomainService::class, new class extends DomainSubdomainService
+        {
+            public function syncFromDnsRecords(Domain $domain): array
+            {
+                throw new \RuntimeException('syncFromDnsRecords should not be called during dry run.');
+            }
+        });
+
+        $exitCode = Artisan::call('domains:create-vehicle-quote-subdomains', [
+            '--dry-run' => true,
+            '--domain' => ['cartransport.au', 'movingcars.com.au'],
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('Would create quoting.cartransport.au -> 170.64.144.64', $output);
+        $this->assertStringContainsString('Would create quoting.movingcars.com.au -> 170.64.144.64', $output);
+        $this->assertStringContainsString('Planned: 2', $output);
+        $this->assertStringContainsString('Existing/skipped: 0', $output);
+    }
+
+    public function test_it_creates_the_configured_record_and_syncs_subdomains(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'movemycar.com.au',
+            'is_active' => true,
+        ]);
+
+        $dnsRecordService = new class extends DomainDnsRecordService
+        {
+            /**
+             * @var array<int, array{domain: string, host: string, type: string, value: string, ttl: int, priority: int|null}>
+             */
+            public array $calls = [];
+
+            /**
+             * @param  array{host: string, type: string, value: string, ttl: int, priority: int|null}  $recordData
+             */
+            public function saveRecord(Domain $domain, array $recordData, ?string $editingDnsRecordId = null): array
+            {
+                $this->calls[] = [
+                    'domain' => $domain->domain,
+                    'host' => $recordData['host'],
+                    'type' => $recordData['type'],
+                    'value' => $recordData['value'],
+                    'ttl' => $recordData['ttl'],
+                    'priority' => $recordData['priority'],
+                ];
+
+                return ['ok' => true, 'message' => 'DNS record added successfully!'];
+            }
+        };
+
+        $subdomainService = new class extends DomainSubdomainService
+        {
+            /**
+             * @var array<int, string>
+             */
+            public array $domains = [];
+
+            public function syncFromDnsRecords(Domain $domain): array
+            {
+                $this->domains[] = $domain->domain;
+
+                return [
+                    'ok' => true,
+                    'message' => 'Synced 1 new subdomain(s) and refreshed DNS resolution for 1 active subdomain(s).',
+                ];
+            }
+        };
+
+        app()->instance(DomainDnsRecordService::class, $dnsRecordService);
+        app()->instance(DomainSubdomainService::class, $subdomainService);
+
+        $exitCode = Artisan::call('domains:create-vehicle-quote-subdomains', [
+            '--domain' => ['movemycar.com.au'],
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $output = Artisan::output();
+        $this->assertSame([
+            [
+                'domain' => 'movemycar.com.au',
+                'host' => 'portal',
+                'type' => 'A',
+                'value' => '170.64.144.64',
+                'ttl' => 300,
+                'priority' => null,
+            ],
+        ], $dnsRecordService->calls);
+        $this->assertSame(['movemycar.com.au'], $subdomainService->domains);
+
+        $this->assertStringContainsString('Created portal.movemycar.com.au -> 170.64.144.64', $output);
+        $this->assertStringContainsString('Created: 1', $output);
+    }
+
+    public function test_it_rejects_unknown_domain_selection(): void
+    {
+        $exitCode = Artisan::call('domains:create-vehicle-quote-subdomains', [
+            '--domain' => ['not-in-scope.example.com'],
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unsupported domain selection: not-in-scope.example.com', Artisan::output());
+    }
+}


### PR DESCRIPTION
## Summary
- add a one-off bulk command for creating the agreed generic quote-portal A records on the vehicle-transport Fleet domains
- protect the run with fixed domain-to-host mappings, hostname collision checks, and a dry-run mode
- sync Domain Monitor subdomain inventory immediately after each created DNS record

## Testing
- php artisan test tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/CreateVehicleQuoteSubdomains.php tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
