### PR TITLE
Fix synced DNS record editing

### DIFF
--- a/app/Livewire/Concerns/ManagesDomainDnsRecords.php
+++ b/app/Livewire/Concerns/ManagesDomainDnsRecords.php
@@ -50,7 +50,7 @@ trait ManagesDomainDnsRecords
         }
 
         $this->editingDnsRecordId = $record->id;
-        $this->dnsRecordHost = $record->host;
+        $this->dnsRecordHost = $this->editableDnsRecordHost($record->host);
         $this->dnsRecordType = $record->type;
         $this->dnsRecordValue = $record->value;
         $this->dnsRecordTtl = $record->ttl ?? 300;
@@ -72,11 +72,8 @@ trait ManagesDomainDnsRecords
             return;
         }
 
-        $host = trim($this->dnsRecordHost ?? '');
-        if ($host === '' || $host === '@') {
-            $host = '@';
-            $this->dnsRecordHost = '@';
-        }
+        $host = $this->normalizedDnsRecordHostInput($this->dnsRecordHost);
+        $this->dnsRecordHost = $host;
 
         $this->validate([
             'dnsRecordHost' => ['required', 'string', 'max:255'],
@@ -94,8 +91,8 @@ trait ManagesDomainDnsRecords
             'dnsRecordPriority.max' => 'Priority cannot exceed 65535.',
         ]);
 
-        if ($host !== '@' && ! preg_match('/^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$/i', $host)) {
-            $this->addError('dnsRecordHost', 'Host must be a valid subdomain name (letters, numbers, hyphens, underscores) or @ for root domain.');
+        if ($host !== '@' && ! preg_match('/^(?:[a-z0-9_](?:[a-z0-9\-_]{0,61}[a-z0-9_])?)(?:\.[a-z0-9_](?:[a-z0-9\-_]{0,61}[a-z0-9_])?)*$/i', $host)) {
+            $this->addError('dnsRecordHost', 'Host must be a valid relative DNS name (for example www, _dmarc, or s1._domainkey) or @ for root domain.');
 
             return;
         }
@@ -172,5 +169,37 @@ trait ManagesDomainDnsRecords
         $this->dnsRecordValue = '';
         $this->dnsRecordTtl = 300;
         $this->dnsRecordPriority = 0;
+    }
+
+    private function normalizedDnsRecordHostInput(?string $host): string
+    {
+        $normalizedHost = trim((string) $host);
+
+        if ($normalizedHost === '' || $normalizedHost === '@') {
+            return '@';
+        }
+
+        $domainName = trim((string) ($this->domain->domain ?? ''));
+
+        if ($domainName === '') {
+            return $normalizedHost;
+        }
+
+        if (strcasecmp($normalizedHost, $domainName) === 0) {
+            return '@';
+        }
+
+        $suffix = '.'.$domainName;
+
+        if (strlen($normalizedHost) > strlen($suffix) && str_ends_with(strtolower($normalizedHost), strtolower($suffix))) {
+            return substr($normalizedHost, 0, -strlen($suffix));
+        }
+
+        return $normalizedHost;
+    }
+
+    private function editableDnsRecordHost(string $host): string
+    {
+        return $this->normalizedDnsRecordHostInput($host);
     }
 }

--- a/tests/Feature/DomainDetailActionsTest.php
+++ b/tests/Feature/DomainDetailActionsTest.php
@@ -94,6 +94,43 @@ class DomainDetailActionsTest extends TestCase
             ->assertSet('dnsRecordPriority', 0);
     }
 
