### PR TITLE
Fix domain detail modal binding

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -13,11 +13,13 @@ $maxWidth = [
     'xl' => 'sm:max-w-xl',
     '2xl' => 'sm:max-w-2xl',
 ][$maxWidth];
+
+$wireModel = $attributes->wire('model');
 @endphp
 
 <div
     x-data="{
-        show: @js($show),
+        show: @if($wireModel) @entangle($wireModel) @else @js($show) @endif,
         closeAction: @js($closeAction),
         focusables() {
             // All focusable element types...

--- a/resources/views/livewire/domain-detail/sections/modals.blade.php
+++ b/resources/views/livewire/domain-detail/sections/modals.blade.php
@@ -1,5 +1,5 @@
 <!-- DNS Record Add/Edit Modal -->
-<x-modal name="dns-record" :show="$showDnsRecordModal" close-action="closeDnsRecordModal" focusable wire:key="dns-record-modal">
+<x-modal name="dns-record" wire:model="showDnsRecordModal" close-action="closeDnsRecordModal" focusable wire:key="dns-record-modal">
     <form wire:submit="saveDnsRecord" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
             {{ $editingDnsRecordId ? 'Edit DNS Record' : 'Add DNS Record' }}
@@ -93,7 +93,7 @@
 </x-modal>
 
 <!-- Subdomain Add/Edit Modal -->
-<x-modal name="subdomain" :show="$showSubdomainModal" close-action="closeSubdomainModal" focusable wire:key="subdomain-modal">
+<x-modal name="subdomain" wire:model="showSubdomainModal" close-action="closeSubdomainModal" focusable wire:key="subdomain-modal">
     <form wire:submit="saveSubdomain" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
             {{ $editingSubdomainId ? 'Edit Subdomain' : 'Add Subdomain' }}
@@ -130,7 +130,7 @@
 </x-modal>
 
 <!-- Delete Confirmation Modal -->
-<x-modal name="delete-domain" :show="$showDeleteModal" close-action="closeDeleteModal" focusable>
+<x-modal name="delete-domain" wire:model="showDeleteModal" close-action="closeDeleteModal" focusable>
     <form wire:submit="deleteDomain" class="p-6">
         <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
             {{ __('Are you sure you want to delete this domain?') }}


### PR DESCRIPTION
## Summary
- bind the shared modal component to Livewire state when a `wire:model` is provided
- switch the domain detail DNS, subdomain, and delete dialogs onto real Livewire-backed modal state
- keep the existing close-action callbacks while making the modal actually respond to backend state changes

## Testing
- php artisan test tests/Feature/DomainDetailActionsTest.php tests/Feature/ProfileTest.php
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
