### PR TITLE
Run the next monitoring integrity lanes

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -6,9 +6,11 @@ use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
 use App\Services\Ga4SignalScanner;
 use App\Services\MonitoringFindingManager;
+use App\Services\PropertySiteSignalScanner;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 class RunMonitoringLane extends Command
 {
@@ -20,8 +22,11 @@ class RunMonitoringLane extends Command
 
     protected $description = 'Run an explicit monitoring lane and emit deduped findings through the Brain path.';
 
-    public function handle(Ga4SignalScanner $scanner, MonitoringFindingManager $findings): int
-    {
+    public function handle(
+        Ga4SignalScanner $ga4Scanner,
+        PropertySiteSignalScanner $siteScanner,
+        MonitoringFindingManager $findings
+    ): int {
         $lane = (string) $this->argument('lane');
         $timeout = max(1, (int) $this->option('timeout'));
         $laneConfig = config('domain_monitor.monitoring_lanes.'.$lane);
@@ -32,16 +37,10 @@ class RunMonitoringLane extends Command
             return self::FAILURE;
         }
 
-        if ($lane !== 'marketing_integrity') {
-            $this->warn(sprintf('Lane [%s] is configured but does not have runnable checks yet.', $lane));
-
-            return self::SUCCESS;
-        }
-
-        $properties = $this->marketingIntegrityProperties();
+        $properties = $this->laneProperties($lane);
 
         if ($properties->isEmpty()) {
-            $this->warn('No active GA4-linked properties matched the requested lane scope.');
+            $this->warn(sprintf('No active properties matched the requested [%s] lane scope.', $lane));
 
             return self::SUCCESS;
         }
@@ -60,41 +59,70 @@ class RunMonitoringLane extends Command
             ]);
 
             $primaryDomain = $property->primaryDomainModel();
+            $audits = match ($lane) {
+                'critical_live' => [
+                    'critical.redirect_policy' => [
+                        'title' => 'Root redirect policy mismatch on live property',
+                        'issue_type' => 'incident',
+                        'audit' => $siteScanner->auditRedirectPolicy($property, $timeout),
+                    ],
+                ],
+                'marketing_integrity' => [
+                    'marketing.ga4_install' => [
+                        'title' => 'GA4 install mismatch on live property',
+                        'issue_type' => 'regression',
+                        'audit' => $ga4Scanner->auditPropertyHomepage($property, $timeout),
+                    ],
+                    'marketing.conversion_surface_ga4' => [
+                        'title' => 'GA4 mismatch on conversion surfaces',
+                        'issue_type' => 'regression',
+                        'audit' => $ga4Scanner->auditConversionSurfaces($property, $timeout),
+                    ],
+                    'marketing.indexability' => [
+                        'title' => 'Homepage indexability mismatch on live property',
+                        'issue_type' => 'regression',
+                        'audit' => $siteScanner->auditIndexability($property, $timeout),
+                    ],
+                ],
+                'seo_agent_readiness' => [
+                    'seo.structured_data' => [
+                        'title' => 'Structured data missing or invalid on homepage',
+                        'issue_type' => 'readiness_gap',
+                        'audit' => $siteScanner->auditStructuredData($property, $timeout),
+                    ],
+                    'seo.agent_readiness' => [
+                        'title' => 'Agent-readiness files missing on live property',
+                        'issue_type' => 'readiness_gap',
+                        'audit' => $siteScanner->auditAgentReadiness($property, $timeout),
+                    ],
+                ],
+                default => [],
+            };
 
-            $homepageAudit = $scanner->auditPropertyHomepage($property, $timeout);
-            $homepageOutcome = $this->syncFinding(
-                findings: $findings,
-                property: $property,
-                findingType: 'marketing.ga4_install',
-                title: 'GA4 install mismatch on live property',
-                audit: $homepageAudit,
-                primaryDomainId: $primaryDomain?->id
-            );
+            $verdicts = [];
 
-            $surfaceAudit = $scanner->auditConversionSurfaces($property, $timeout);
-            $surfaceOutcome = $this->syncFinding(
-                findings: $findings,
-                property: $property,
-                findingType: 'marketing.conversion_surface_ga4',
-                title: 'GA4 mismatch on conversion surfaces',
-                audit: $surfaceAudit,
-                primaryDomainId: $primaryDomain?->id
-            );
+            foreach ($audits as $findingType => $definition) {
+                $outcome = $this->syncFinding(
+                    findings: $findings,
+                    property: $property,
+                    findingType: $findingType,
+                    issueType: (string) $definition['issue_type'],
+                    title: (string) $definition['title'],
+                    audit: (array) $definition['audit'],
+                    primaryDomainId: $primaryDomain?->id
+                );
 
-            $opened += (int) in_array($homepageOutcome, ['opened', 'reopened'], true);
-            $updated += (int) ($homepageOutcome === 'updated');
-            $recovered += (int) ($homepageOutcome === 'recovered');
+                $opened += (int) in_array($outcome, ['opened', 'reopened'], true);
+                $updated += (int) ($outcome === 'updated');
+                $recovered += (int) ($outcome === 'recovered');
+                $verdicts[] = sprintf(
+                    '%s=%s',
+                    Str::afterLast($findingType, '.'),
+                    (string) data_get($definition, 'audit.verdict', 'unknown')
+                );
+            }
 