+    public function test_opening_edit_dns_record_modal_normalizes_synced_hostnames_for_editing(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'wemove.com.au',
+        ]);
+
+        $rootRecord = DnsRecord::factory()->create([
+            'domain_id' => $domain->id,
+            'host' => 'wemove.com.au',
+            'type' => 'A',
+            'value' => '203.0.113.10',
+        ]);
+
+        $wwwRecord = DnsRecord::factory()->create([
+            'domain_id' => $domain->id,
+            'host' => 'www.wemove.com.au',
+            'type' => 'A',
+            'value' => '203.0.113.11',
+        ]);
+
+        $dkimRecord = DnsRecord::factory()->create([
+            'domain_id' => $domain->id,
+            'host' => 's1._domainkey.wemove.com.au',
+            'type' => 'CNAME',
+            'value' => 'selector.example.net',
+        ]);
+
+        Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
+            ->call('openEditDnsRecordModal', $rootRecord->id)
+            ->assertSet('showDnsRecordModal', true)
+            ->assertSet('dnsRecordHost', '@')
+            ->call('openEditDnsRecordModal', $wwwRecord->id)
+            ->assertSet('dnsRecordHost', 'www')
+            ->call('openEditDnsRecordModal', $dkimRecord->id)
+            ->assertSet('dnsRecordHost', 's1._domainkey');
+    }
+
     public function test_saving_dns_record_with_blank_host_normalizes_to_root_domain(): void
     {
         $domain = Domain::factory()->create([
@@ -145,6 +182,64 @@ class DomainDetailActionsTest extends TestCase
             'ttl' => 300,
             'priority' => 0,
             'record_id' => 'RID-NEW-123',
+        ]);
+    }
+
+    public function test_saving_existing_dns_record_accepts_synced_full_hostname_input(): void
+    {
+        $domain = Domain::factory()->create([
+            'domain' => 'wemove.com.au',
+        ]);
+
+        $record = DnsRecord::factory()->create([
+            'domain_id' => $domain->id,
+            'record_id' => 'RID-WWW-123',
+            'host' => 'www.wemove.com.au',
+            'type' => 'A',
+            'value' => '203.0.113.10',
+            'ttl' => 300,
+            'priority' => 0,
+        ]);
+
+        $credential = SynergyCredential::factory()->create([
+            'is_active' => true,
+        ]);
+
+        $synergyAlias = Mockery::mock('alias:App\Services\SynergyWholesaleClient');
+        /** @phpstan-ignore-next-line */
+        $synergyAlias->shouldReceive('isAustralianTld')
+            ->with($domain->domain)
+            ->andReturnTrue();
+
+        $synergyClient = Mockery::mock();
+        /** @phpstan-ignore-next-line */
+        $synergyAlias->shouldReceive('fromEncryptedCredentials')
+            ->with($credential->reseller_id, $credential->api_key_encrypted, $credential->api_url)
+            ->andReturn($synergyClient);
+
+        /** @phpstan-ignore-next-line */
+        $synergyClient->shouldReceive('updateDnsRecord')
+            ->once()
+            ->with($domain->domain, 'RID-WWW-123', 'www', 'A', '203.0.113.44', 600, 0)
+            ->andReturn([
+                'status' => 'OK',
+                'error_message' => null,
+            ]);
+
+        Livewire::test(DomainDetail::class, ['domainId' => $domain->id])
+            ->call('openEditDnsRecordModal', $record->id)
+            ->assertSet('dnsRecordHost', 'www')
+            ->set('dnsRecordValue', '203.0.113.44')
+            ->set('dnsRecordTtl', 600)
+            ->call('saveDnsRecord')
+            ->assertHasNoErrors()
+            ->assertSet('showDnsRecordModal', false);
+
+        $this->assertDatabaseHas('dns_records', [
+            'id' => $record->id,
+            'host' => 'www',
+            'value' => '203.0.113.44',
+            'ttl' => 600,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- normalize synced DNS record hosts into editable relative names before populating the domain detail form
- accept full synced hostnames on save and collapse them back to relative host values for validation and registrar updates
- add regression coverage for editing root, single-label, and multi-label synced DNS records

## Testing
- php artisan test tests/Feature/DomainDetailActionsTest.php --filter='opening_edit_dns_record_modal_normalizes_synced_hostnames_for_editing|saving_existing_dns_record_accepts_synced_full_hostname_input|opening_add_dns_record_modal_resets_the_form_state|closing_dns_record_modal_resets_form_state|saving_dns_record_with_blank_host_normalizes_to_root_domain'
- ./vendor/bin/phpstan analyse app/Livewire/Concerns/ManagesDomainDnsRecords.php tests/Feature/DomainDetailActionsTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
