### PR TITLE
Harden Forge deploy view caching

### DIFF
--- a/FORGE-DEPLOY-SCRIPT.sh
+++ b/FORGE-DEPLOY-SCRIPT.sh
@@ -25,11 +25,13 @@ $FORGE_PHP artisan storage:link
 # Apply schema changes before the new release goes live.
 $FORGE_PHP artisan migrate --force
 
-# Rebuild framework caches for the new release.
+# Rebuild framework caches for the new release. We intentionally skip Blade
+# precompilation here because Forge zero-downtime deploys share the compiled
+# views directory across releases, and `view:cache` has shown transient rename
+# failures there while views still compile on demand safely in production.
 $FORGE_PHP artisan optimize:clear
 $FORGE_PHP artisan config:cache
 $FORGE_PHP artisan route:cache
-$FORGE_PHP artisan view:cache
 $FORGE_PHP artisan event:cache
 
 # Switch the current symlink to the new release.

--- a/docs/DEPLOYMENT-CHECKLIST.md
+++ b/docs/DEPLOYMENT-CHECKLIST.md
@@ -79,7 +79,6 @@ php artisan migrate --force
 php artisan storage:link
 php artisan config:cache
 php artisan route:cache
-php artisan view:cache
 php artisan event:cache
 npm ci
 npm run build

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -169,11 +169,14 @@ php artisan migrate --force
 php artisan storage:link
 php artisan config:cache
 php artisan route:cache
-php artisan view:cache
 php artisan event:cache
 npm ci
 npm run build
 ```
+
+This project intentionally skips `php artisan view:cache` on Forge because the
+shared compiled views directory has produced transient rename failures during
+zero-downtime deployments. Blade views will still compile on demand.
 
 ## Post-Deployment Steps
 


### PR DESCRIPTION
## Summary
- remove `php artisan view:cache` from the checked-in Forge deploy script
- align the deployment docs and checklist with the production script
- document why Blade precompilation is intentionally skipped on Forge for this app

## Verification
- confirmed the latest Forge deploy succeeded on April 21, 2026
- confirmed the earlier failed deploy on April 21, 2026 died inside `view:cache` with a `rename(...storage/framework/views...)` error
- ran `./vendor/bin/pint --dirty`
- ran a placeholder-substituted `bash -n` parse of `FORGE-DEPLOY-SCRIPT.sh` because Forge macros are not valid in a raw local shell parse
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
