### PR TITLE
Add monitoring lanes and GA4 integrity findings

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use App\Services\Ga4SignalScanner;
+use App\Services\MonitoringFindingManager;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class RunMonitoringLane extends Command
+{
+    protected $signature = 'monitoring:run-lane
+                            {lane : Monitoring lane slug}
+                            {--property= : Optional web property slug}
+                            {--domain= : Optional primary domain name}
+                            {--timeout=10 : HTTP timeout in seconds for live verification requests}';
+
+    protected $description = 'Run an explicit monitoring lane and emit deduped findings through the Brain path.';
+
+    public function handle(Ga4SignalScanner $scanner, MonitoringFindingManager $findings): int
+    {
+        $lane = (string) $this->argument('lane');
+        $timeout = max(1, (int) $this->option('timeout'));
+        $laneConfig = config('domain_monitor.monitoring_lanes.'.$lane);
+
+        if (! is_array($laneConfig)) {
+            $this->error(sprintf('Unknown monitoring lane [%s].', $lane));
+
+            return self::FAILURE;
+        }
+
+        if ($lane !== 'marketing_integrity') {
+            $this->warn(sprintf('Lane [%s] is configured but does not have runnable checks yet.', $lane));
+
+            return self::SUCCESS;
+        }
+
+        $properties = $this->marketingIntegrityProperties();
+
+        if ($properties->isEmpty()) {
+            $this->warn('No active GA4-linked properties matched the requested lane scope.');
+
+            return self::SUCCESS;
+        }
+
+        $opened = 0;
+        $updated = 0;
+        $recovered = 0;
+
+        foreach ($properties as $property) {
+            $property->loadMissing([
+                'primaryDomain',
+                'propertyDomains.domain',
+                'analyticsSources',
+                'conversionSurfaces.analyticsSource',
+                'conversionSurfaces.domain',
+            ]);
+
+            $primaryDomain = $property->primaryDomainModel();
+
+            $homepageAudit = $scanner->auditPropertyHomepage($property, $timeout);
+            $homepageOutcome = $this->syncFinding(
+                findings: $findings,
+                property: $property,
+                findingType: 'marketing.ga4_install',
+                title: 'GA4 install mismatch on live property',
+                audit: $homepageAudit,
+                primaryDomainId: $primaryDomain?->id
+            );
+
+            $surfaceAudit = $scanner->auditConversionSurfaces($property, $timeout);
+            $surfaceOutcome = $this->syncFinding(
+                findings: $findings,
+                property: $property,
+                findingType: 'marketing.conversion_surface_ga4',
+                title: 'GA4 mismatch on conversion surfaces',
+                audit: $surfaceAudit,
+                primaryDomainId: $primaryDomain?->id
+            );
+
+            $opened += (int) in_array($homepageOutcome, ['opened', 'reopened'], true);
+            $updated += (int) ($homepageOutcome === 'updated');
+            $recovered += (int) ($homepageOutcome === 'recovered');
+
+            $opened += (int) in_array($surfaceOutcome, ['opened', 'reopened'], true);
+            $updated += (int) ($surfaceOutcome === 'updated');
+            $recovered += (int) ($surfaceOutcome === 'recovered');
+
+            $this->line(sprintf(
+                '[%s] homepage=%s | conversion_surfaces=%s',
+                $property->slug,
+                $homepageAudit['verdict'],
+                $surfaceAudit['verdict']
+            ));
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            'Lane [%s] complete for %d propertie(s). Findings opened/reopened: %d, updated: %d, recovered: %d.',
+            $lane,
+            $properties->count(),
+            $opened,
+            $updated,
+            $recovered
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<int, WebProperty>
+     */
+    private function marketingIntegrityProperties(): Collection
+    {
+        $propertyFilter = $this->optionString('property');
+        $domainFilter = $this->optionString('domain');
+
+        return WebProperty::query()
+            ->where('status', 'active')
+            ->with([
+                'primaryDomain',
+                'propertyDomains.domain',
+                'analyticsSources',
+                'conversionSurfaces.analyticsSource',
+                'conversionSurfaces.domain',
+            ])
+            ->whereHas('analyticsSources', function (Builder $query): void {
+                $query->where('provider', 'ga4')
+                    ->where('status', 'active');
+            })
+            ->when(
+                $propertyFilter,
+                fn (Builder $query) => $query->where('slug', $propertyFilter)
+            )
+            ->when(
+                $domainFilter,
+                fn (Builder $query) => $query->whereHas(
+                    'propertyDomains.domain',
+                    fn (Builder $domainQuery) => $domainQuery->where('domain', $domainFilter)
+                )
+            )
+            ->get()
+            ->filter(fn (WebProperty $property): bool => $this->expectedMeasurementId($property) !== null)
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $audit
+     */
+    private function syncFinding(
+        MonitoringFindingManager $findings,
+        WebProperty $property,
+        string $findingType,
+        string $title,
+        array $audit,
+        ?string $primaryDomainId
+    ): string {
+        if (($audit['status'] ?? null) === 'fail') {
+            return $findings->reportPropertyFinding(
+                property: $property,
+                findingType: $findingType,
+                lane: 'marketing_integrity',
+                issueType: 'regression',
+                title: $title,
+                summary: (string) ($audit['summary'] ?? ''),
+                evidence: $audit['evidence'] ?? [],
+                primaryDomainId: $primaryDomainId
+            );
+        }
+
+        return $findings->recoverPropertyFinding(
+            property: $property,
+            findingType: $findingType,
+            lane: 'marketing_integrity',
+            recoverySummary: (string) ($audit['summary'] ?? ''),
+            recoveryEvidence: $audit['evidence'] ?? [],
+            primaryDomainId: $primaryDomainId
+        );
+    }
+
+    private function optionString(string $name): ?string
+    {
+        $value = $this->option($name);
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function expectedMeasurementId(WebProperty $property): ?string
+    {
+        $source = $property->primaryAnalyticsSource('ga4');
+
+        if (! $source instanceof PropertyAnalyticsSource) {
+            return null;
+        }
+
+        $providerConfig = $source->provider_config;
+        $measurementId = is_array($providerConfig)
+            ? ($providerConfig['measurement_id'] ?? null)
+            : null;
+
+        if (! is_string($measurementId) || trim($measurementId) === '') {
+            $measurementId = $source->external_id;
+        }
+
+        if (trim($measurementId) === '') {
+            return null;
+        }
+
+        $normalized = strtoupper(trim($measurementId));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -198,7 +198,7 @@ class RunMonitoringLane extends Command
     {
         $source = $property->primaryAnalyticsSource('ga4');
 
-        if (! $source instanceof PropertyAnalyticsSource) {
+        if (! $source instanceof PropertyAnalyticsSource || $source->status !== 'active') {
             return null;
         }
 

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -208,6 +208,14 @@ class Domain extends Model
     }
 
     /**
+     * @return HasMany<MonitoringFinding, $this>
+     */
+    public function monitoringFindings(): HasMany
+    {
+        return $this->hasMany(MonitoringFinding::class)->orderByDesc('last_detected_at');
+    }
+
+    /**
      * @return HasOne<DomainCheck, $this>
      */
     public function latestSeoCheck(): HasOne

--- a/app/Models/MonitoringFinding.php
+++ b/app/Models/MonitoringFinding.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
@@ -27,6 +28,9 @@ use Illuminate\Support\Str;
  */
 class MonitoringFinding extends Model
 {
+    /** @use HasFactory<\Database\Factories\MonitoringFindingFactory> */
+    use HasFactory;
+
     public const STATUS_OPEN = 'open';
 
     public const STATUS_RECOVERED = 'recovered';

--- a/app/Models/MonitoringFinding.php
+++ b/app/Models/MonitoringFinding.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * @property string $id
+ * @property string $issue_id
+ * @property string $lane
+ * @property string $finding_type
+ * @property string $issue_type
+ * @property string $scope_type
+ * @property string|null $domain_id
+ * @property string|null $web_property_id
+ * @property string $status
+ * @property string $title
+ * @property string|null $summary
+ * @property \Illuminate\Support\Carbon|null $first_detected_at
+ * @property \Illuminate\Support\Carbon|null $last_detected_at
+ * @property \Illuminate\Support\Carbon|null $recovered_at
+ * @property array<string, mixed>|null $evidence
+ * @property Domain|null $domain
+ * @property WebProperty|null $webProperty
+ */
+class MonitoringFinding extends Model
+{
+    public const STATUS_OPEN = 'open';
+
+    public const STATUS_RECOVERED = 'recovered';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'issue_id',
+        'lane',
+        'finding_type',
+        'issue_type',
+        'scope_type',
+        'domain_id',
+        'web_property_id',
+        'status',
+        'title',
+        'summary',
+        'first_detected_at',
+        'last_detected_at',
+        'recovered_at',
+        'evidence',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'first_detected_at' => 'datetime',
+            'last_detected_at' => 'datetime',
+            'recovered_at' => 'datetime',
+            'evidence' => 'array',
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        static::creating(function (self $finding): void {
+            if (empty($finding->id)) {
+                $finding->id = Str::uuid()->toString();
+            }
+        });
+    }
+
+    /**
+     * @return BelongsTo<Domain, $this>
+     */
+    public function domain(): BelongsTo
+    {
+        return $this->belongsTo(Domain::class);
+    }
+
+    /**
+     * @return BelongsTo<WebProperty, $this>
+     */
+    public function webProperty(): BelongsTo
+    {
+        return $this->belongsTo(WebProperty::class);
+    }
+}

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -227,6 +227,14 @@ class WebProperty extends Model
     }
 
     /**
+     * @return HasMany<MonitoringFinding, $this>
+     */
+    public function monitoringFindings(): HasMany
+    {
+        return $this->hasMany(MonitoringFinding::class)->orderByDesc('last_detected_at');
+    }
+
+    /**
      * @return HasMany<DomainSeoBaseline, $this>
      */
     public function seoBaselines(): HasMany

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -232,7 +232,7 @@ class DetectedIssueSummaryService
             ->where('status', MonitoringFinding::STATUS_OPEN)
             ->with([
                 'domain:id,domain',
-                'webProperty:id,slug,name,production_url,primary_domain_id',
+                'webProperty',
                 'webProperty.propertyDomains.domain:id,domain',
             ])
             ->orderByDesc('last_detected_at')

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Domain;
 use App\Models\DomainCheck;
+use App\Models\MonitoringFinding;
 use App\Models\WebProperty;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Collection;
@@ -75,6 +76,7 @@ class DetectedIssueSummaryService
         $brokenLinksEvidence = $this->brokenLinksEvidenceMapForQueueItems($queueItems);
         $issues = $this->flattenIssues($queueSnapshot['must_fix'] ?? [], 'must_fix', $issueEvidence, $brokenLinksEvidence)
             ->concat($this->flattenIssues($queueSnapshot['should_fix'] ?? [], 'should_fix', $issueEvidence, $brokenLinksEvidence))
+            ->concat($this->monitoringFindingIssues())
             ->pipe(function (Collection $issues) use ($includeExpectedExclusions, $includeSuppressed): Collection {
                 $issueIds = $issues
                     ->pluck('issue_id')
@@ -219,6 +221,75 @@ class DetectedIssueSummaryService
         return collect($items)
             ->flatMap(fn (array $item): array => $this->makeIssues($item, $severity, $issueEvidence, $brokenLinksEvidence))
             ->values();
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function monitoringFindingIssues(): Collection
+    {
+        $issues = MonitoringFinding::query()
+            ->where('status', MonitoringFinding::STATUS_OPEN)
+            ->with([
+                'domain:id,domain',
+                'webProperty:id,slug,name,production_url,primary_domain_id',
+                'webProperty.propertyDomains.domain:id,domain',
+            ])
+            ->orderByDesc('last_detected_at')
+            ->get()
+            ->map(function (MonitoringFinding $finding): array {
+                $property = $finding->webProperty;
+                $severity = in_array($finding->issue_type, ['incident', 'regression'], true)
+                    ? 'must_fix'
+                    : 'should_fix';
+
+                return [
+                    'issue_id' => $finding->issue_id,
+                    'property_slug' => $property?->slug,
+                    'property_name' => $property?->name,
+                    'domain' => ($finding->domain instanceof Domain ? $finding->domain->domain : null) ?? $property?->primaryDomainName(),
+                    'issue_class' => $finding->finding_type,
+                    'severity' => $severity,
+                    'detector' => 'domain_monitor.monitoring_lane',
+                    'status' => 'open',
+                    'detected_at' => $finding->last_detected_at instanceof \Illuminate\Support\Carbon
+                        ? $finding->last_detected_at->toIso8601String()
+                        : null,
+                    'rollout_scope' => 'property_only',
+                    'control_id' => null,
+                    'platform_profile' => null,
+                    'host_profile' => null,
+                    'control_profile' => null,
+                    'control_state' => null,
+                    'execution_surface' => 'monitoring_lane',
+                    'fleet_managed' => false,
+                    'controller_repo' => null,
+                    'controller_repo_url' => null,
+                    'conversion_links' => $property?->conversionLinkSummary(),
+                    'canonical_origin' => $property?->canonicalOriginSummary(),
+                    'site_identity' => $property?->siteIdentitySummary(),
+                    'evidence' => [
+                        'primary_reasons' => [$finding->summary],
+                        'secondary_reasons' => [],
+                        'related_issue_classes' => [$finding->finding_type],
+                        'coverage_required' => false,
+                        'coverage_status' => null,
+                        'coverage_gap' => false,
+                        'property_match_confidence' => $property instanceof WebProperty ? 'high' : 'none',
+                        'baseline_surface' => null,
+                        'source_domain_id' => $finding->domain_id,
+                        'lane' => $finding->lane,
+                        'finding_type' => $finding->finding_type,
+                        'issue_type' => $finding->issue_type,
+                        'summary' => $finding->summary,
+                        'details' => $finding->evidence ?? [],
+                    ],
+                ];
+            })
+            ->values();
+
+        /** @var Collection<int, array<string, mixed>> $issues */
+        return $issues;
     }
 
     /**

--- a/app/Services/Ga4SignalScanner.php
+++ b/app/Services/Ga4SignalScanner.php
@@ -1,0 +1,495 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use App\Models\WebPropertyConversionSurface;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class Ga4SignalScanner
+{
+    private const int MAX_SCRIPT_ASSETS = 3;
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail'|'skipped',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditPropertyHomepage(WebProperty $property, int $timeout = 10): array
+    {
+        $expectedMeasurementId = $this->expectedMeasurementId($property->primaryAnalyticsSource('ga4'));
+
+        if ($expectedMeasurementId === null) {
+            return [
+                'status' => 'skipped',
+                'verdict' => 'missing_expected_measurement_id',
+                'summary' => 'Property does not have an active GA4 measurement ID configured.',
+                'evidence' => [
+                    'verdict' => 'missing_expected_measurement_id',
+                    'urls' => [],
+                ],
+            ];
+        }
+
+        $candidateUrls = $this->candidateUrlsForProperty($property);
+        $probe = $this->firstSuccessfulProbe($candidateUrls, $timeout);
+
+        if ($probe === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'fetch_failed',
+                'summary' => 'Could not fetch any live property URL to verify the GA4 install.',
+                'evidence' => [
+                    'verdict' => 'fetch_failed',
+                    'expected_measurement_id' => $expectedMeasurementId,
+                    'urls' => $candidateUrls->all(),
+                ],
+            ];
+        }
+
+        $analysis = $this->analyzeHtml($probe['html'], $probe['url'], $timeout);
+        [$verdict, $summary] = $this->verdictForSignalSet(
+            $expectedMeasurementId,
+            $analysis['measurement_ids']
+        );
+
+        return [
+            'status' => $verdict === 'installed_match' ? 'ok' : 'fail',
+            'verdict' => $verdict,
+            'summary' => $summary,
+            'evidence' => [
+                'verdict' => $verdict,
+                'expected_measurement_id' => $expectedMeasurementId,
+                'detected_measurement_ids' => $analysis['measurement_ids'],
+                'detected_script_hosts' => $analysis['tracker_hosts'],
+                'best_url' => $probe['url'],
+                'urls' => $candidateUrls->all(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail'|'skipped',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditConversionSurfaces(WebProperty $property, int $timeout = 10): array
+    {
+        $surfaces = $this->candidateSurfaces($property);
+
+        if ($surfaces->isEmpty()) {
+            return [
+                'status' => 'skipped',
+                'verdict' => 'no_conversion_surfaces',
+                'summary' => 'Property does not currently expose any conversion surfaces with GA4 bindings.',
+                'evidence' => [
+                    'verdict' => 'no_conversion_surfaces',
+                    'failing_surfaces' => [],
+                    'surfaces' => [],
+                ],
+            ];
+        }
+
+        $results = $surfaces->map(
+            fn (array $surface): array => $this->auditSurface($surface, $timeout)
+        )->values();
+
+        $failing = $results
+            ->filter(fn (array $result): bool => $result['verdict'] !== 'installed_match')
+            ->values();
+
+        if ($failing->isEmpty()) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'installed_match',
+                'summary' => 'All conversion surfaces resolve to the expected GA4 measurement ID.',
+                'evidence' => [
+                    'verdict' => 'installed_match',
+                    'failing_surfaces' => [],
+                    'surfaces' => $results->all(),
+                ],
+            ];
+        }
+
+        $summary = sprintf(
+            '%d conversion surface(s) are not resolving to the expected GA4 measurement ID.',
+            $failing->count()
+        );
+
+        $primaryVerdict = (string) ($failing->first()['verdict'] ?? 'conversion_surface_mismatch');
+
+        return [
+            'status' => 'fail',
+            'verdict' => $primaryVerdict,
+            'summary' => $summary,
+            'evidence' => [
+                'verdict' => $primaryVerdict,
+                'failing_surfaces' => $failing->all(),
+                'surfaces' => $results->all(),
+            ],
+        ];
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function candidateUrlsForProperty(WebProperty $property): Collection
+    {
+        $urls = [];
+
+        if (is_string($property->production_url) && trim($property->production_url) !== '') {
+            $urls[] = trim($property->production_url);
+        }
+
+        $primaryDomain = $property->primaryDomainName();
+        if (is_string($primaryDomain) && $primaryDomain !== '') {
+            $urls[] = 'https://'.$primaryDomain.'/';
+        }
+
+        $normalizedUrls = collect($urls)
+            ->map(fn (string $url): string => $this->normalizedUrl($url))
+            ->filter()
+            ->unique()
+            ->values();
+
+        /** @var Collection<int, string> $normalizedUrls */
+        return $normalizedUrls;
+    }
+
+    /**
+     * @return Collection<int, array{surface: WebPropertyConversionSurface, expected_measurement_id: string, url: string}>
+     */
+    private function candidateSurfaces(WebProperty $property): Collection
+    {
+        $surfaces = $property->relationLoaded('conversionSurfaces')
+            ? $property->conversionSurfaces
+            : $property->conversionSurfaces()->with(['analyticsSource', 'domain'])->get();
+
+        return $surfaces
+            ->loadMissing(['analyticsSource', 'domain'])
+            ->map(function (WebPropertyConversionSurface $surface) use ($property): ?array {
+                $source = $surface->analytics_binding_mode === 'inherits_property'
+                    ? $property->primaryAnalyticsSource('ga4')
+                    : $surface->analyticsSource;
+
+                $expectedMeasurementId = $this->expectedMeasurementId($source);
+                if ($expectedMeasurementId === null) {
+                    return null;
+                }
+
+                $hostname = trim($surface->hostname);
+                if ($hostname === '') {
+                    return null;
+                }
+
+                return [
+                    'surface' => $surface,
+                    'expected_measurement_id' => $expectedMeasurementId,
+                    'url' => 'https://'.$hostname.'/',
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    /**
+     * @param  array{surface: WebPropertyConversionSurface, expected_measurement_id: string, url: string}  $surface
+     * @return array<string, mixed>
+     */
+    private function auditSurface(array $surface, int $timeout): array
+    {
+        $probe = $this->firstSuccessfulProbe(collect([$surface['url']]), $timeout);
+
+        if ($probe === null) {
+            return [
+                'hostname' => $surface['surface']->hostname,
+                'verdict' => 'fetch_failed',
+                'summary' => 'Could not fetch the conversion surface to verify GA4.',
+                'expected_measurement_id' => $surface['expected_measurement_id'],
+                'detected_measurement_ids' => [],
+                'detected_script_hosts' => [],
+                'best_url' => $surface['url'],
+            ];
+        }
+
+        $analysis = $this->analyzeHtml($probe['html'], $probe['url'], $timeout);
+        [$verdict, $summary] = $this->verdictForSignalSet(
+            $surface['expected_measurement_id'],
+            $analysis['measurement_ids']
+        );
+
+        return [
+            'hostname' => $surface['surface']->hostname,
+            'verdict' => $verdict,
+            'summary' => $summary,
+            'expected_measurement_id' => $surface['expected_measurement_id'],
+            'detected_measurement_ids' => $analysis['measurement_ids'],
+            'detected_script_hosts' => $analysis['tracker_hosts'],
+            'best_url' => $probe['url'],
+        ];
+    }
+
+    private function expectedMeasurementId(?PropertyAnalyticsSource $source): ?string
+    {
+        if (! $source instanceof PropertyAnalyticsSource || $source->status !== 'active') {
+            return null;
+        }
+
+        $providerConfig = $source->provider_config;
+        $measurementId = is_array($providerConfig)
+            ? ($providerConfig['measurement_id'] ?? null)
+            : null;
+
+        if (! is_string($measurementId) || trim($measurementId) === '') {
+            $measurementId = $source->external_id;
+        }
+
+        if (trim($measurementId) === '') {
+            return null;
+        }
+
+        $normalized = strtoupper(trim($measurementId));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @param  array<int, string>  $detectedMeasurementIds
+     * @return array{0: string, 1: string}
+     */
+    private function verdictForSignalSet(string $expectedMeasurementId, array $detectedMeasurementIds): array
+    {
+        $normalizedDetected = array_values(array_unique(array_map(
+            static fn (string $measurementId): string => strtoupper($measurementId),
+            array_filter($detectedMeasurementIds, 'is_string')
+        )));
+
+        $expectedPresent = in_array($expectedMeasurementId, $normalizedDetected, true);
+
+        if ($normalizedDetected === []) {
+            return [
+                'missing_ga4',
+                'No GA4 measurement ID was detected on the live page.',
+            ];
+        }
+
+        if (count($normalizedDetected) > 1) {
+            return [
+                'duplicate_streams',
+                sprintf(
+                    'Multiple GA4 measurement IDs were detected on the live page: %s.',
+                    implode(', ', $normalizedDetected)
+                ),
+            ];
+        }
+
+        if (! $expectedPresent) {
+            return [
+                'wrong_measurement_id',
+                sprintf(
+                    'The live page is using [%s] instead of the expected [%s].',
+                    $normalizedDetected[0],
+                    $expectedMeasurementId
+                ),
+            ];
+        }
+
+        return [
+            'installed_match',
+            'The live page is using the expected GA4 measurement ID.',
+        ];
+    }
+
+    /**
+     * @param  Collection<int, string>  $urls
+     * @return array{url: string, html: string}|null
+     */
+    private function firstSuccessfulProbe(Collection $urls, int $timeout): ?array
+    {
+        foreach ($urls as $url) {
+            try {
+                $response = Http::timeout($timeout)
+                    ->withHeaders([
+                        'User-Agent' => 'domain-monitor-ga4-audit/1.0',
+                    ])
+                    ->get($url);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (! $response->successful()) {
+                continue;
+            }
+
+            $html = (string) $response->body();
+            if ($html === '') {
+                continue;
+            }
+
+            return [
+                'url' => $url,
+                'html' => $html,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{measurement_ids: array<int, string>, tracker_hosts: array<int, string>}
+     */
+    private function analyzeHtml(string $html, string $baseUrl, int $timeout): array
+    {
+        $measurementIds = $this->extractMeasurementIds($html);
+        $trackerHosts = $this->extractTrackerHosts($html);
+        $scriptUrls = $this->extractScriptUrls($html, $baseUrl);
+        $baseHost = parse_url($baseUrl, PHP_URL_HOST);
+
+        foreach ($scriptUrls as $scriptUrl) {
+            $scriptHost = parse_url($scriptUrl, PHP_URL_HOST);
+            if (! is_string($scriptHost) || ! is_string($baseHost) || Str::lower($scriptHost) !== Str::lower($baseHost)) {
+                continue;
+            }
+
+            try {
+                $response = Http::timeout($timeout)
+                    ->withHeaders([
+                        'User-Agent' => 'domain-monitor-ga4-audit/1.0',
+                    ])
+                    ->get($scriptUrl);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if (! $response->successful()) {
+                continue;
+            }
+
+            $scriptBody = (string) $response->body();
+            if ($scriptBody === '') {
+                continue;
+            }
+
+            $measurementIds = array_values(array_unique(array_merge(
+                $measurementIds,
+                $this->extractMeasurementIds($scriptBody)
+            )));
+            $trackerHosts = array_values(array_unique(array_merge(
+                $trackerHosts,
+                $this->extractTrackerHosts($scriptBody)
+            )));
+        }
+
+        sort($measurementIds);
+        sort($trackerHosts);
+
+        return [
+            'measurement_ids' => $measurementIds,
+            'tracker_hosts' => $trackerHosts,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractMeasurementIds(string $content): array
+    {
+        preg_match_all('/\bG-[A-Z0-9]{4,}\b/i', $content, $matches);
+        $matchedIds = $matches[0];
+
+        return array_values(array_unique(array_map(
+            static fn (string $measurementId): string => strtoupper($measurementId),
+            $matchedIds
+        )));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractTrackerHosts(string $content): array
+    {
+        $hosts = [];
+
+        preg_match_all('/https?:\/\/([^\/"\']+)/i', $content, $matches);
+        $matchedHosts = $matches[1];
+
+        foreach ($matchedHosts as $host) {
+            $normalized = Str::lower(trim($host));
+            if (
+                str_contains($normalized, 'googletagmanager.com')
+                || str_contains($normalized, 'google-analytics.com')
+            ) {
+                $hosts[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($hosts));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractScriptUrls(string $html, string $baseUrl): array
+    {
+        preg_match_all('/<script[^>]+src=["\']([^"\']+)["\']/i', $html, $matches);
+
+        $baseParts = parse_url($baseUrl);
+        if (! is_array($baseParts) || ! isset($baseParts['scheme'], $baseParts['host'])) {
+            return [];
+        }
+
+        $origin = strtolower((string) $baseParts['scheme']).'://'.strtolower((string) $baseParts['host']);
+
+        $resolved = collect($matches[1])
+            ->filter(fn (string $src): bool => trim($src) !== '')
+            ->map(function (string $src) use ($origin, $baseUrl): string {
+                $trimmed = trim($src);
+
+                if (str_starts_with($trimmed, '//')) {
+                    return 'https:'.$trimmed;
+                }
+
+                if (str_starts_with($trimmed, 'http://') || str_starts_with($trimmed, 'https://')) {
+                    return $trimmed;
+                }
+
+                if (str_starts_with($trimmed, '/')) {
+                    return $origin.$trimmed;
+                }
+
+                $basePath = rtrim(dirname(parse_url($baseUrl, PHP_URL_PATH) ?: '/'), '/');
+
+                return $origin.($basePath !== '' ? $basePath.'/' : '/').ltrim($trimmed, '/');
+            })
+            ->filter()
+            ->unique()
+            ->take(self::MAX_SCRIPT_ASSETS)
+            ->values();
+
+        return $resolved->all();
+    }
+
+    private function normalizedUrl(string $url): ?string
+    {
+        $trimmed = trim($url);
+
+        if ($trimmed === '') {
+            return null;
+        }
+
+        if (! str_starts_with(Str::lower($trimmed), 'https://')) {
+            return null;
+        }
+
+        return str_ends_with($trimmed, '/') ? $trimmed : $trimmed.'/';
+    }
+}

--- a/app/Services/MonitoringFindingManager.php
+++ b/app/Services/MonitoringFindingManager.php
@@ -117,7 +117,6 @@ class MonitoringFindingManager
         $finding->forceFill([
             'status' => MonitoringFinding::STATUS_RECOVERED,
             'summary' => $recoverySummary,
-            'last_detected_at' => now(),
             'recovered_at' => now(),
             'evidence' => $normalizedEvidence,
         ])->save();

--- a/app/Services/MonitoringFindingManager.php
+++ b/app/Services/MonitoringFindingManager.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\MonitoringFinding;
+use App\Models\WebProperty;
+use Brain\Client\BrainEventClient;
+
+class MonitoringFindingManager
+{
+    public function __construct(
+        private readonly DetectedIssueIdentityService $issueIdentityService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    public function reportPropertyFinding(
+        WebProperty $property,
+        string $findingType,
+        string $lane,
+        string $issueType,
+        string $title,
+        string $summary,
+        array $evidence,
+        ?string $primaryDomainId = null
+    ): string {
+        $normalizedEvidence = $this->normalizeEvidence($evidence);
+        $issueId = $this->issueIdentityService->makeIssueId(
+            $primaryDomainId ?? '',
+            $property->slug,
+            $findingType
+        );
+        $now = now();
+
+        $finding = MonitoringFinding::query()->firstWhere('issue_id', $issueId);
+        $action = 'updated';
+
+        if (! $finding instanceof MonitoringFinding) {
+            MonitoringFinding::query()->create([
+                'issue_id' => $issueId,
+                'lane' => $lane,
+                'finding_type' => $findingType,
+                'issue_type' => $issueType,
+                'scope_type' => 'web_property',
+                'domain_id' => $primaryDomainId,
+                'web_property_id' => $property->id,
+                'status' => MonitoringFinding::STATUS_OPEN,
+                'title' => $title,
+                'summary' => $summary,
+                'first_detected_at' => $now,
+                'last_detected_at' => $now,
+                'recovered_at' => null,
+                'evidence' => $normalizedEvidence,
+            ]);
+
+            $this->emitBrainEvent('opened', $issueId, $property, $findingType, $lane, $issueType, $title, $summary, MonitoringFinding::STATUS_OPEN, $normalizedEvidence, $primaryDomainId);
+
+            return 'opened';
+        }
+
+        if ($finding->status === MonitoringFinding::STATUS_RECOVERED) {
+            $action = 'reopened';
+        } elseif (
+            $finding->summary === $summary
+            && $this->normalizedJson(is_array($finding->evidence) ? $finding->evidence : []) === $this->normalizedJson($normalizedEvidence)
+        ) {
+            $action = 'observed';
+        }
+
+        $finding->forceFill([
+            'lane' => $lane,
+            'finding_type' => $findingType,
+            'issue_type' => $issueType,
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomainId,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => $title,
+            'summary' => $summary,
+            'last_detected_at' => $now,
+            'recovered_at' => null,
+            'evidence' => $normalizedEvidence,
+        ])->save();
+
+        if ($action !== 'observed') {
+            $this->emitBrainEvent($action, $issueId, $property, $findingType, $lane, $issueType, $title, $summary, MonitoringFinding::STATUS_OPEN, $normalizedEvidence, $primaryDomainId);
+        }
+
+        return $action;
+    }
+
+    /**
+     * @param  array<string, mixed>  $recoveryEvidence
+     */
+    public function recoverPropertyFinding(
+        WebProperty $property,
+        string $findingType,
+        string $lane,
+        string $recoverySummary,
+        array $recoveryEvidence = [],
+        ?string $primaryDomainId = null
+    ): string {
+        $issueId = $this->issueIdentityService->makeIssueId(
+            $primaryDomainId ?? '',
+            $property->slug,
+            $findingType
+        );
+        $finding = MonitoringFinding::query()->firstWhere('issue_id', $issueId);
+
+        if (! $finding instanceof MonitoringFinding || $finding->status === MonitoringFinding::STATUS_RECOVERED) {
+            return 'noop';
+        }
+
+        $normalizedEvidence = $this->normalizeEvidence($recoveryEvidence);
+
+        $finding->forceFill([
+            'status' => MonitoringFinding::STATUS_RECOVERED,
+            'summary' => $recoverySummary,
+            'last_detected_at' => now(),
+            'recovered_at' => now(),
+            'evidence' => $normalizedEvidence,
+        ])->save();
+
+        $this->emitBrainEvent(
+            'recovered',
+            $issueId,
+            $property,
+            $findingType,
+            $lane,
+            $finding->issue_type,
+            $finding->title,
+            $recoverySummary,
+            MonitoringFinding::STATUS_RECOVERED,
+            $normalizedEvidence,
+            $primaryDomainId
+        );
+
+        return 'recovered';
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     */
+    private function emitBrainEvent(
+        string $action,
+        string $issueId,
+        WebProperty $property,
+        string $findingType,
+        string $lane,
+        string $issueType,
+        string $title,
+        string $summary,
+        string $findingStatus,
+        array $evidence,
+        ?string $primaryDomainId
+    ): void {
+        $baseUrl = config('services.brain.base_url');
+        $apiKey = config('services.brain.api_key');
+
+        if (! is_string($baseUrl) || $baseUrl === '' || ! is_string($apiKey) || $apiKey === '') {
+            return;
+        }
+
+        /** @var BrainEventClient $brain */
+        $brain = app(BrainEventClient::class);
+
+        $payload = [
+            'issue_id' => $issueId,
+            'fingerprint' => 'domain_monitor.finding:'.$issueId,
+            'message' => sprintf('%s: %s', $title, $summary),
+            'action' => $action,
+            'lane' => $lane,
+            'finding_type' => $findingType,
+            'issue_type' => $issueType,
+            'finding_status' => $findingStatus,
+            'title' => $title,
+            'summary' => $summary,
+            'occurred_at' => now()->toIso8601String(),
+            'domain_id' => $primaryDomainId,
+            'web_property' => [
+                'id' => $property->id,
+                'slug' => $property->slug,
+                'name' => $property->name,
+                'primary_domain' => $property->primaryDomainName(),
+                'production_url' => $property->production_url,
+            ],
+            'evidence' => $evidence,
+        ];
+
+        $brain->sendAsync('domain_monitor.finding.'.$action, $payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<string, mixed>
+     */
+    private function normalizeEvidence(array $evidence): array
+    {
+        ksort($evidence);
+
+        foreach ($evidence as $key => $value) {
+            if (is_array($value)) {
+                $evidence[$key] = $this->normalizeNestedArray($value);
+            }
+        }
+
+        return $evidence;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $value
+     * @return array<int|string, mixed>
+     */
+    private function normalizeNestedArray(array $value): array
+    {
+        if (array_is_list($value)) {
+            return array_map(
+                fn (mixed $item): mixed => is_array($item) ? $this->normalizeNestedArray($item) : $item,
+                $value
+            );
+        }
+
+        ksort($value);
+
+        foreach ($value as $key => $item) {
+            if (is_array($item)) {
+                $value[$key] = $this->normalizeNestedArray($item);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $value
+     */
+    private function normalizedJson(array $value): string
+    {
+        return json_encode($this->normalizeNestedArray($value), JSON_THROW_ON_ERROR);
+    }
+}

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -850,4 +850,53 @@ return [
             ],
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Monitoring Lanes
+    |--------------------------------------------------------------------------
+    |
+    | Explicit monitoring lanes keep fast live incidents separate from slower
+    | marketing/readiness audits. The first runnable lane is
+    | marketing_integrity, which verifies live GA4 behavior on property and
+    | conversion-surface hosts and emits deduped findings through Brain.
+    |
+    */
+    'monitoring_lanes' => [
+        'critical_live' => [
+            'cadence' => 'frequent',
+            'issue_type' => 'incident',
+            'checks' => [
+                'uptime',
+                'http',
+                'ssl',
+                'redirect_policy',
+            ],
+        ],
+        'marketing_integrity' => [
+            'cadence' => 'daily',
+            'issue_type' => 'regression',
+            'checks' => [
+                'ga4_install',
+                'conversion_surface_ga4',
+            ],
+        ],
+        'seo_agent_readiness' => [
+            'cadence' => 'daily',
+            'issue_type' => 'readiness_gap',
+            'checks' => [
+                'indexability',
+                'structured_data',
+                'agent_readiness',
+            ],
+        ],
+        'deep_audit' => [
+            'cadence' => 'weekly',
+            'issue_type' => 'cleanup',
+            'checks' => [
+                'broken_links',
+                'external_links',
+            ],
+        ],
+    ],
 ];

--- a/database/factories/MonitoringFindingFactory.php
+++ b/database/factories/MonitoringFindingFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MonitoringFinding;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MonitoringFinding>
+ */
+class MonitoringFindingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $firstDetectedAt = fake()->dateTimeBetween('-7 days', '-1 day');
+        $lastDetectedAt = (clone $firstDetectedAt)->modify('+'.fake()->numberBetween(1, 48).' hours');
+
+        return [
+            'issue_id' => 'dm:'.fake()->uuid().':'.fake()->lexify('????????????????'),
+            'lane' => fake()->randomElement(['marketing_integrity', 'critical_live', 'seo_agent_readiness', 'deep_audit']),
+            'finding_type' => fake()->randomElement([
+                'marketing.ga4_install',
+                'marketing.conversion_surface_ga4',
+                'seo.agent_readiness',
+                'critical.redirect_policy',
+            ]),
+            'issue_type' => fake()->randomElement(['incident', 'regression', 'readiness_gap', 'cleanup']),
+            'scope_type' => 'web_property',
+            'domain_id' => \App\Models\Domain::factory(),
+            'web_property_id' => \App\Models\WebProperty::factory(),
+            'status' => fake()->randomElement([\App\Models\MonitoringFinding::STATUS_OPEN, \App\Models\MonitoringFinding::STATUS_RECOVERED]),
+            'title' => fake()->sentence(6),
+            'summary' => fake()->sentence(),
+            'first_detected_at' => $firstDetectedAt,
+            'last_detected_at' => $lastDetectedAt,
+            'recovered_at' => fake()->optional()->dateTimeBetween($lastDetectedAt, 'now'),
+            'evidence' => [
+                'verdict' => fake()->randomElement(['missing_ga4', 'wrong_measurement_id', 'duplicate_streams']),
+            ],
+        ];
+    }
+}

--- a/database/migrations/2026_04_21_125252_create_monitoring_findings_table.php
+++ b/database/migrations/2026_04_21_125252_create_monitoring_findings_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('monitoring_findings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('issue_id')->unique();
+            $table->string('lane', 80);
+            $table->string('finding_type', 120);
+            $table->string('issue_type', 40);
+            $table->string('scope_type', 40)->default('web_property');
+            $table->uuid('domain_id')->nullable();
+            $table->uuid('web_property_id')->nullable();
+            $table->string('status', 20)->default('open');
+            $table->string('title');
+            $table->text('summary')->nullable();
+            $table->timestamp('first_detected_at')->nullable();
+            $table->timestamp('last_detected_at')->nullable();
+            $table->timestamp('recovered_at')->nullable();
+            $table->json('evidence')->nullable();
+            $table->timestamps();
+
+            $table->foreign('domain_id')->references('id')->on('domains')->nullOnDelete();
+            $table->foreign('web_property_id')->references('id')->on('web_properties')->nullOnDelete();
+            $table->index(['lane', 'status']);
+            $table->index(['finding_type', 'status']);
+            $table->index(['web_property_id', 'finding_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('monitoring_findings');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -790,6 +790,12 @@ Schedule::command('analytics:refresh-matomo-install-audits')
     ->at('08:50')
     ->timezone('UTC');
 
+// Verify live marketing-integrity checks that are not covered by infrastructure-only health checks.
+Schedule::command('monitoring:run-lane marketing_integrity')
+    ->daily()
+    ->at('08:55')
+    ->timezone('UTC');
+
 // Refresh fleet automation coverage after upstream analytics imports have had time to settle.
 Schedule::command('analytics:refresh-automation-coverage')
     ->daily()

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\MonitoringFinding;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use App\Models\WebPropertyConversionSurface;
+use App\Models\WebPropertyDomain;
+use Brain\Client\BrainEventClient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Mockery;
+use Tests\TestCase;
+
+class RunMonitoringLaneCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_marketing_integrity_lane_creates_and_surfaces_a_ga4_install_finding(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('tracked.example.au', 'Tracked Example');
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-EXPECTED123',
+            'external_name' => 'Tracked Example',
+            'provider_config' => [
+                'measurement_id' => 'G-EXPECTED123',
+            ],
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        Http::fake([
+            'https://tracked.example.au/' => Http::response('<html><head><title>No GA4</title></head><body>Missing</body></html>', 200),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $sendAsyncExpectation */
+        $sendAsyncExpectation = $brain->shouldReceive('sendAsync');
+        $sendAsyncExpectation->once()->withArgs(function (string $eventType, array $payload) use ($property): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.ga4_install', $payload['finding_type']);
+            $this->assertSame($property->slug, data_get($payload, 'web_property.slug'));
+            $this->assertSame('regression', $payload['issue_type']);
+            $this->assertSame('open', $payload['finding_status']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $finding = MonitoringFinding::query()->where('finding_type', 'marketing.ga4_install')->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
+        $this->assertSame($property->id, $finding->web_property_id);
+        $this->assertSame('missing_ga4', data_get($finding->evidence, 'verdict'));
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+        /** @var array<int, array<string, mixed>> $issues */
+        $matchingIssue = collect($issues)->firstWhere('issue_id', $finding->issue_id);
+
+        $this->assertIsArray($matchingIssue);
+        $this->assertSame('marketing.ga4_install', $matchingIssue['issue_class']);
+        $this->assertSame('must_fix', $matchingIssue['severity']);
+    }
+
+    public function test_marketing_integrity_lane_recovers_existing_findings_and_flags_conversion_surface_mismatches(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('brand.example.au', 'Brand Example');
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-EXPECTED999',
+            'external_name' => 'Brand Example',
+            'provider_config' => [
+                'measurement_id' => 'G-EXPECTED999',
+            ],
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $surfaceDomain = Domain::factory()->create([
+            'domain' => 'quotes.brand.example.au',
+            'is_active' => true,
+            'platform' => 'Laravel',
+        ]);
+
+        WebPropertyConversionSurface::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $surfaceDomain->id,
+            'property_analytics_source_id' => $source->id,
+            'hostname' => 'quotes.brand.example.au',
+            'surface_type' => 'quote',
+            'journey_type' => 'household',
+            'analytics_binding_mode' => 'inherits_property',
+            'event_contract_binding_mode' => 'inherits_property',
+            'rollout_status' => 'instrumented',
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $recoveredExpectation */
+        $recoveredExpectation = $brain->shouldReceive('sendAsync');
+        $recoveredExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.recovered', $eventType);
+            $this->assertSame('marketing.ga4_install', $payload['finding_type']);
+            $this->assertSame('recovered', $payload['finding_status']);
+
+            return true;
+        });
+        /** @var Mockery\Expectation $openedExpectation */
+        $openedExpectation = $brain->shouldReceive('sendAsync');
+        $openedExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.conversion_surface_ga4', $payload['finding_type']);
+
+            return true;
+        });
+
+        $primaryDomain = $property->primaryDomainModel();
+        $this->assertInstanceOf(Domain::class, $primaryDomain);
+
+        MonitoringFinding::create([
+            'issue_id' => app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
+                $primaryDomain->id,
+                $property->slug,
+                'marketing.ga4_install'
+            ),
+            'lane' => 'marketing_integrity',
+            'finding_type' => 'marketing.ga4_install',
+            'issue_type' => 'regression',
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'GA4 install mismatch on live property',
+            'summary' => 'Old failure',
+            'first_detected_at' => now()->subDay(),
+            'last_detected_at' => now()->subDay(),
+            'evidence' => ['verdict' => 'missing_ga4'],
+        ]);
+
+        Http::fake([
+            'https://brand.example.au/' => Http::response(
+                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-EXPECTED999\"></script><script>gtag('config','G-EXPECTED999');</script>",
+                200
+            ),
+            'https://quotes.brand.example.au/' => Http::response(
+                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-WRONG000\"></script><script>gtag('config','G-WRONG000');</script>",
+                200
+            ),
+        ]);
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'marketing.ga4_install',
+            'status' => MonitoringFinding::STATUS_RECOVERED,
+        ]);
+
+        $conversionFinding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.conversion_surface_ga4')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $conversionFinding->status);
+        $this->assertSame('wrong_measurement_id', data_get($conversionFinding->evidence, 'verdict'));
+        $this->assertSame('quotes.brand.example.au', data_get($conversionFinding->evidence, 'failing_surfaces.0.hostname'));
+    }
+
+    private function makeProperty(string $domainName, string $name): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+            'platform' => 'Astro',
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $name,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://'.$domainName.'/',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+}

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -141,7 +141,7 @@ class RunMonitoringLaneCommandTest extends TestCase
         $primaryDomain = $property->primaryDomainModel();
         $this->assertInstanceOf(Domain::class, $primaryDomain);
 
-        MonitoringFinding::create([
+        MonitoringFinding::factory()->create([
             'issue_id' => app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
                 $primaryDomain->id,
                 $property->slug,
@@ -191,6 +191,89 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame(MonitoringFinding::STATUS_OPEN, $conversionFinding->status);
         $this->assertSame('wrong_measurement_id', data_get($conversionFinding->evidence, 'verdict'));
         $this->assertSame('quotes.brand.example.au', data_get($conversionFinding->evidence, 'failing_surfaces.0.hostname'));
+    }
+
+    public function test_marketing_integrity_lane_skips_properties_without_an_active_primary_ga4_source(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('inactive-primary.example.au', 'Inactive Primary');
+        $primarySource = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-INACTIVE001',
+            'external_name' => 'Inactive Primary',
+            'provider_config' => [
+                'measurement_id' => 'G-INACTIVE001',
+            ],
+            'is_primary' => true,
+            'status' => 'inactive',
+        ]);
+
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-ACTIVE999',
+            'external_name' => 'Inactive Primary Secondary',
+            'provider_config' => [
+                'measurement_id' => 'G-ACTIVE999',
+            ],
+            'is_primary' => false,
+            'status' => 'active',
+        ]);
+
+        $primaryDomain = $property->primaryDomainModel();
+        $this->assertInstanceOf(Domain::class, $primaryDomain);
+
+        MonitoringFinding::factory()->create([
+            'issue_id' => app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
+                $primaryDomain->id,
+                $property->slug,
+                'marketing.ga4_install'
+            ),
+            'lane' => 'marketing_integrity',
+            'finding_type' => 'marketing.ga4_install',
+            'issue_type' => 'regression',
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'GA4 install mismatch on live property',
+            'summary' => 'Existing open finding',
+            'evidence' => ['verdict' => 'missing_ga4'],
+        ]);
+
+        Http::fake([
+            'https://inactive-primary.example.au/' => Http::response(
+                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-ACTIVE999\"></script><script>gtag('config','G-ACTIVE999');</script>",
+                200
+            ),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        $brain->shouldNotReceive('sendAsync');
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseHas('monitoring_findings', [
+            'issue_id' => app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
+                $primaryDomain->id,
+                $property->slug,
+                'marketing.ga4_install'
+            ),
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $this->assertDatabaseHas('property_analytics_sources', [
+            'id' => $primarySource->id,
+            'status' => 'inactive',
+            'is_primary' => true,
+        ]);
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty


### PR DESCRIPTION
## Summary
- add explicit monitoring lane configuration and a new `monitoring:run-lane` command
- add a persisted monitoring finding model that dedupes by stable issue id and emits open/update/recovery events through the existing Brain path
- implement the first marketing-integrity checks for property homepage GA4 installs and conversion-surface GA4 mismatches, and surface those findings through `/api/issues`

## Verification
- `php artisan test tests/Feature/RunMonitoringLaneCommandTest.php`
- `php artisan test tests/Feature/DetectedIssueApiTest.php`
- `./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Models/MonitoringFinding.php app/Services/MonitoringFindingManager.php app/Services/Ga4SignalScanner.php app/Services/DetectedIssueSummaryService.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G`
- `./vendor/bin/pint --dirty`

Closes #120
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
