### PR TITLE
Add critical live health findings

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -61,6 +61,21 @@ class RunMonitoringLane extends Command
             $primaryDomain = $property->primaryDomainModel();
             $audits = match ($lane) {
                 'critical_live' => [
+                    'critical.uptime' => [
+                        'title' => 'Root uptime failure on live property',
+                        'issue_type' => 'incident',
+                        'audit' => $siteScanner->auditUptime($property, $timeout),
+                    ],
+                    'critical.http_response' => [
+                        'title' => 'Root HTTP response failure on live property',
+                        'issue_type' => 'incident',
+                        'audit' => $siteScanner->auditHttpResponse($property, $timeout),
+                    ],
+                    'critical.ssl' => [
+                        'title' => 'SSL certificate failure on live property',
+                        'issue_type' => 'incident',
+                        'audit' => $siteScanner->auditSsl($property, $timeout),
+                    ],
                     'critical.redirect_policy' => [
                         'title' => 'Root redirect policy mismatch on live property',
                         'issue_type' => 'incident',
@@ -179,6 +194,15 @@ class RunMonitoringLane extends Command
             ->filter(function (WebProperty $property) use ($lane): bool {
                 if ($lane === 'marketing_integrity') {
                     return $this->expectedMeasurementId($property) !== null;
+                }
+
+                if ($lane === 'critical_live') {
+                    $primaryDomain = $property->primaryDomainModel();
+
+                    return $primaryDomain !== null
+                        && $primaryDomain->monitoringSkipReason('uptime') === null
+                        && $primaryDomain->monitoringSkipReason('http') === null
+                        && $primaryDomain->monitoringSkipReason('ssl') === null;
                 }
 
                 return $property->production_url !== null || $property->primaryDomainName() !== null;

--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -12,6 +12,189 @@ use Illuminate\Support\Str;
 
 class PropertySiteSignalScanner
 {
+    public function __construct(
+        private readonly UptimeHealthCheck $uptimeHealthCheck,
+        private readonly HttpHealthCheck $httpHealthCheck,
+        private readonly SslHealthCheck $sslHealthCheck,
+    ) {}
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditUptime(WebProperty $property, int $timeout = 10): array
+    {
+        $domain = $property->primaryDomainName();
+
+        if (! is_string($domain) || trim($domain) === '') {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_primary_domain',
+                'summary' => 'Property does not have a primary domain for uptime monitoring.',
+                'evidence' => [
+                    'verdict' => 'missing_primary_domain',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $result = $this->uptimeHealthCheck->check($domain, max(1, min($timeout, 10)));
+
+        if ($result['is_valid']) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'uptime_ok',
+                'summary' => 'Root uptime probe succeeded.',
+                'evidence' => [
+                    'verdict' => 'uptime_ok',
+                    'domain' => $domain,
+                    'details' => $result['payload'],
+                ],
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'verdict' => 'uptime_failed',
+            'summary' => 'Root uptime probe failed for the primary domain.',
+            'evidence' => [
+                'verdict' => 'uptime_failed',
+                'domain' => $domain,
+                'details' => $result['payload'],
+                'error_message' => $result['error_message'],
+                'status_code' => $result['status_code'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditHttpResponse(WebProperty $property, int $timeout = 10): array
+    {
+        $domain = $property->primaryDomainName();
+
+        if (! is_string($domain) || trim($domain) === '') {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_primary_domain',
+                'summary' => 'Property does not have a primary domain for HTTP monitoring.',
+                'evidence' => [
+                    'verdict' => 'missing_primary_domain',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $result = $this->httpHealthCheck->check($domain, $timeout);
+        $statusCode = $result['status_code'];
+        $isHealthy = $result['is_up']
+            && is_int($statusCode)
+            && $statusCode >= 200
+            && $statusCode < 400;
+
+        if ($isHealthy) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'http_ok',
+                'summary' => 'Root HTTP response succeeded for the primary domain.',
+                'evidence' => [
+                    'verdict' => 'http_ok',
+                    'domain' => $domain,
+                    'details' => $result['payload'],
+                    'status_code' => $statusCode,
+                ],
+            ];
+        }
+
+        $verdict = is_int($statusCode) && $statusCode >= 400 && $statusCode < 500
+            ? 'http_client_error'
+            : 'http_unavailable';
+
+        return [
+            'status' => 'fail',
+            'verdict' => $verdict,
+            'summary' => 'Root HTTP response is failing or returning an unexpected status for the primary domain.',
+            'evidence' => [
+                'verdict' => $verdict,
+                'domain' => $domain,
+                'details' => $result['payload'],
+                'error_message' => $result['error_message'],
+                'status_code' => $statusCode,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditSsl(WebProperty $property, int $timeout = 10): array
+    {
+        $domain = $property->primaryDomainName();
+
+        if (! is_string($domain) || trim($domain) === '') {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_primary_domain',
+                'summary' => 'Property does not have a primary domain for SSL monitoring.',
+                'evidence' => [
+                    'verdict' => 'missing_primary_domain',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $result = $this->sslHealthCheck->check($domain, $timeout);
+        $daysUntilExpiry = $result['days_until_expiry'];
+        $isExpiringSoon = is_int($daysUntilExpiry) && $daysUntilExpiry <= 7;
+
+        if ($result['is_valid'] && ! $isExpiringSoon) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'ssl_ok',
+                'summary' => 'SSL certificate looks healthy for the primary domain.',
+                'evidence' => [
+                    'verdict' => 'ssl_ok',
+                    'domain' => $domain,
+                    'details' => $result['payload'],
+                    'days_until_expiry' => $daysUntilExpiry,
+                ],
+            ];
+        }
+
+        $verdict = $isExpiringSoon ? 'ssl_expiring_soon' : 'ssl_invalid';
+        $summary = $isExpiringSoon
+            ? 'SSL certificate is expiring soon on the primary domain.'
+            : 'SSL certificate is invalid or unavailable on the primary domain.';
+
+        return [
+            'status' => 'fail',
+            'verdict' => $verdict,
+            'summary' => $summary,
+            'evidence' => [
+                'verdict' => $verdict,
+                'domain' => $domain,
+                'details' => $result['payload'],
+                'error_message' => $result['error_message'],
+                'days_until_expiry' => $daysUntilExpiry,
+            ],
+        ];
+    }
+
     /**
      * @return array{
      *   status: 'ok'|'fail',

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -8,6 +8,10 @@ use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
 use App\Models\WebPropertyConversionSurface;
 use App\Models\WebPropertyDomain;
+use App\Services\HttpHealthCheck;
+use App\Services\PropertySiteSignalScanner;
+use App\Services\SslHealthCheck;
+use App\Services\UptimeHealthCheck;
 use Brain\Client\BrainEventClient;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -404,6 +408,34 @@ class RunMonitoringLaneCommandTest extends TestCase
             'canonical_origin_policy' => 'known',
         ])->save();
 
+        $this->mockCriticalLiveHealthChecks(
+            uptime: [
+                'is_valid' => true,
+                'status_code' => 200,
+                'duration_ms' => 10,
+                'error_message' => null,
+                'payload' => ['url' => 'https://redirect.example.au', 'status_code' => 200, 'duration_ms' => 10],
+            ],
+            http: [
+                'status_code' => 200,
+                'duration_ms' => 11,
+                'is_up' => true,
+                'error_message' => null,
+                'payload' => ['url' => 'https://redirect.example.au', 'headers' => [], 'redirected' => false],
+            ],
+            ssl: [
+                'is_valid' => true,
+                'expires_at' => now()->addDays(30)->toIso8601String(),
+                'days_until_expiry' => 30,
+                'issuer' => 'Example CA',
+                'protocol' => 'TLSv1.3',
+                'cipher' => 'TLS_AES_256_GCM_SHA384',
+                'chain' => [],
+                'error_message' => null,
+                'payload' => ['domain' => 'redirect.example.au', 'days_until_expiry' => 30],
+            ],
+        );
+
         Http::fake([
             'http://redirect.example.au/' => Http::response(
                 'ok',
@@ -441,6 +473,104 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
         $this->assertSame('http_upgrade_failed', data_get($finding->evidence, 'verdict'));
+    }
+
+    public function test_critical_live_lane_reports_uptime_http_and_ssl_failures(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('critical-live.example.au', 'Critical Live');
+        $property->forceFill([
+            'canonical_origin_scheme' => 'https',
+            'canonical_origin_host' => 'critical-live.example.au',
+            'canonical_origin_policy' => 'known',
+        ])->save();
+
+        $this->mockCriticalLiveHealthChecks(
+            uptime: [
+                'is_valid' => false,
+                'status_code' => null,
+                'duration_ms' => 20,
+                'error_message' => 'Connection timed out',
+                'payload' => ['url' => 'https://critical-live.example.au', 'error_type' => 'exception', 'duration_ms' => 20],
+            ],
+            http: [
+                'status_code' => 503,
+                'duration_ms' => 25,
+                'is_up' => false,
+                'error_message' => 'HTTP 503',
+                'payload' => ['url' => 'https://critical-live.example.au', 'headers' => [], 'redirected' => false],
+            ],
+            ssl: [
+                'is_valid' => false,
+                'expires_at' => null,
+                'days_until_expiry' => null,
+                'issuer' => null,
+                'protocol' => null,
+                'cipher' => null,
+                'chain' => [],
+                'error_message' => 'ssl connect failed',
+                'payload' => ['domain' => 'critical-live.example.au', 'error_type' => 'connection'],
+            ],
+        );
+
+        Http::fake([
+            'http://critical-live.example.au/' => Http::response(
+                '',
+                200,
+                ['X-Guzzle-Redirect-History' => ['https://critical-live.example.au/'], 'X-Guzzle-Redirect-Status-History' => ['301']]
+            ),
+            'https://www.critical-live.example.au/' => Http::response(
+                '',
+                200,
+                ['X-Guzzle-Redirect-History' => ['https://critical-live.example.au/'], 'X-Guzzle-Redirect-Status-History' => ['301']]
+            ),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $criticalLiveExpectation */
+        $criticalLiveExpectation = $brain->shouldReceive('sendAsync');
+        $criticalLiveExpectation->times(3)->withArgs(
+            fn (string $eventType, array $payload): bool => $eventType === 'domain_monitor.finding.opened'
+                && in_array($payload['finding_type'], ['critical.uptime', 'critical.http_response', 'critical.ssl'], true)
+                && $payload['issue_type'] === 'incident'
+        );
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'critical_live',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'critical.uptime',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'critical.http_response',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'critical.ssl',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+        $criticalIssue = collect($issues)->firstWhere('issue_class', 'critical.uptime');
+
+        $this->assertIsArray($criticalIssue);
+        $this->assertSame('must_fix', $criticalIssue['severity']);
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty
@@ -498,5 +628,33 @@ class RunMonitoringLaneCommandTest extends TestCase
         }
 
         return sprintf('<html><head>%s</head><body>Body</body></html>', $head);
+    }
+
+    /**
+     * @param  array<string, mixed>  $uptime
+     * @param  array<string, mixed>  $http
+     * @param  array<string, mixed>  $ssl
+     */
+    private function mockCriticalLiveHealthChecks(array $uptime, array $http, array $ssl): void
+    {
+        $uptimeHealthCheck = Mockery::mock(UptimeHealthCheck::class);
+        /** @var Mockery\Expectation $uptimeExpectation */
+        $uptimeExpectation = $uptimeHealthCheck->shouldReceive('check');
+        $uptimeExpectation->andReturn($uptime);
+        $this->instance(UptimeHealthCheck::class, $uptimeHealthCheck);
+
+        $httpHealthCheck = Mockery::mock(HttpHealthCheck::class);
+        /** @var Mockery\Expectation $httpExpectation */
+        $httpExpectation = $httpHealthCheck->shouldReceive('check');
+        $httpExpectation->andReturn($http);
+        $this->instance(HttpHealthCheck::class, $httpHealthCheck);
+
+        $sslHealthCheck = Mockery::mock(SslHealthCheck::class);
+        /** @var Mockery\Expectation $sslExpectation */
+        $sslExpectation = $sslHealthCheck->shouldReceive('check');
+        $sslExpectation->andReturn($ssl);
+        $this->instance(SslHealthCheck::class, $sslHealthCheck);
+
+        app()->forgetInstance(PropertySiteSignalScanner::class);
     }
 }


### PR DESCRIPTION
## Summary
- expand the `critical_live` lane so it emits deduped findings for uptime, root HTTP response, and SSL health in addition to redirect policy
- adapt the existing uptime/http/ssl health checks through `PropertySiteSignalScanner` so the new lane reuses known probe logic instead of inventing a parallel implementation
- add feature coverage for critical live failures while keeping the redirect-policy path deterministic with mocked health checks

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Services/PropertySiteSignalScanner.php app/Services/MonitoringFindingManager.php app/Services/DetectedIssueSummaryService.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight

Part of #120
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
