### PR TITLE
Add owned subdomain drift audit command

### DIFF
--- a/app/Services/PropertyConversionLinkScanner.php
+++ b/app/Services/PropertyConversionLinkScanner.php
@@ -77,6 +77,90 @@ class PropertyConversionLinkScanner
      */
     public function extractAnchors(string $html, string $baseUrl): array
     {
+        return $this->extractAnchorsForXPath($html, $baseUrl, '//nav//a[@href] | //header//a[@href]');
+    }
+
+    /**
+     * @return array<int, array{href: string, text: string, bucket: string|null, score: int}>
+     */
+    public function extractAllAnchors(string $html, string $baseUrl): array
+    {
+        return $this->extractAnchorsForXPath($html, $baseUrl, '//a[@href]');
+    }
+
+    /**
+     * @return array{
+     *   homepage_url: string,
+     *   canonical_moveroo_host: string|null,
+     *   owned_subdomain_hosts: array<int, string>,
+     *   offending_links: array<int, array{href: string, text: string, host: string}>
+     * }
+     */
+    public function auditOwnedSubdomainLinkDriftForProperty(WebProperty $property): array
+    {
+        $homepageUrl = $this->homepageUrlForProperty($property);
+
+        if ($homepageUrl === null) {
+            throw new \RuntimeException('Property does not have a scannable production URL or primary domain.');
+        }
+
+        if (! $this->isAllowedScanUrl($homepageUrl, $property)) {
+            throw new \RuntimeException('Property homepage URL is not allowed for conversion-link scanning.');
+        }
+
+        $response = $this->http
+            ->timeout(15)
+            ->withoutRedirecting()
+            ->withHeaders([
+                'Accept' => 'text/html,application/xhtml+xml',
+                'User-Agent' => 'DomainMonitorConversionLinkScanner/1.0 (+https://monitor.again.com.au)',
+            ])
+            ->get($homepageUrl);
+
+        if (! $response->successful()) {
+            throw new \RuntimeException(sprintf(
+                'Homepage URL returned non-success HTTP status [%d].',
+                $response->status()
+            ));
+        }
+
+        $canonicalMoverooHost = $this->targetMoverooHost($property);
+        $ownedSubdomainHosts = $this->ownedSubdomainHosts($property);
+        $offendingHosts = array_values(array_diff($ownedSubdomainHosts, array_filter([$canonicalMoverooHost])));
+
+        $offendingLinks = collect($this->extractAllAnchors($response->body(), $homepageUrl))
+            ->map(function (array $anchor): ?array {
+                $host = parse_url($anchor['href'], PHP_URL_HOST);
+
+                if (! is_string($host) || $host === '') {
+                    return null;
+                }
+
+                return [
+                    'href' => $anchor['href'],
+                    'text' => $anchor['text'],
+                    'host' => Str::lower($host),
+                ];
+            })
+            ->filter(fn (?array $anchor): bool => is_array($anchor))
+            ->filter(fn (array $anchor): bool => in_array($anchor['host'], $offendingHosts, true))
+            ->unique(fn (array $anchor): string => $anchor['host'].'|'.$anchor['href'])
+            ->values()
+            ->all();
+
+        return [
+            'homepage_url' => $homepageUrl,
+            'canonical_moveroo_host' => $canonicalMoverooHost,
+            'owned_subdomain_hosts' => $ownedSubdomainHosts,
+            'offending_links' => $offendingLinks,
+        ];
+    }
+
+    /**
+     * @return array<int, array{href: string, text: string, bucket: string|null, score: int}>
+     */
+    private function extractAnchorsForXPath(string $html, string $baseUrl, string $query): array
+    {
         $dom = new DOMDocument;
 
         $previousInternalErrors = libxml_use_internal_errors(true);
@@ -85,7 +169,7 @@ class PropertyConversionLinkScanner
         libxml_use_internal_errors($previousInternalErrors);
 
         $xpath = new DOMXPath($dom);
-        $nodes = $xpath->query('//nav//a[@href] | //header//a[@href]');
+        $nodes = $xpath->query($query);
 
         $anchors = [];
 
@@ -242,6 +326,23 @@ class PropertyConversionLinkScanner
         }
 
         return array_values(array_unique($hosts));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function ownedSubdomainHosts(WebProperty $property): array