-            $opened += (int) in_array($surfaceOutcome, ['opened', 'reopened'], true);
-            $updated += (int) ($surfaceOutcome === 'updated');
-            $recovered += (int) ($surfaceOutcome === 'recovered');
-
-            $this->line(sprintf(
-                '[%s] homepage=%s | conversion_surfaces=%s',
-                $property->slug,
-                $homepageAudit['verdict'],
-                $surfaceAudit['verdict']
-            ));
+            $this->line(sprintf('[%s] %s', $property->slug, implode(' | ', $verdicts)));
         }
 
         $this->newLine();
@@ -113,12 +141,12 @@ class RunMonitoringLane extends Command
     /**
      * @return Collection<int, WebProperty>
      */
-    private function marketingIntegrityProperties(): Collection
+    private function laneProperties(string $lane): Collection
     {
         $propertyFilter = $this->optionString('property');
         $domainFilter = $this->optionString('domain');
 
-        return WebProperty::query()
+        $query = WebProperty::query()
             ->where('status', 'active')
             ->with([
                 'primaryDomain',
@@ -127,10 +155,6 @@ class RunMonitoringLane extends Command
                 'conversionSurfaces.analyticsSource',
                 'conversionSurfaces.domain',
             ])
-            ->whereHas('analyticsSources', function (Builder $query): void {
-                $query->where('provider', 'ga4')
-                    ->where('status', 'active');
-            })
             ->when(
                 $propertyFilter,
                 fn (Builder $query) => $query->where('slug', $propertyFilter)
@@ -141,9 +165,24 @@ class RunMonitoringLane extends Command
                     'propertyDomains.domain',
                     fn (Builder $domainQuery) => $domainQuery->where('domain', $domainFilter)
                 )
-            )
+            );
+
+        if ($lane === 'marketing_integrity') {
+            $query->whereHas('analyticsSources', function (Builder $query): void {
+                $query->where('provider', 'ga4')
+                    ->where('status', 'active');
+            });
+        }
+
+        return $query
             ->get()
-            ->filter(fn (WebProperty $property): bool => $this->expectedMeasurementId($property) !== null)
+            ->filter(function (WebProperty $property) use ($lane): bool {
+                if ($lane === 'marketing_integrity') {
+                    return $this->expectedMeasurementId($property) !== null;
+                }
+
+                return $property->production_url !== null || $property->primaryDomainName() !== null;
+            })
             ->values();
     }
 
@@ -154,6 +193,7 @@ class RunMonitoringLane extends Command
         MonitoringFindingManager $findings,
         WebProperty $property,
         string $findingType,
+        string $issueType,
         string $title,
         array $audit,
         ?string $primaryDomainId
