### PR TITLE
Fix vehicle quote subdomain DNS priority

### DIFF
--- a/app/Console/Commands/CreateVehicleQuoteSubdomains.php
+++ b/app/Console/Commands/CreateVehicleQuoteSubdomains.php
@@ -105,7 +105,7 @@ class CreateVehicleQuoteSubdomains extends Command
                 'type' => 'A',
                 'value' => self::TARGET_IP,
                 'ttl' => 300,
-                'priority' => null,
+                'priority' => 0,
             ]);
 
             if ($result['ok'] === false) {

--- a/tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
+++ b/tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
@@ -45,7 +45,7 @@ class CreateVehicleQuoteSubdomainsCommandTest extends TestCase
         app()->instance(DomainDnsRecordService::class, new class extends DomainDnsRecordService
         {
             /**
-             * @param  array{host: string, type: string, value: string, ttl: int, priority: int|null}  $recordData
+             * @param  array{host: string, type: string, value: string, ttl: int, priority: int}  $recordData
              */
             public function saveRecord(Domain $domain, array $recordData, ?string $editingDnsRecordId = null): array
             {
@@ -86,12 +86,12 @@ class CreateVehicleQuoteSubdomainsCommandTest extends TestCase
         $dnsRecordService = new class extends DomainDnsRecordService
         {
             /**
-             * @var array<int, array{domain: string, host: string, type: string, value: string, ttl: int, priority: int|null}>
+             * @var array<int, array{domain: string, host: string, type: string, value: string, ttl: int, priority: int}>
              */
             public array $calls = [];
 
             /**
-             * @param  array{host: string, type: string, value: string, ttl: int, priority: int|null}  $recordData
+             * @param  array{host: string, type: string, value: string, ttl: int, priority: int}  $recordData
              */
             public function saveRecord(Domain $domain, array $recordData, ?string $editingDnsRecordId = null): array
             {
@@ -143,7 +143,7 @@ class CreateVehicleQuoteSubdomainsCommandTest extends TestCase
                 'type' => 'A',
                 'value' => '170.64.144.64',
                 'ttl' => 300,
-                'priority' => null,
+                'priority' => 0,
             ],
         ], $dnsRecordService->calls);
         $this->assertSame(['movemycar.com.au'], $subdomainService->domains);


### PR DESCRIPTION
## Summary
- pass an integer DNS priority when creating the bulk vehicle quote A records
- keep the command behavior the same otherwise
- update the command test to assert the registrar payload uses priority 0

## Testing
- php artisan test tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/CreateVehicleQuoteSubdomains.php tests/Feature/CreateVehicleQuoteSubdomainsCommandTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
