### PR TITLE
Fix modal backdrop close race

### DIFF
--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -57,6 +57,7 @@ $wireModel = $attributes->wire('model');
     x-on:open-modal.window="$event.detail == '{{ $name }}' ? show = true : null"
     x-on:close-modal.window="$event.detail == '{{ $name }}' ? close() : null"
     x-on:close.stop="close()"
+    x-on:click.self="close()"
     x-on:keydown.escape.window="close()"
     x-on:keydown.tab.prevent="$event.shiftKey || nextFocusable().focus()"
     x-on:keydown.shift.tab.prevent="prevFocusable().focus()"
@@ -67,7 +68,6 @@ $wireModel = $attributes->wire('model');
     <div
         x-show="show"
         class="fixed inset-0 transform transition-all"
-        x-on:click="close()"
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0"
         x-transition:enter-end="opacity-100"
@@ -81,6 +81,7 @@ $wireModel = $attributes->wire('model');
     <div
         x-show="show"
         class="mb-6 bg-white dark:bg-gray-800 rounded-lg overflow-hidden shadow-xl transform transition-all sm:w-full {{ $maxWidth }} sm:mx-auto"
+        x-on:click.stop
         x-transition:enter="ease-out duration-300"
         x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
         x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"


### PR DESCRIPTION
## Summary
- move outside-click closing onto the modal shell instead of the backdrop layer
- stop click propagation from the modal content itself
- avoid the open-then-immediate-close behavior when action buttons launch a modal

## Testing
- php artisan test tests/Feature/DomainDetailActionsTest.php tests/Feature/ProfileTest.php
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