@@ -162,8 +202,8 @@ class RunMonitoringLane extends Command
             return $findings->reportPropertyFinding(
                 property: $property,
                 findingType: $findingType,
-                lane: 'marketing_integrity',
-                issueType: 'regression',
+                lane: $this->argument('lane'),
+                issueType: $issueType,
                 title: $title,
                 summary: (string) ($audit['summary'] ?? ''),
                 evidence: $audit['evidence'] ?? [],
@@ -174,7 +214,7 @@ class RunMonitoringLane extends Command
         return $findings->recoverPropertyFinding(
             property: $property,
             findingType: $findingType,
-            lane: 'marketing_integrity',
+            lane: (string) $this->argument('lane'),
             recoverySummary: (string) ($audit['summary'] ?? ''),
             recoveryEvidence: $audit['evidence'] ?? [],
             primaryDomainId: $primaryDomainId

--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -1,0 +1,685 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\WebProperty;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class PropertySiteSignalScanner
+{
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditIndexability(WebProperty $property, int $timeout = 10): array
+    {
+        $probe = $this->firstSuccessfulProbe($this->candidateUrlsForProperty($property), $timeout);
+
+        if ($probe === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'fetch_failed',
+                'summary' => 'Could not fetch any live property URL to verify homepage indexability.',
+                'evidence' => [
+                    'verdict' => 'fetch_failed',
+                    'urls' => $this->candidateUrlsForProperty($property)->all(),
+                ],
+            ];
+        }
+
+        $expectedOrigin = $this->expectedOrigin($property);
+        $canonicalUrl = $this->extractCanonicalUrl($probe['html']);
+        $noindex = $this->hasNoindexDirective($probe['html'], $probe['headers']);
+        $robots = $this->fetchRobotsFile($probe['final_url'], $timeout);
+        $sitemapReference = $robots['sitemap_url'] ?? null;
+        $problems = [];
+
+        if ($canonicalUrl === null) {
+            $problems[] = 'missing_canonical';
+        } elseif ($expectedOrigin !== null && ! $this->canonicalMatchesExpectedOrigin($canonicalUrl, $expectedOrigin, $probe['final_url'])) {
+            $problems[] = 'wrong_canonical';
+        }
+
+        if ($noindex) {
+            $problems[] = 'homepage_noindex';
+        }
+
+        if ($expectedOrigin !== null && ! $this->finalUrlMatchesExpectedOrigin($probe['final_url'], $expectedOrigin)) {
+            $problems[] = 'preferred_host_mismatch';
+        }
+
+        if (! is_string($sitemapReference) || trim($sitemapReference) === '') {
+            $problems[] = 'sitemap_not_referenced';
+        }
+
+        if ($problems === []) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'indexable',
+                'summary' => 'Homepage canonical, robots, and sitemap signals look indexable.',
+                'evidence' => [
+                    'verdict' => 'indexable',
+                    'best_url' => $probe['url'],
+                    'final_url' => $probe['final_url'],
+                    'canonical_url' => $canonicalUrl,
+                    'expected_origin' => $expectedOrigin,
+                    'has_noindex' => false,
+                    'robots_url' => $robots['url'],
+                    'robots_status' => $robots['status'],
+                    'sitemap_url' => $sitemapReference,
+                    'problems' => [],
+                ],
+            ];
+        }
+
+        $verdict = $problems[0];
+
+        return [
+            'status' => 'fail',
+            'verdict' => $verdict,
+            'summary' => $this->summaryForIndexabilityProblems($problems, $expectedOrigin),
+            'evidence' => [
+                'verdict' => $verdict,
+                'best_url' => $probe['url'],
+                'final_url' => $probe['final_url'],
+                'canonical_url' => $canonicalUrl,
+                'expected_origin' => $expectedOrigin,
+                'has_noindex' => $noindex,
+                'robots_url' => $robots['url'],
+                'robots_status' => $robots['status'],
+                'sitemap_url' => $sitemapReference,
+                'problems' => $problems,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditStructuredData(WebProperty $property, int $timeout = 10): array
+    {
+        $probe = $this->firstSuccessfulProbe($this->candidateUrlsForProperty($property), $timeout);
+
+        if ($probe === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'fetch_failed',
+                'summary' => 'Could not fetch any live property URL to verify structured data.',
+                'evidence' => [
+                    'verdict' => 'fetch_failed',
+                    'urls' => $this->candidateUrlsForProperty($property)->all(),
+                ],
+            ];
+        }
+
+        $scripts = $this->structuredDataScripts($probe['html']);
+        $validScriptCount = collect($scripts)
+            ->filter(fn (array $script): bool => $script['valid'])
+            ->count();
+
+        if ($scripts === []) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_structured_data',
+                'summary' => 'Homepage does not expose any JSON-LD structured data.',
+                'evidence' => [
+                    'verdict' => 'missing_structured_data',
+                    'best_url' => $probe['url'],
+                    'final_url' => $probe['final_url'],
+                    'script_count' => 0,
+                    'valid_script_count' => 0,
+                ],
+            ];
+        }
+
+        if ($validScriptCount === 0) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'invalid_structured_data',
+                'summary' => 'Homepage exposes JSON-LD script tags, but none contain valid JSON.',
+                'evidence' => [
+                    'verdict' => 'invalid_structured_data',
+                    'best_url' => $probe['url'],
+                    'final_url' => $probe['final_url'],
+                    'script_count' => count($scripts),
+                    'valid_script_count' => 0,
+                    'scripts' => $scripts,
+                ],
+            ];
+        }
+
+        return [
+            'status' => 'ok',
+            'verdict' => 'structured_data_present',
+            'summary' => 'Homepage exposes valid JSON-LD structured data.',
+            'evidence' => [
+                'verdict' => 'structured_data_present',
+                'best_url' => $probe['url'],
+                'final_url' => $probe['final_url'],
+                'script_count' => count($scripts),
+                'valid_script_count' => $validScriptCount,
+                'scripts' => $scripts,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditAgentReadiness(WebProperty $property, int $timeout = 10): array
+    {
+        $baseUrl = $this->baseUrlForProperty($property);
+        $robots = $this->fetchTextFile($baseUrl.'/robots.txt', $timeout);
+        $sitemap = $this->fetchSitemapFile($baseUrl, $timeout);
+        $llms = $this->fetchTextFile($baseUrl.'/llms.txt', $timeout);
+        $missing = collect([
+            $robots['ok'] ? null : 'robots.txt',
+            $sitemap['ok'] ? null : 'sitemap',
+            $llms['ok'] ? null : 'llms.txt',
+        ])->filter()->values();
+
+        if ($missing->isEmpty()) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'agent_readiness_present',
+                'summary' => 'robots.txt, sitemap, and llms.txt are all reachable.',
+                'evidence' => [
+                    'verdict' => 'agent_readiness_present',
+                    'base_url' => $baseUrl,
+                    'robots' => Arr::except($robots, ['body']),
+                    'sitemap' => Arr::except($sitemap, ['body']),
+                    'llms' => Arr::except($llms, ['body']),
+                    'missing_files' => [],
+                ],
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'verdict' => 'agent_readiness_missing',
+            'summary' => sprintf(
+                'Agent-readiness files are incomplete: missing %s.',
+                $missing->implode(', ')
+            ),
+            'evidence' => [
+                'verdict' => 'agent_readiness_missing',
+                'base_url' => $baseUrl,
+                'robots' => Arr::except($robots, ['body']),
+                'sitemap' => Arr::except($sitemap, ['body']),
+                'llms' => Arr::except($llms, ['body']),
+                'missing_files' => $missing->all(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditRedirectPolicy(WebProperty $property, int $timeout = 10): array
+    {
+        $expectedOrigin = $this->expectedOrigin($property);
+
+        if ($expectedOrigin === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_expected_origin',
+                'summary' => 'Property does not have a resolvable preferred origin for redirect checks.',
+                'evidence' => [
+                    'verdict' => 'missing_expected_origin',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $expectedParts = parse_url($expectedOrigin);
+        $expectedHost = is_array($expectedParts) ? (string) ($expectedParts['host'] ?? '') : '';
+        $httpProbe = $this->probeUrl('http://'.$expectedHost.'/', $timeout);
+        $alternateHost = $this->alternateHost($expectedHost);
+        $alternateProbe = $alternateHost !== null
+            ? $this->probeUrl('https://'.$alternateHost.'/', $timeout)
+            : null;
+        $problems = [];
+
+        if ($httpProbe === null) {
+            $problems[] = 'http_fetch_failed';
+        } else {
+            if (! $this->finalUrlMatchesExpectedOrigin($httpProbe['final_url'], $expectedOrigin)) {
+                $problems[] = 'http_upgrade_failed';
+            }
+
+            if (count($httpProbe['redirect_chain']) > 2) {
+                $problems[] = 'redirect_chain_too_long';
+            }
+        }
+
+        if ($alternateHost !== null) {
+            if ($alternateProbe === null) {
+                $problems[] = 'preferred_host_unverified';
+            } elseif (! $this->finalUrlMatchesExpectedOrigin($alternateProbe['final_url'], $expectedOrigin)) {
+                $problems[] = 'preferred_host_mismatch';
+            }
+        }
+
+        if ($problems === []) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'redirect_policy_ok',
+                'summary' => 'Root redirects resolve cleanly to the preferred HTTPS host.',
+                'evidence' => [
+                    'verdict' => 'redirect_policy_ok',
+                    'expected_origin' => $expectedOrigin,
+                    'http_probe' => $httpProbe,
+                    'alternate_probe' => $alternateProbe,
+                    'problems' => [],
+                ],
+            ];
+        }
+
+        $verdict = $problems[0];
+
+        return [
+            'status' => 'fail',
+            'verdict' => $verdict,
+            'summary' => $this->summaryForRedirectProblems($problems, $expectedOrigin),
+            'evidence' => [
+                'verdict' => $verdict,
+                'expected_origin' => $expectedOrigin,
+                'http_probe' => $httpProbe,
+                'alternate_probe' => $alternateProbe,
+                'problems' => $problems,
+            ],
+        ];
+    }
+
+    /**
+     * @return Collection<int, string>
+     */
+    private function candidateUrlsForProperty(WebProperty $property): Collection
+    {
+        $urls = [];
+
+        if (is_string($property->production_url) && trim($property->production_url) !== '') {
+            $urls[] = trim($property->production_url);
+        }
+
+        $expectedOrigin = $this->expectedOrigin($property);
+        if ($expectedOrigin !== null) {
+            $urls[] = $expectedOrigin.'/';
+        }
+
+        $primaryDomain = $property->primaryDomainName();
+        if (is_string($primaryDomain) && trim($primaryDomain) !== '') {
+            $urls[] = 'https://'.trim($primaryDomain).'/';
+        }
+
+        /** @var Collection<int, string> $normalizedUrls */
+        $normalizedUrls = collect($urls)
+            ->map(fn (string $url): string => $this->normalizedUrl($url))
+            ->filter(fn (string $url): bool => $url !== '')
+            ->unique()
+            ->values();
+
+        return $normalizedUrls;
+    }
+
+    private function baseUrlForProperty(WebProperty $property): string
+    {
+        return $this->expectedOrigin($property)
+            ?? rtrim($this->normalizedUrl($property->production_url ?? ''), '/')
+            ?: 'https://'.trim((string) $property->primaryDomainName());
+    }
+
+    private function expectedOrigin(WebProperty $property): ?string
+    {
+        $scheme = $property->canonical_origin_scheme;
+        $host = $property->canonical_origin_host;
+
+        if (is_string($scheme) && trim($scheme) !== '' && is_string($host) && trim($host) !== '') {
+            return strtolower(trim($scheme)).'://'.Str::lower(trim($host));
+        }
+
+        $primaryDomain = $property->primaryDomainName();
+
+        if (! is_string($primaryDomain) || trim($primaryDomain) === '') {
+            return null;
+        }
+
+        return 'https://'.Str::lower(trim($primaryDomain));
+    }
+
+    /**
+     * @param  Collection<int, string>  $urls
+     * @return array<string, mixed>|null
+     */
+    private function firstSuccessfulProbe(Collection $urls, int $timeout): ?array
+    {
+        foreach ($urls as $url) {
+            $probe = $this->probeUrl($url, $timeout);
+
+            if ($probe !== null && $probe['successful']) {
+                return $probe;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function probeUrl(string $url, int $timeout): ?array
+    {
+        try {
+            $response = Http::timeout($timeout)
+                ->withHeaders(['User-Agent' => 'DomainMonitor/1.0'])
+                ->withOptions([
+                    'allow_redirects' => [
+                        'max' => 5,
+                        'track_redirects' => true,
+                    ],
+                ])
+                ->get($url);
+
+            $redirectHistory = Arr::wrap($response->header('X-Guzzle-Redirect-History'));
+            $statusHistory = Arr::wrap($response->header('X-Guzzle-Redirect-Status-History'));
+            $finalUrl = is_string(last($redirectHistory)) && trim((string) last($redirectHistory)) !== ''
+                ? (string) last($redirectHistory)
+                : $url;
+
+            $normalizedRedirectHistory = collect($redirectHistory)
+                ->map(fn (string $item): string => trim($item))
+                ->filter(fn (string $item): bool => $item !== '')
+                ->values()
+                ->all();
+            $normalizedStatusHistory = collect($statusHistory)
+                ->map(fn (string $item): int => (int) $item)
+                ->values()
+                ->all();
+
+            return [
+                'url' => $url,
+                'final_url' => $finalUrl,
+                'status' => $response->status(),
+                'successful' => $response->successful(),
+                'headers' => $response->headers(),
+                'html' => $response->body(),
+                'redirect_chain' => $normalizedRedirectHistory,
+                'redirect_statuses' => $normalizedStatusHistory,
+            ];
+        } catch (ConnectionException|RequestException) {
+            return null;
+        }
+    }
+
+    /**
+     * @return array{ok: bool, url: string, status: int, body: string|null, error: string|null, sitemap_url?: string|null}
+     */
+    private function fetchRobotsFile(string $pageUrl, int $timeout): array
+    {
+        $parts = parse_url($pageUrl);
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return [
+                'ok' => false,
+                'url' => '',
+                'status' => 0,
+                'body' => null,
+                'error' => 'invalid_page_url',
+                'sitemap_url' => null,
+            ];
+        }
+
+        $baseUrl = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+        if (isset($parts['port'])) {
+            $baseUrl .= ':'.$parts['port'];
+        }
+
+        $robots = $this->fetchTextFile($baseUrl.'/robots.txt', $timeout);
+        $body = $robots['body'] ?? null;
+
+        if (! is_string($body) || $body === '') {
+            $robots['sitemap_url'] = null;
+
+            return $robots;
+        }
+
+        preg_match('/^\s*Sitemap:\s*(\S+)\s*$/im', $body, $matches);
+        $robots['sitemap_url'] = is_string($matches[1] ?? null) ? trim($matches[1]) : null;
+
+        return $robots;
+    }
+
+    /**
+     * @return array{ok: bool, url: string, status: int, body: string|null, error: string|null}
+     */
+    private function fetchTextFile(string $url, int $timeout): array
+    {
+        try {
+            $response = Http::timeout($timeout)
+                ->withHeaders(['User-Agent' => 'DomainMonitor/1.0'])
+                ->get($url);
+
+            return [
+                'ok' => $response->successful(),
+                'url' => $url,
+                'status' => $response->status(),
+                'body' => $response->successful() ? $response->body() : null,
+                'error' => $response->successful() ? null : 'status_'.$response->status(),
+            ];
+        } catch (ConnectionException|RequestException $exception) {
+            return [
+                'ok' => false,
+                'url' => $url,
+                'status' => 0,
+                'body' => null,
+                'error' => $exception->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @return array{ok: bool, url: string, status: int, body: string|null, error: string|null}
+     */
+    private function fetchSitemapFile(string $baseUrl, int $timeout): array
+    {
+        $base = rtrim($baseUrl, '/');
+        $sitemap = $this->fetchTextFile($base.'/sitemap.xml', $timeout);
+
+        if ($sitemap['ok']) {
+            return $sitemap;
+        }
+
+        return $this->fetchTextFile($base.'/sitemap_index.xml', $timeout);
+    }
+
+    private function extractCanonicalUrl(string $html): ?string
+    {
+        if (preg_match('/<link[^>]+rel=["\'][^"\']*canonical[^"\']*["\'][^>]+href=["\']([^"\']+)["\']/i', $html, $matches) === 1) {
+            return trim((string) $matches[1]);
+        }
+
+        if (preg_match('/<link[^>]+href=["\']([^"\']+)["\'][^>]+rel=["\'][^"\']*canonical[^"\']*["\']/i', $html, $matches) === 1) {
+            return trim((string) $matches[1]);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, array<int, string>>  $headers
+     */
+    private function hasNoindexDirective(string $html, array $headers): bool
+    {
+        if (preg_match('/<meta[^>]+name=["\']robots["\'][^>]+content=["\']([^"\']*)["\']/i', $html, $matches) === 1) {
+            return Str::contains(Str::lower((string) $matches[1]), 'noindex');
+        }
+
+        if (preg_match('/<meta[^>]+content=["\']([^"\']*)["\'][^>]+name=["\']robots["\']/i', $html, $matches) === 1) {
+            return Str::contains(Str::lower((string) $matches[1]), 'noindex');
+        }
+
+        $robotsHeaders = $headers['X-Robots-Tag'] ?? $headers['x-robots-tag'] ?? [];
+
+        return collect(Arr::wrap($robotsHeaders))
+            ->contains(fn (string $header): bool => Str::contains(Str::lower($header), 'noindex'));
+    }
+
+    /**
+     * @return array<int, array{valid: bool, type: string|null}>
+     */
+    private function structuredDataScripts(string $html): array
+    {
+        preg_match_all('/<script[^>]*type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is', $html, $matches);
+        $contents = $matches[1];
+
+        return collect($contents)
+            ->map(function (string $content): array {
+                $decoded = json_decode(trim($content), true);
+
+                if (! is_array($decoded)) {
+                    return ['valid' => false, 'type' => null];
+                }
+
+                $type = data_get($decoded, '@type');
+
+                if (! is_string($type) && is_array(data_get($decoded, '@graph'))) {
+                    $type = collect(data_get($decoded, '@graph'))
+                        ->first(fn (mixed $node): bool => is_array($node) && is_string($node['@type'] ?? null))['@type'] ?? null;
+                }
+
+                return [
+                    'valid' => true,
+                    'type' => is_string($type) ? $type : null,
+                ];
+            })
+            ->all();
+    }
+
+    private function canonicalMatchesExpectedOrigin(string $canonicalUrl, string $expectedOrigin, string $pageUrl): bool
+    {
+        if (str_starts_with($canonicalUrl, '/')) {
+            $parts = parse_url($pageUrl);
+
+            if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+                return false;
+            }
+
+            $canonicalUrl = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']).$canonicalUrl;
+        }
+
+        return $this->finalUrlMatchesExpectedOrigin($canonicalUrl, $expectedOrigin);
+    }
+
+    private function finalUrlMatchesExpectedOrigin(string $url, string $expectedOrigin): bool
+    {
+        $final = parse_url($url);
+        $expected = parse_url($expectedOrigin);
+
+        if (! is_array($final) || ! is_array($expected)) {
+            return false;
+        }
+
+        return Str::lower((string) ($final['scheme'] ?? '')) === Str::lower((string) ($expected['scheme'] ?? ''))
+            && Str::lower((string) ($final['host'] ?? '')) === Str::lower((string) ($expected['host'] ?? ''));
+    }
+
+    private function alternateHost(string $expectedHost): ?string
+    {
+        $normalized = Str::lower(trim($expectedHost));
+
+        if ($normalized === '' || Str::startsWith($normalized, 'www.') && Str::substrCount($normalized, '.') < 2) {
+            return null;
+        }
+
+        return Str::startsWith($normalized, 'www.')
+            ? Str::after($normalized, 'www.')
+            : 'www.'.$normalized;
+    }
+
+    /**
+     * @param  array<int, string>  $problems
+     */
+    private function summaryForIndexabilityProblems(array $problems, ?string $expectedOrigin): string
+    {
+        $labels = collect($problems)
+            ->map(fn (string $problem): string => match ($problem) {
+                'missing_canonical' => 'canonical tag is missing',
+                'wrong_canonical' => 'canonical does not match the preferred origin',
+                'homepage_noindex' => 'homepage is marked noindex',
+                'preferred_host_mismatch' => 'homepage does not resolve to the preferred host',
+                'sitemap_not_referenced' => 'robots.txt does not reference a sitemap',
+                default => $problem,
+            })
+            ->all();
+
+        $suffix = $expectedOrigin !== null ? sprintf(' Expected origin: %s.', $expectedOrigin) : '';
+
+        return sprintf(
+            'Homepage indexability signals are off: %s.%s',
+            implode('; ', $labels),
+            $suffix
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $problems
+     */
+    private function summaryForRedirectProblems(array $problems, string $expectedOrigin): string
+    {
+        $labels = collect($problems)
+            ->map(fn (string $problem): string => match ($problem) {
+                'http_fetch_failed' => 'HTTP root could not be fetched',
+                'http_upgrade_failed' => 'HTTP root did not resolve to the preferred HTTPS origin',
+                'redirect_chain_too_long' => 'redirect chain is longer than expected',
+                'preferred_host_unverified' => 'non-preferred host redirect could not be verified',
+                'preferred_host_mismatch' => 'non-preferred host did not redirect to the preferred host',
+                default => $problem,
+            })
+            ->all();
+
+        return sprintf(
+            'Root redirect policy is not clean: %s. Expected origin: %s.',
+            implode('; ', $labels),
+            $expectedOrigin
+        );
+    }
+
+    private function normalizedUrl(?string $url): string
+    {
+        if (! is_string($url) || trim($url) === '') {
+            return '';
+        }
+
+        $trimmed = trim($url);
+
+        if (! str_starts_with($trimmed, 'http://') && ! str_starts_with($trimmed, 'https://')) {
+            $trimmed = 'https://'.$trimmed;
+        }
+
+        return $trimmed;
+    }
+}

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -858,8 +858,9 @@ return [
     |
     | Explicit monitoring lanes keep fast live incidents separate from slower
     | marketing/readiness audits. The first runnable lane is
-    | marketing_integrity, which verifies live GA4 behavior on property and
-    | conversion-surface hosts and emits deduped findings through Brain.
+    | marketing_integrity verifies live GA4 behavior plus homepage
+    | indexability, seo_agent_readiness covers crawl/agent-facing signals,
+    | and critical_live handles redirect hygiene on the preferred root host.
     |
     */
     'monitoring_lanes' => [
@@ -879,13 +880,13 @@ return [
             'checks' => [
                 'ga4_install',
                 'conversion_surface_ga4',
+                'indexability',
             ],
         ],
         'seo_agent_readiness' => [
             'cadence' => 'daily',
             'issue_type' => 'readiness_gap',
             'checks' => [
-                'indexability',
                 'structured_data',
                 'agent_readiness',
             ],

--- a/routes/console.php
+++ b/routes/console.php
@@ -796,10 +796,21 @@ Schedule::command('monitoring:run-lane marketing_integrity')
     ->at('08:55')
     ->timezone('UTC');
 
+// Verify crawl and agent-facing readiness signals after marketing-integrity scans settle.
+Schedule::command('monitoring:run-lane seo_agent_readiness')
+    ->daily()
+    ->at('09:00')
+    ->timezone('UTC');
+
 // Refresh fleet automation coverage after upstream analytics imports have had time to settle.
 Schedule::command('analytics:refresh-automation-coverage')
     ->daily()
     ->at('09:05')
+    ->timezone('UTC');
+
+// Verify preferred-root redirect policy frequently so live host drift is caught before slower audits run.
+Schedule::command('monitoring:run-lane critical_live')
+    ->hourlyAt(15)
     ->timezone('UTC');
 
 // Refresh a small batch of stale or missing official Search Console API enrichment after analytics coverage settles.

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -39,7 +39,9 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
 
         Http::fake([
-            'https://tracked.example.au/' => Http::response('<html><head><title>No GA4</title></head><body>Missing</body></html>', 200),
+            'https://tracked.example.au/' => Http::response($this->homepageHtml(canonical: 'https://tracked.example.au/'), 200),
+            'https://tracked.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\nSitemap: https://tracked.example.au/sitemap.xml\n", 200),
+            'https://tracked.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
         ]);
 
         $brain = Mockery::mock(BrainEventClient::class);
@@ -162,12 +164,17 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
 
         Http::fake([
-            'https://brand.example.au/' => Http::response(
-                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-EXPECTED999\"></script><script>gtag('config','G-EXPECTED999');</script>",
-                200
-            ),
+            'https://brand.example.au/' => Http::response($this->homepageHtml(
+                canonical: 'https://brand.example.au/',
+                measurementId: 'G-EXPECTED999'
+            ), 200),
+            'https://brand.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\nSitemap: https://brand.example.au/sitemap.xml\n", 200),
+            'https://brand.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
             'https://quotes.brand.example.au/' => Http::response(
-                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-WRONG000\"></script><script>gtag('config','G-WRONG000');</script>",
+                $this->homepageHtml(
+                    canonical: 'https://quotes.brand.example.au/',
+                    measurementId: 'G-WRONG000'
+                ),
                 200
             ),
         ]);
@@ -276,6 +283,166 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
     }
 
+    public function test_marketing_integrity_lane_reports_indexability_failures(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('indexability.example.au', 'Indexability Example');
+        PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-INDEX001',
+            'external_name' => 'Indexability Example',
+            'provider_config' => [
+                'measurement_id' => 'G-INDEX001',
+            ],
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        Http::fake([
+            'https://indexability.example.au/' => Http::response(
+                $this->homepageHtml(measurementId: 'G-INDEX001', metaRobots: 'noindex,follow'),
+                200
+            ),
+            'https://indexability.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $indexabilityExpectation */
+        $indexabilityExpectation = $brain->shouldReceive('sendAsync');
+        $indexabilityExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.indexability', $payload['finding_type']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.indexability')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
+        $this->assertSame('missing_canonical', data_get($finding->evidence, 'verdict'));
+        $this->assertSame(['missing_canonical', 'homepage_noindex', 'sitemap_not_referenced'], data_get($finding->evidence, 'problems'));
+    }
+
+    public function test_seo_agent_readiness_lane_reports_missing_structured_data_and_agent_files(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('readiness.example.au', 'Readiness Example');
+
+        Http::fake([
+            'https://readiness.example.au/' => Http::response($this->homepageHtml(canonical: 'https://readiness.example.au/'), 200),
+            'https://readiness.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
+            'https://readiness.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
+            'https://readiness.example.au/llms.txt' => Http::response('missing', 404),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $seoReadinessExpectation */
+        $seoReadinessExpectation = $brain->shouldReceive('sendAsync');
+        $seoReadinessExpectation->twice()->withArgs(
+            fn (string $eventType, array $payload): bool => $eventType === 'domain_monitor.finding.opened'
+                && in_array($payload['finding_type'], ['seo.structured_data', 'seo.agent_readiness'], true)
+        );
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'seo_agent_readiness',
+            '--property' => $property->slug,
+        ]));
+
+        $structuredDataFinding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'seo.structured_data')
+            ->firstOrFail();
+
+        $agentFinding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'seo.agent_readiness')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $structuredDataFinding->status);
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $agentFinding->status);
+        $this->assertSame(['llms.txt'], data_get($agentFinding->evidence, 'missing_files'));
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+        /** @var array<int, array<string, mixed>> $issues */
+        $matchingIssue = collect($issues)->firstWhere('issue_id', $structuredDataFinding->issue_id);
+
+        $this->assertIsArray($matchingIssue);
+        $this->assertSame('should_fix', $matchingIssue['severity']);
+    }
+
+    public function test_critical_live_lane_reports_redirect_policy_mismatches(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('redirect.example.au', 'Redirect Example');
+        $property->forceFill([
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'redirect.example.au',
+            'canonical_origin_policy' => 'known',
+        ])->save();
+
+        Http::fake([
+            'http://redirect.example.au/' => Http::response(
+                'ok',
+                200,
+                ['X-Guzzle-Redirect-History' => [], 'X-Guzzle-Redirect-Status-History' => []]
+            ),
+            'https://www.redirect.example.au/' => Http::response(
+                'ok',
+                200,
+                ['X-Guzzle-Redirect-History' => [], 'X-Guzzle-Redirect-Status-History' => []]
+            ),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $criticalLiveExpectation */
+        $criticalLiveExpectation = $brain->shouldReceive('sendAsync');
+        $criticalLiveExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('critical.redirect_policy', $payload['finding_type']);
+            $this->assertSame('incident', $payload['issue_type']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'critical_live',
+            '--property' => $property->slug,
+        ]));
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'critical.redirect_policy')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
+        $this->assertSame('http_upgrade_failed', data_get($finding->evidence, 'verdict'));
+    }
+
     private function makeProperty(string $domainName, string $name): WebProperty
     {
         $domain = Domain::factory()->create([
@@ -301,5 +468,35 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
 
         return $property;
+    }
+
+    private function homepageHtml(
+        ?string $canonical = null,
+        ?string $measurementId = null,
+        ?string $metaRobots = null,
+        bool $includeStructuredData = false
+    ): string {
+        $head = '<title>Test Page</title>';
+
+        if ($canonical !== null) {
+            $head .= sprintf('<link rel="canonical" href="%s" />', $canonical);
+        }
+
+        if ($metaRobots !== null) {
+            $head .= sprintf('<meta name="robots" content="%s" />', $metaRobots);
+        }
+
+        if ($measurementId !== null) {
+            $head .= sprintf(
+                '<script async src="https://www.googletagmanager.com/gtag/js?id=%1$s"></script><script>gtag("config","%1$s");</script>',
+                $measurementId
+            );
+        }
+
+        if ($includeStructuredData) {
+            $head .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Example"}</script>';
+        }
+
+        return sprintf('<html><head>%s</head><body>Body</body></html>', $head);
     }
 }


### PR DESCRIPTION
## Summary
- make `monitoring:run-lane` dispatch the configured `critical_live`, `marketing_integrity`, and `seo_agent_readiness` checks instead of only the initial GA4 path
- add `PropertySiteSignalScanner` for homepage indexability, structured-data, agent-readiness, and redirect-policy probes with deduped finding emission through the existing Brain path
- schedule the new runnable lanes and cover the new findings with focused feature tests

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Services/PropertySiteSignalScanner.php app/Services/Ga4SignalScanner.php app/Services/MonitoringFindingManager.php app/Services/DetectedIssueSummaryService.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight

Closes #120
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