+    {
+        return $property->orderedDomainLinks()
+            ->filter(function ($link): bool {
+                return $link->usage_type === 'subdomain'
+                    && is_string($link->domain?->domain)
+                    && $link->domain->domain !== '';
+            })
+            ->map(fn ($link): string => Str::lower((string) $link->domain?->domain))
+            ->unique()
+            ->values()
+            ->all();
     }
 
     private function normalizeUrl(string $href, string $baseUrl): ?string

--- a/routes/console.php
+++ b/routes/console.php
@@ -157,6 +157,84 @@ Artisan::command('fleet:scan-conversion-links {propertySlug? : Optional web prop
     return $failed > 0 ? Command::FAILURE : Command::SUCCESS;
 })->purpose('Scan live homepage navigation for current quote and booking links on Fleet properties.');
 
+Artisan::command('fleet:audit-owned-subdomain-links {propertySlug? : Optional web property slug}', function (PropertyConversionLinkScanner $scanner) {
+    $propertySlug = $this->argument('propertySlug');
+
+    $query = WebProperty::query()
+        ->with(['primaryDomain', 'propertyDomains.domain']);
+
+    if (is_string($propertySlug) && $propertySlug !== '') {
+        $query->where('slug', $propertySlug);
+    } else {
+        $query->fleetFocus();
+    }
+
+    $properties = $query
+        ->orderBy('name')
+        ->get();
+
+    if ($properties->isEmpty()) {
+        $this->warn('No web properties matched the owned-subdomain audit scope.');
+
+        return Command::INVALID;
+    }
+
+    $clean = 0;
+    $drifted = 0;
+    $failed = 0;
+
+    foreach ($properties as $property) {
+        try {
+            $audit = $scanner->auditOwnedSubdomainLinkDriftForProperty($property);
+
+            if ($audit['canonical_moveroo_host'] === null) {
+                $this->line(sprintf('[%s] skipped: no canonical moveroo subdomain configured.', $property->slug));
+                $clean++;
+
+                continue;
+            }
+
+            $offendingLinks = $audit['offending_links'];
+
+            if ($offendingLinks === []) {
+                $this->info(sprintf('[%s] clean: no owned-subdomain drift links found.', $property->slug));
+                $clean++;
+
+                continue;
+            }
+
+            $drifted++;
+            $this->warn(sprintf(
+                '[%s] drift: canonical=%s | offending links=%d',
+                $property->slug,
+                $audit['canonical_moveroo_host'],
+                count($offendingLinks)
+            ));
+
+            foreach ($offendingLinks as $link) {
+                $this->line(sprintf(
+                    '  - [%s] %s (%s)',
+                    $link['host'],
+                    $link['href'],
+                    $link['text'] !== '' ? $link['text'] : 'no anchor text'
+                ));
+            }
+        } catch (\Throwable $exception) {
+            $this->warn(sprintf('[%s] audit failed: %s', $property->slug, $exception->getMessage()));
+            $failed++;
+        }
+    }
+
+    $this->line(sprintf(
+        'Owned-subdomain audit complete. Clean [%d], drifted [%d], failed [%d].',
+        $clean,
+        $drifted,
+        $failed
+    ));
+
+    return ($drifted > 0 || $failed > 0) ? Command::FAILURE : Command::SUCCESS;
+})->purpose('Audit Fleet properties for links to owned subdomains other than the canonical Moveroo subdomain.');
+
 Artisan::command('analytics:import-search-console-evidence {property : Web property slug} {path : Path to the Google Search Console page indexing export ZIP} {--captured-by= : Optional captured_by value}', function (ManualSearchConsoleEvidenceImporter $importer) {
     $propertyArgument = $this->argument('property');
     $pathArgument = $this->argument('path');

--- a/tests/Feature/WebPropertyConversionLinksTest.php
+++ b/tests/Feature/WebPropertyConversionLinksTest.php
@@ -780,4 +780,158 @@ class WebPropertyConversionLinksTest extends TestCase
         $this->assertSame('https://removalists.moveroo.com.au/quote/household', $property->current_household_quote_url);
         $this->assertNull($property->current_household_booking_url);
     }
+
+    public function test_fleet_owned_subdomain_audit_is_clean_when_only_canonical_moveroo_subdomain_is_linked(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'wemove.com.au',
+            'is_active' => true,
+        ]);
+
+        $canonicalSubdomain = Domain::factory()->create([
+            'domain' => 'quotes.wemove.com.au',
+            'is_active' => true,
+        ]);
+
+        $legacySubdomain = Domain::factory()->create([
+            'domain' => 'removalportal.wemove.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'wemove-com-au',
+            'name' => 'wemove.com.au',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://wemove.com.au',
+            'target_moveroo_subdomain_url' => 'https://quotes.wemove.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $canonicalSubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $legacySubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://wemove.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://quotes.wemove.com.au/quote/household">Get Quote</a>
+                            <a href="https://quotes.wemove.com.au/contact">Contact</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->assertSame(0, Artisan::call('fleet:audit-owned-subdomain-links', ['propertySlug' => 'wemove-com-au']));
+        $this->assertStringContainsString('clean: no owned-subdomain drift links found', Artisan::output());
+    }
+
+    public function test_fleet_owned_subdomain_audit_flags_links_to_other_owned_subdomains(): void
+    {
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $tag = DomainTag::firstOrCreate(
+            ['name' => 'fleet.live'],
+            [
+                'priority' => 95,
+                'color' => '#2563EB',
+            ]
+        );
+
+        $domain = Domain::factory()->create([
+            'domain' => 'backloadingremovals.com.au',
+            'is_active' => true,
+        ]);
+
+        $canonicalSubdomain = Domain::factory()->create([
+            'domain' => 'mymovehub.backloadingremovals.com.au',
+            'is_active' => true,
+        ]);
+
+        $legacySubdomain = Domain::factory()->create([
+            'domain' => 'removalist.backloadingremovals.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloadingremovals-com-au',
+            'name' => 'backloadingremovals.com.au',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://backloadingremovals.com.au',
+            'target_moveroo_subdomain_url' => 'https://mymovehub.backloadingremovals.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $canonicalSubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $legacySubdomain->id,
+            'usage_type' => 'subdomain',
+            'is_canonical' => false,
+        ]);
+
+        $domain->tags()->syncWithoutDetaching([$tag->id]);
+
+        Http::fake([
+            'https://backloadingremovals.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <body>
+                        <header>
+                            <a href="https://mymovehub.backloadingremovals.com.au/quote/household">Canonical quote</a>
+                            <a href="https://removalist.backloadingremovals.com.au/payments">Legacy portal</a>
+                        </header>
+                    </body>
+                </html>
+            HTML),
+        ]);
+
+        $this->assertSame(1, Artisan::call('fleet:audit-owned-subdomain-links', ['propertySlug' => 'backloadingremovals-com-au']));
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('drift: canonical=mymovehub.backloadingremovals.com.au', $output);
+        $this->assertStringContainsString('removalist.backloadingremovals.com.au', $output);
+        $this->assertStringContainsString('https://removalist.backloadingremovals.com.au/payments', $output);
+    }
 }


### PR DESCRIPTION
## Summary
- add a Fleet audit command that flags homepage links to owned subdomains other than the configured canonical Moveroo subdomain
- extend the conversion link scanner with a full-page anchor audit path for owned subdomain drift
- cover both the clean and drifted command paths with feature tests

## Testing
- php artisan test tests/Feature/WebPropertyConversionLinksTest.php --filter='test_fleet_owned_subdomain_audit_is_clean_when_only_canonical_moveroo_subdomain_is_linked|test_fleet_owned_subdomain_audit_flags_links_to_other_owned_subdomains'
- ./vendor/bin/phpstan analyse app/Services/PropertyConversionLinkScanner.php tests/Feature/WebPropertyConversionLinksTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
