### PR TITLE
Add stable analytics config to property payloads

### DIFF
--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Services\PropertyExecutionReadinessResolver;
+use App\Services\WebPropertyAnalyticsSummaryBuilder;
 use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
 use App\Services\WebPropertyGscEvidenceSummaryBuilder;
 use App\Services\WebPropertyPlatformMigrationSummaryBuilder;
@@ -827,6 +828,7 @@ class WebProperty extends Model
             'domains' => $this->domainSummaries($includeFullExternalLinks),
             'repositories' => $this->repositorySummaries(),
             'analytics_sources' => $this->analyticsSourceSummaries(),
+            'analytics' => $this->analyticsSummary(),
             'health_summary' => $this->healthSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
@@ -858,6 +860,18 @@ class WebProperty extends Model
     public function siteIdentitySummary(): array
     {
         return app(WebPropertySiteIdentitySummaryBuilder::class)->build($this);
+    }
+
+    /**
+     * @return array{
+     *   enabled: bool,
+     *   provider: string|null,
+     *   config: array<string, string|null>
+     * }
+     */
+    public function analyticsSummary(): array
+    {
+        return app(WebPropertyAnalyticsSummaryBuilder::class)->build($this);
     }
 
     /**

--- a/app/Services/WebPropertyAnalyticsSummaryBuilder.php
+++ b/app/Services/WebPropertyAnalyticsSummaryBuilder.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AnalyticsInstallAudit;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class WebPropertyAnalyticsSummaryBuilder
+{
+    /**
+     * @return array{
+     *   enabled: bool,
+     *   provider: string|null,
+     *   config: array<string, string|null>
+     * }
+     */
+    public function build(WebProperty $property): array
+    {
+        $source = $this->primarySource($property);
+
+        if (! $source instanceof PropertyAnalyticsSource) {
+            return $this->defaultSummary();
+        }
+
+        $provider = $this->normalizedText($source->provider);
+        if ($provider === null) {
+            return $this->defaultSummary();
+        }
+
+        $config = $this->providerConfig($source, $provider);
+
+        return [
+            'enabled' => $this->isEnabled($source, $provider, $config),
+            'provider' => $provider,
+            'config' => $config,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   enabled: bool,
+     *   provider: string|null,
+     *   config: array<string, string|null>
+     * }
+     */
+    private function defaultSummary(): array
+    {
+        return [
+            'enabled' => false,
+            'provider' => null,
+            'config' => [],
+        ];
+    }
+
+    private function primarySource(WebProperty $property): ?PropertyAnalyticsSource
+    {
+        /** @var Collection<int, PropertyAnalyticsSource>|null $loadedSources */
+        $loadedSources = $property->relationLoaded('analyticsSources')
+            ? $property->getRelation('analyticsSources')
+            : null;
+
+        if ($loadedSources instanceof Collection) {
+            $primarySource = $loadedSources
+                ->sortByDesc(fn (PropertyAnalyticsSource $source): bool => $source->is_primary)
+                ->values()
+                ->first();
+
+            return $primarySource instanceof PropertyAnalyticsSource ? $primarySource : null;
+        }
+
+        $primarySource = $property->analyticsSources()
+            ->with('latestInstallAudit')
+            ->orderByDesc('is_primary')
+            ->first();
+
+        return $primarySource instanceof PropertyAnalyticsSource ? $primarySource : null;
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function providerConfig(PropertyAnalyticsSource $source, string $provider): array
+    {
+        return match ($provider) {
+            'matomo' => [
+                'base_url' => $this->matomoBaseUrl($source),
+                'site_id' => $this->normalizedText($source->external_id),
+            ],
+            'gtm' => [
+                'container_id' => $this->normalizedText($source->external_id),
+            ],
+            'ga4' => [
+                'measurement_id' => $this->normalizedText($source->external_id),
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * @param  array<string, string|null>  $config
+     */
+    private function isEnabled(PropertyAnalyticsSource $source, string $provider, array $config): bool
+    {
+        if ($source->status !== 'active') {
+            return false;
+        }
+
+        return match ($provider) {
+            'matomo' => $this->filledConfigValue($config, 'base_url') && $this->filledConfigValue($config, 'site_id'),
+            'gtm' => $this->filledConfigValue($config, 'container_id'),
+            'ga4' => $this->filledConfigValue($config, 'measurement_id'),
+            default => false,
+        };
+    }
+
+    private function matomoBaseUrl(PropertyAnalyticsSource $source): ?string
+    {
+        $audit = $source->relationLoaded('latestInstallAudit')
+            ? $source->latestInstallAudit
+            : $source->latestInstallAudit()->first();
+
+        if ($audit instanceof AnalyticsInstallAudit) {
+            $expectedTrackerHost = $this->normalizedHost($audit->expected_tracker_host);
+            if ($expectedTrackerHost !== null) {
+                return 'https://'.$expectedTrackerHost;
+            }
+
+            foreach ($audit->detected_tracker_hosts ?? [] as $trackerHost) {
+                $normalizedTrackerHost = $this->normalizedHost($trackerHost);
+                if ($normalizedTrackerHost !== null) {
+                    return 'https://'.$normalizedTrackerHost;
+                }
+            }
+        }
+
+        return $this->normalizedOriginUrl(config('services.matomo.base_url'));
+    }
+
+    private function normalizedText(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizedHost(mixed $value): ?string
+    {
+        $normalized = $this->normalizedText($value);
+        if ($normalized === null) {
+            return null;
+        }
+
+        if (str_starts_with($normalized, 'http://') || str_starts_with($normalized, 'https://')) {
+            $parts = parse_url($normalized);
+            if (! is_array($parts) || ! isset($parts['host'])) {
+                return null;
+            }
+
+            return Str::lower((string) $parts['host']);
+        }
+
+        return Str::lower(rtrim($normalized, '.'));
+    }
+
+    private function normalizedOriginUrl(mixed $value): ?string
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($value));
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $origin = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $origin .= ':'.$parts['port'];
+        }
+
+        return $origin;
+    }
+
+    /**
+     * @param  array<string, string|null>  $config
+     */
+    private function filledConfigValue(array $config, string $key): bool
+    {
+        return isset($config[$key]) && $config[$key] !== '';
+    }
+}

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -266,6 +266,10 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.repositories.0.repo_name', 'moveroo/moveroo-website-astro')
             ->assertJsonPath('web_properties.0.analytics_sources.0.external_id', '6')
             ->assertJsonPath('web_properties.0.analytics_sources.0.install_audit.install_verdict', 'installed_match')
+            ->assertJsonPath('web_properties.0.analytics.enabled', true)
+            ->assertJsonPath('web_properties.0.analytics.provider', 'matomo')
+            ->assertJsonPath('web_properties.0.analytics.config.base_url', 'https://stats.redirection.com.au')
+            ->assertJsonPath('web_properties.0.analytics.config.site_id', '6')
             ->assertJsonPath('web_properties.0.health_summary.checks.uptime', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.http', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.ssl', 'warn')
@@ -466,6 +470,11 @@ class WebPropertyApiTest extends TestCase
                         'quote_portal',
                         'contact_page',
                     ],
+                    'analytics' => [
+                        'enabled',
+                        'provider',
+                        'config',
+                    ],
                     'platform_migration' => [
                         'current_platform',
                         'target_platform',
@@ -521,6 +530,9 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.site_identity.primary_domain', 'https://stable-links.example.com/')
             ->assertJsonPath('web_properties.0.site_identity.quote_portal', null)
             ->assertJsonPath('web_properties.0.site_identity.contact_page', null)
+            ->assertJsonPath('web_properties.0.analytics.enabled', false)
+            ->assertJsonPath('web_properties.0.analytics.provider', null)
+            ->assertJsonPath('web_properties.0.analytics.config', [])
             ->assertJsonPath('web_properties.0.platform_migration.current_platform', $property->platform)
             ->assertJsonPath('web_properties.0.platform_migration.target_platform', null)
             ->assertJsonPath('web_properties.0.platform_migration.astro_cutover_at', null)
@@ -563,6 +575,11 @@ class WebPropertyApiTest extends TestCase
                         'primary_domain',
                         'quote_portal',
                         'contact_page',
+                    ],
+                    'analytics' => [
+                        'enabled',
+                        'provider',
+                        'config',
                     ],
                     'platform_migration' => [
                         'current_platform',
@@ -619,6 +636,9 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.site_identity.primary_domain', 'https://stable-links.example.com/')
             ->assertJsonPath('data.site_identity.quote_portal', null)
             ->assertJsonPath('data.site_identity.contact_page', null)
+            ->assertJsonPath('data.analytics.enabled', false)
+            ->assertJsonPath('data.analytics.provider', null)
+            ->assertJsonPath('data.analytics.config', [])
             ->assertJsonPath('data.platform_migration.current_platform', $property->platform)
             ->assertJsonPath('data.platform_migration.target_platform', null)
             ->assertJsonPath('data.platform_migration.astro_cutover_at', null)

--- a/tests/Unit/WebPropertySummaryBuildersTest.php
+++ b/tests/Unit/WebPropertySummaryBuildersTest.php
@@ -2,10 +2,13 @@
 
 namespace Tests\Unit;
 
+use App\Models\AnalyticsInstallAudit;
 use App\Models\Domain;
 use App\Models\DomainSeoBaseline;
+use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
+use App\Services\WebPropertyAnalyticsSummaryBuilder;
 use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
 use App\Services\WebPropertyGscEvidenceSummaryBuilder;
 use App\Services\WebPropertySeoBaselineSummaryBuilder;
@@ -156,6 +159,48 @@ class WebPropertySummaryBuildersTest extends TestCase
             'primary_domain' => null,
             'quote_portal' => null,
             'contact_page' => null,
+        ], $summary);
+    }
+
+    public function test_analytics_builder_returns_stable_disabled_defaults_without_source(): void
+    {
+        $property = new WebProperty;
+        $property->setRelation('analyticsSources', new EloquentCollection);
+
+        $summary = (new WebPropertyAnalyticsSummaryBuilder)->build($property);
+
+        $this->assertSame([
+            'enabled' => false,
+            'provider' => null,
+            'config' => [],
+        ], $summary);
+    }
+
+    public function test_analytics_builder_exposes_matomo_config_with_stable_shape(): void
+    {
+        $property = new WebProperty;
+
+        $source = new PropertyAnalyticsSource([
+            'provider' => 'matomo',
+            'external_id' => '13',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+        $source->setRelation('latestInstallAudit', new AnalyticsInstallAudit([
+            'expected_tracker_host' => 'stats.redirection.com.au',
+        ]));
+
+        $property->setRelation('analyticsSources', new EloquentCollection([$source]));
+
+        $summary = (new WebPropertyAnalyticsSummaryBuilder)->build($property);
+
+        $this->assertSame([
+            'enabled' => true,
+            'provider' => 'matomo',
+            'config' => [
+                'base_url' => 'https://stats.redirection.com.au',
+                'site_id' => '13',
+            ],
         ], $summary);
     }
 


### PR DESCRIPTION
## Summary
- add a normalized top-level analytics block to web property payloads
- map current Matomo bindings into a stable provider/config contract
- lock the contract with builder and API tests for both populated and disabled cases

## Testing
- php artisan test tests/Unit/WebPropertySummaryBuildersTest.php
- php artisan test tests/Feature/WebPropertyApiTest.php --filter='test_web_properties_summary_returns_contract_v1_payload|test_property_apis_always_expose_fully_shaped_conversion_links_contract'
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Services/WebPropertyAnalyticsSummaryBuilder.php tests/Unit/WebPropertySummaryBuildersTest.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
- vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
