### PR TITLE
Add quote handoff and deep audit monitoring

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -319,11 +319,12 @@ class RunMonitoringLane extends Command
 
     private function hasQuoteHandoffTargets(WebProperty $property): bool
     {
-        $targets = $property->conversionLinkSummary()['target'];
-
-        foreach (['household_quote', 'household_booking', 'vehicle_quote', 'vehicle_booking', 'moveroo_subdomain'] as $key) {
-            $value = $targets[$key] ?? null;
-
+        foreach ([
+            $property->target_household_quote_url,
+            $property->target_household_booking_url,
+            $property->target_vehicle_quote_url,
+            $property->target_vehicle_booking_url,
+        ] as $value) {
             if (is_string($value) && trim($value) !== '') {
                 return true;
             }

--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
+use App\Services\DomainHealthCheckRunner;
 use App\Services\Ga4SignalScanner;
 use App\Services\MonitoringFindingManager;
 use App\Services\PropertySiteSignalScanner;
@@ -25,7 +26,8 @@ class RunMonitoringLane extends Command
     public function handle(
         Ga4SignalScanner $ga4Scanner,
         PropertySiteSignalScanner $siteScanner,
-        MonitoringFindingManager $findings
+        MonitoringFindingManager $findings,
+        DomainHealthCheckRunner $domainHealthCheckRunner
     ): int {
         $lane = (string) $this->argument('lane');
         $timeout = max(1, (int) $this->option('timeout'));
@@ -59,6 +61,7 @@ class RunMonitoringLane extends Command
             ]);
 
             $primaryDomain = $property->primaryDomainModel();
+            $expectedMeasurementId = $this->expectedMeasurementId($property);
             $audits = match ($lane) {
                 'critical_live' => [
                     'critical.uptime' => [
@@ -82,23 +85,13 @@ class RunMonitoringLane extends Command
                         'audit' => $siteScanner->auditRedirectPolicy($property, $timeout),
                     ],
                 ],
-                'marketing_integrity' => [
-                    'marketing.ga4_install' => [
-                        'title' => 'GA4 install mismatch on live property',
-                        'issue_type' => 'regression',
-                        'audit' => $ga4Scanner->auditPropertyHomepage($property, $timeout),
-                    ],
-                    'marketing.conversion_surface_ga4' => [
-                        'title' => 'GA4 mismatch on conversion surfaces',
-                        'issue_type' => 'regression',
-                        'audit' => $ga4Scanner->auditConversionSurfaces($property, $timeout),
-                    ],
-                    'marketing.indexability' => [
-                        'title' => 'Homepage indexability mismatch on live property',
-                        'issue_type' => 'regression',
-                        'audit' => $siteScanner->auditIndexability($property, $timeout),
-                    ],
-                ],
+                'marketing_integrity' => $this->marketingIntegrityAudits(
+                    property: $property,
+                    ga4Scanner: $ga4Scanner,
+                    siteScanner: $siteScanner,
+                    timeout: $timeout,
+                    expectedMeasurementId: $expectedMeasurementId
+                ),
                 'seo_agent_readiness' => [
                     'seo.structured_data' => [
                         'title' => 'Structured data missing or invalid on homepage',
@@ -111,6 +104,12 @@ class RunMonitoringLane extends Command
                         'audit' => $siteScanner->auditAgentReadiness($property, $timeout),
                     ],
                 ],
+                'deep_audit' => $this->deepAuditAudits(
+                    property: $property,
+                    siteScanner: $siteScanner,
+                    healthCheckRunner: $domainHealthCheckRunner,
+                    primaryDomainId: $primaryDomain?->id
+                ),
                 default => [],
             };
 
@@ -182,20 +181,9 @@ class RunMonitoringLane extends Command
                 )
             );
 
-        if ($lane === 'marketing_integrity') {
-            $query->whereHas('analyticsSources', function (Builder $query): void {
-                $query->where('provider', 'ga4')
-                    ->where('status', 'active');
-            });
-        }
-
         return $query
             ->get()
             ->filter(function (WebProperty $property) use ($lane): bool {
-                if ($lane === 'marketing_integrity') {
-                    return $this->expectedMeasurementId($property) !== null;
-                }
-
                 if ($lane === 'critical_live') {
                     $primaryDomain = $property->primaryDomainModel();
 
@@ -205,9 +193,80 @@ class RunMonitoringLane extends Command
                         && $primaryDomain->monitoringSkipReason('ssl') === null;
                 }
 
+                if ($lane === 'deep_audit') {
+                    $primaryDomain = $property->primaryDomainModel();
+
+                    return $primaryDomain !== null
+                        && $primaryDomain->monitoringSkipReason('broken_links') === null;
+                }
+
                 return $property->production_url !== null || $property->primaryDomainName() !== null;
             })
             ->values();
+    }
+
+    /**
+     * @return array<string, array{title: string, issue_type: string, audit: array<string, mixed>}>
+     */
+    private function marketingIntegrityAudits(
+        WebProperty $property,
+        Ga4SignalScanner $ga4Scanner,
+        PropertySiteSignalScanner $siteScanner,
+        int $timeout,
+        ?string $expectedMeasurementId
+    ): array {
+        $audits = [
+            'marketing.indexability' => [
+                'title' => 'Homepage indexability mismatch on live property',
+                'issue_type' => 'regression',
+                'audit' => $siteScanner->auditIndexability($property, $timeout),
+            ],
+        ];
+
+        if ($expectedMeasurementId !== null) {
+            $audits['marketing.ga4_install'] = [
+                'title' => 'GA4 install mismatch on live property',
+                'issue_type' => 'regression',
+                'audit' => $ga4Scanner->auditPropertyHomepage($property, $timeout),
+            ];
+            $audits['marketing.conversion_surface_ga4'] = [
+                'title' => 'GA4 mismatch on conversion surfaces',
+                'issue_type' => 'regression',
+                'audit' => $ga4Scanner->auditConversionSurfaces($property, $timeout),
+            ];
+        }
+
+        if ($this->hasQuoteHandoffTargets($property)) {
+            $audits['marketing.quote_handoff_integrity'] = [
+                'title' => 'Quote handoff mismatch on live property',
+                'issue_type' => 'regression',
+                'audit' => $siteScanner->auditQuoteHandoffIntegrity($property),
+            ];
+        }
+
+        return $audits;
+    }
+
+    /**
+     * @return array<string, array{title: string, issue_type: string, audit: array<string, mixed>}>
+     */
+    private function deepAuditAudits(
+        WebProperty $property,
+        PropertySiteSignalScanner $siteScanner,
+        DomainHealthCheckRunner $healthCheckRunner,
+        ?string $primaryDomainId
+    ): array {
+        if ($primaryDomainId === null || ! $property->primaryDomainModel()) {
+            return [];
+        }
+
+        return [
+            'seo.broken_links' => [
+                'title' => 'Broken links found during deep audit crawl',
+                'issue_type' => 'cleanup',
+                'audit' => $siteScanner->auditBrokenLinks($property, $healthCheckRunner),
+            ],
+        ];
     }
 
     /**
@@ -256,6 +315,21 @@ class RunMonitoringLane extends Command
         $trimmed = trim($value);
 
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function hasQuoteHandoffTargets(WebProperty $property): bool
+    {
+        $targets = $property->conversionLinkSummary()['target'];
+
+        foreach (['household_quote', 'household_booking', 'vehicle_quote', 'vehicle_booking', 'moveroo_subdomain'] as $key) {
+            $value = $targets[$key] ?? null;
+
+            if (is_string($value) && trim($value) !== '') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function expectedMeasurementId(WebProperty $property): ?string

--- a/app/Services/DetectedIssueSummaryService.php
+++ b/app/Services/DetectedIssueSummaryService.php
@@ -94,6 +94,7 @@ class DetectedIssueSummaryService
                         && (bool) data_get($issue, 'verification.is_currently_suppressed', false))
                     ->reject(fn (array $issue): bool => ! $includeExpectedExclusions
                         && is_array(data_get($issue, 'evidence.expected_exclusion')))
+                    ->pipe(fn (Collection $issues): Collection => $this->deduplicateIssues($issues))
                     ->values();
             })
             ->values();
@@ -239,6 +240,7 @@ class DetectedIssueSummaryService
             ->get()
             ->map(function (MonitoringFinding $finding): array {
                 $property = $finding->webProperty;
+                $findingEvidence = is_array($finding->evidence) ? $finding->evidence : [];
                 $severity = in_array($finding->issue_type, ['incident', 'regression'], true)
                     ? 'must_fix'
                     : 'should_fix';
@@ -282,7 +284,8 @@ class DetectedIssueSummaryService
                         'finding_type' => $finding->finding_type,
                         'issue_type' => $finding->issue_type,
                         'summary' => $finding->summary,
-                        'details' => $finding->evidence ?? [],
+                        ...$findingEvidence,
+                        'details' => $findingEvidence,
                     ],
                 ];
             })
@@ -290,6 +293,40 @@ class DetectedIssueSummaryService
 
         /** @var Collection<int, array<string, mixed>> $issues */
         return $issues;
+    }
+
+    /**
+     * @param  Collection<int, array<string, mixed>>  $issues
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function deduplicateIssues(Collection $issues): Collection
+    {
+        return $issues
+            ->groupBy(fn (array $issue): string => (string) ($issue['issue_id'] ?? ''))
+            ->map(function (Collection $group): array {
+                /** @var array<string, mixed> $preferred */
+                $preferred = $group
+                    ->sortByDesc(fn (array $issue): int => $this->issuePreferenceScore($issue))
+                    ->first();
+
+                return $preferred;
+            })
+            ->values();
+    }
+
+    /**
+     * @param  array<string, mixed>  $issue
+     */
+    private function issuePreferenceScore(array $issue): int
+    {
+        $detector = is_string($issue['detector'] ?? null) ? $issue['detector'] : '';
+        $detectedAt = is_string($issue['detected_at'] ?? null) ? strtotime($issue['detected_at']) : false;
+
+        return match ($detector) {
+            'domain_monitor.monitoring_lane' => 2_000_000_000 + (is_int($detectedAt) ? $detectedAt : 0),
+            'domain_monitor.priority_queue' => 1_000_000_000 + (is_int($detectedAt) ? $detectedAt : 0),
+            default => is_int($detectedAt) ? $detectedAt : 0,
+        };
     }
 
     /**

--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\DomainCheck;
 use App\Models\WebProperty;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
@@ -16,6 +17,7 @@ class PropertySiteSignalScanner
         private readonly UptimeHealthCheck $uptimeHealthCheck,
         private readonly HttpHealthCheck $httpHealthCheck,
         private readonly SslHealthCheck $sslHealthCheck,
+        private readonly PropertyConversionLinkScanner $conversionLinkScanner,
     ) {}
 
     /**
@@ -410,6 +412,192 @@ class PropertySiteSignalScanner
                 'sitemap' => Arr::except($sitemap, ['body']),
                 'llms' => Arr::except($llms, ['body']),
                 'missing_files' => $missing->all(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditQuoteHandoffIntegrity(WebProperty $property): array
+    {
+        try {
+            $scan = $this->conversionLinkScanner->scanForProperty($property);
+        } catch (\Throwable $exception) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'scan_failed',
+                'summary' => 'Could not scan the live homepage to verify quote handoff links.',
+                'evidence' => [
+                    'verdict' => 'scan_failed',
+                    'property_slug' => $property->slug,
+                    'error_message' => $exception->getMessage(),
+                ],
+            ];
+        }
+
+        $targets = $property->conversionLinkSummary()['target'];
+        $current = [
+            'household_quote' => $scan['current_household_quote_url'] ?? null,
+            'household_booking' => $scan['current_household_booking_url'] ?? null,
+            'vehicle_quote' => $scan['current_vehicle_quote_url'] ?? null,
+            'vehicle_booking' => $scan['current_vehicle_booking_url'] ?? null,
+        ];
+        $mismatches = [];
+
+        foreach (['household_quote', 'household_booking', 'vehicle_quote', 'vehicle_booking'] as $slot) {
+            $expectedUrl = $this->normalizedComparableUrl($targets[$slot] ?? null);
+
+            if ($expectedUrl === null) {
+                continue;
+            }
+
+            $detectedUrl = $this->normalizedComparableUrl($current[$slot] ?? null);
+
+            if ($detectedUrl === $expectedUrl) {
+                continue;
+            }
+
+            $mismatches[] = [
+                'slot' => $slot,
+                'expected_url' => $expectedUrl,
+                'detected_url' => $detectedUrl,
+                'expected_host' => $this->hostForComparableUrl($expectedUrl),
+                'detected_host' => $this->hostForComparableUrl($detectedUrl),
+            ];
+        }
+
+        if ($mismatches === []) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'handoff_ok',
+                'summary' => 'Live quote and booking handoff links match the configured targets.',
+                'evidence' => [
+                    'verdict' => 'handoff_ok',
+                    'current' => $current,
+                    'expected' => $targets,
+                    'mismatches' => [],
+                ],
+            ];
+        }
+
+        $verdict = collect($mismatches)
+            ->contains(fn (array $mismatch): bool => $mismatch['detected_url'] === null)
+                ? 'missing_handoff_link'
+                : 'wrong_handoff_target';
+
+        return [
+            'status' => 'fail',
+            'verdict' => $verdict,
+            'summary' => sprintf(
+                '%d live quote or booking handoff link(s) do not match the configured targets.',
+                count($mismatches)
+            ),
+            'evidence' => [
+                'verdict' => $verdict,
+                'current' => $current,
+                'expected' => $targets,
+                'mismatches' => $mismatches,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
+    public function auditBrokenLinks(WebProperty $property, DomainHealthCheckRunner $healthCheckRunner): array
+    {
+        $primaryDomain = $property->primaryDomainModel();
+
+        if ($primaryDomain === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_primary_domain',
+                'summary' => 'Property does not have a primary domain for broken-link verification.',
+                'evidence' => [
+                    'verdict' => 'missing_primary_domain',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $refresh = $healthCheckRunner->run($primaryDomain, 'broken_links');
+        $latestCheck = $primaryDomain->checks()
+            ->where('check_type', 'broken_links')
+            ->latest('finished_at')
+            ->latest('created_at')
+            ->first();
+
+        if (! $latestCheck instanceof DomainCheck) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'broken_links_refresh_failed',
+                'summary' => 'Broken-link crawl did not produce a persisted result.',
+                'evidence' => [
+                    'verdict' => 'broken_links_refresh_failed',
+                    'refresh_status' => $refresh['status'],
+                    'refresh_reason' => $refresh['reason'] ?? null,
+                ],
+            ];
+        }
+
+        $payload = is_array($latestCheck->payload) ? $latestCheck->payload : [];
+        $brokenLinks = is_array($payload['broken_links'] ?? null) ? $payload['broken_links'] : [];
+        $brokenLinksCount = is_numeric($payload['broken_links_count'] ?? null)
+            ? (int) $payload['broken_links_count']
+            : count($brokenLinks);
+        $pagesScanned = is_numeric($payload['pages_scanned'] ?? null)
+            ? (int) $payload['pages_scanned']
+            : 0;
+
+        if ($latestCheck->status === 'unknown' || $pagesScanned === 0) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'crawl_unverified',
+                'summary' => 'Broken-link crawl could not verify any live pages.',
+                'evidence' => [
+                    'verdict' => 'crawl_unverified',
+                    'refresh_status' => $refresh['status'],
+                    'refresh_reason' => $refresh['reason'] ?? null,
+                    'pages_scanned' => $pagesScanned,
+                    'error_message' => $latestCheck->error_message,
+                ],
+            ];
+        }
+
+        if ($brokenLinksCount === 0) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'broken_links_clear',
+                'summary' => 'Deep audit crawl did not find broken links.',
+                'evidence' => [
+                    'verdict' => 'broken_links_clear',
+                    'pages_scanned' => $pagesScanned,
+                    'broken_links_count' => 0,
+                    'broken_links' => [],
+                ],
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'verdict' => 'broken_links_detected',
+            'summary' => sprintf('Deep audit crawl found %d broken link(s).', $brokenLinksCount),
+            'evidence' => [
+                'verdict' => 'broken_links_detected',
+                'pages_scanned' => $pagesScanned,
+                'broken_links_count' => $brokenLinksCount,
+                'broken_links' => $brokenLinks,
             ],
         ];
     }
@@ -864,5 +1052,40 @@ class PropertySiteSignalScanner
         }
 
         return $trimmed;
+    }
+
+    private function normalizedComparableUrl(mixed $url): ?string
+    {
+        if (! is_string($url) || trim($url) === '') {
+            return null;
+        }
+
+        $parts = parse_url(trim($url));
+
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        $normalized = strtolower((string) $parts['scheme']).'://'.Str::lower((string) $parts['host']);
+
+        if (isset($parts['port'])) {
+            $normalized .= ':'.$parts['port'];
+        }
+
+        $path = isset($parts['path']) ? (string) $parts['path'] : '';
+        $normalized .= $path !== '' ? rtrim($path, '/') : '';
+
+        return $normalized;
+    }
+
+    private function hostForComparableUrl(?string $url): ?string
+    {
+        if (! is_string($url) || $url === '') {
+            return null;
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return is_string($host) && $host !== '' ? Str::lower($host) : null;
     }
 }

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -858,9 +858,10 @@ return [
     |
     | Explicit monitoring lanes keep fast live incidents separate from slower
     | marketing/readiness audits. The first runnable lane is
-    | marketing_integrity verifies live GA4 behavior plus homepage
-    | indexability, seo_agent_readiness covers crawl/agent-facing signals,
-    | and critical_live handles redirect hygiene on the preferred root host.
+    | marketing_integrity verifies live GA4 behavior, quote handoff, and
+    | homepage indexability, seo_agent_readiness covers crawl/agent-facing
+    | signals, critical_live handles redirect hygiene on the preferred root
+    | host, and deep_audit currently starts with a deduped broken-links pass.
     |
     */
     'monitoring_lanes' => [
@@ -881,6 +882,7 @@ return [
                 'ga4_install',
                 'conversion_surface_ga4',
                 'indexability',
+                'quote_handoff_integrity',
             ],
         ],
         'seo_agent_readiness' => [
@@ -896,7 +898,6 @@ return [
             'issue_type' => 'cleanup',
             'checks' => [
                 'broken_links',
-                'external_links',
             ],
         ],
     ],

--- a/routes/console.php
+++ b/routes/console.php
@@ -813,6 +813,13 @@ Schedule::command('monitoring:run-lane critical_live')
     ->hourlyAt(15)
     ->timezone('UTC');
 
+// Run slower broken-link cleanup audits weekly through the monitoring-lane issue flow.
+Schedule::command('monitoring:run-lane deep_audit')
+    ->weekly()
+    ->sundays()
+    ->at('09:30')
+    ->timezone('UTC');
+
 // Refresh a small batch of stale or missing official Search Console API enrichment after analytics coverage settles.
 if ($googleSearchConsoleConfigured) {
     Schedule::command('analytics:refresh-search-console-api-enrichment')

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -8,6 +8,7 @@ use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
 use App\Models\WebPropertyConversionSurface;
 use App\Models\WebPropertyDomain;
+use App\Services\BrokenLinkHealthCheck;
 use App\Services\HttpHealthCheck;
 use App\Services\PropertySiteSignalScanner;
 use App\Services\SslHealthCheck;
@@ -257,9 +258,11 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         Http::fake([
             'https://inactive-primary.example.au/' => Http::response(
-                "<script async src=\"https://www.googletagmanager.com/gtag/js?id=G-ACTIVE999\"></script><script>gtag('config','G-ACTIVE999');</script>",
+                "<html><head><link rel=\"canonical\" href=\"https://inactive-primary.example.au/\" /><script async src=\"https://www.googletagmanager.com/gtag/js?id=G-ACTIVE999\"></script><script>gtag('config','G-ACTIVE999');</script></head><body>Body</body></html>",
                 200
             ),
+            'https://inactive-primary.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\nSitemap: https://inactive-primary.example.au/sitemap.xml\n", 200),
+            'https://inactive-primary.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
         ]);
 
         $brain = Mockery::mock(BrainEventClient::class);
@@ -337,6 +340,58 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
         $this->assertSame('missing_canonical', data_get($finding->evidence, 'verdict'));
         $this->assertSame(['missing_canonical', 'homepage_noindex', 'sitemap_not_referenced'], data_get($finding->evidence, 'problems'));
+    }
+
+    public function test_marketing_integrity_lane_reports_quote_handoff_mismatches_without_requiring_ga4(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('handoff.example.au', 'Handoff Example');
+        $property->forceFill([
+            'target_household_quote_url' => 'https://quotes.handoff.example.au/quote/household',
+            'target_vehicle_quote_url' => 'https://quotes.handoff.example.au/quote/vehicle',
+        ])->save();
+
+        Http::fake([
+            'https://handoff.example.au' => Http::response($this->homepageHtml(
+                canonical: 'https://handoff.example.au/',
+                body: '<nav><a href="https://legacy.example.au/start-quote">Moving quote</a><a href="https://quotes.handoff.example.au/quote/vehicle">Car quote</a></nav>'
+            ), 200),
+            'https://handoff.example.au/' => Http::response($this->homepageHtml(
+                canonical: 'https://handoff.example.au/',
+                body: '<nav><a href="https://legacy.example.au/start-quote">Moving quote</a><a href="https://quotes.handoff.example.au/quote/vehicle">Car quote</a></nav>'
+            ), 200),
+            'https://handoff.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\nSitemap: https://handoff.example.au/sitemap.xml\n", 200),
+            'https://handoff.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $quoteHandoffExpectation */
+        $quoteHandoffExpectation = $brain->shouldReceive('sendAsync');
+        $quoteHandoffExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.quote_handoff_integrity', $payload['finding_type']);
+            $this->assertSame('regression', $payload['issue_type']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.quote_handoff_integrity')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
+        $this->assertSame('wrong_handoff_target', data_get($finding->evidence, 'verdict'));
+        $this->assertSame('household_quote', data_get($finding->evidence, 'mismatches.0.slot'));
+        $this->assertNull(MonitoringFinding::query()->where('finding_type', 'marketing.ga4_install')->first());
     }
 
     public function test_seo_agent_readiness_lane_reports_missing_structured_data_and_agent_files(): void
@@ -573,6 +628,102 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame('must_fix', $criticalIssue['severity']);
     }
 
+    public function test_deep_audit_lane_opens_broken_links_findings_and_dedupes_issue_surface(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('deep-audit.example.au', 'Deep Audit');
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksExpectation */
+        $brokenLinksExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksExpectation->once()->andReturn([
+            'is_valid' => false,
+            'verified' => true,
+            'broken_links_count' => 2,
+            'pages_scanned' => 8,
+            'broken_links' => [
+                [
+                    'url' => 'https://deep-audit.example.au/missing-page/',
+                    'status' => 404,
+                    'found_on' => 'https://deep-audit.example.au/services/',
+                ],
+                [
+                    'url' => 'https://deep-audit.example.au/old-booking/',
+                    'status' => 410,
+                    'found_on' => 'https://deep-audit.example.au/contact/',
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 2,
+                'pages_scanned' => 8,
+                'broken_links' => [
+                    [
+                        'url' => 'https://deep-audit.example.au/missing-page/',
+                        'status' => 404,
+                        'found_on' => 'https://deep-audit.example.au/services/',
+                    ],
+                    [
+                        'url' => 'https://deep-audit.example.au/old-booking/',
+                        'status' => 410,
+                        'found_on' => 'https://deep-audit.example.au/contact/',
+                    ],
+                ],
+                'duration_ms' => 18,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $deepAuditExpectation */
+        $deepAuditExpectation = $brain->shouldReceive('sendAsync');
+        $deepAuditExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('seo.broken_links', $payload['finding_type']);
+            $this->assertSame('cleanup', $payload['issue_type']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $primaryDomain = $property->primaryDomainModel();
+        $this->assertInstanceOf(Domain::class, $primaryDomain);
+
+        $this->assertDatabaseHas('domain_checks', [
+            'domain_id' => $primaryDomain->id,
+            'check_type' => 'broken_links',
+            'status' => 'fail',
+        ]);
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'seo.broken_links',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+        $this->assertSame(1, collect($issues)->where('issue_class', 'seo.broken_links')->count());
+
+        /** @var array<string, mixed>|null $brokenLinksIssue */
+        $brokenLinksIssue = collect($issues)->firstWhere('issue_class', 'seo.broken_links');
+        $this->assertIsArray($brokenLinksIssue);
+        $this->assertSame('domain_monitor.monitoring_lane', $brokenLinksIssue['detector']);
+        $this->assertSame(2, data_get($brokenLinksIssue, 'evidence.broken_links_count'));
+    }
+
     private function makeProperty(string $domainName, string $name): WebProperty
     {
         $domain = Domain::factory()->create([
@@ -604,7 +755,8 @@ class RunMonitoringLaneCommandTest extends TestCase
         ?string $canonical = null,
         ?string $measurementId = null,
         ?string $metaRobots = null,
-        bool $includeStructuredData = false
+        bool $includeStructuredData = false,
+        string $body = 'Body'
     ): string {
         $head = '<title>Test Page</title>';
 
@@ -627,7 +779,7 @@ class RunMonitoringLaneCommandTest extends TestCase
             $head .= '<script type="application/ld+json">{"@context":"https://schema.org","@type":"Organization","name":"Example"}</script>';
         }
 
-        return sprintf('<html><head>%s</head><body>Body</body></html>', $head);
+        return sprintf('<html><head>%s</head><body>%s</body></html>', $head, $body);
     }
 
     /**

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -394,6 +394,39 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertNull(MonitoringFinding::query()->where('finding_type', 'marketing.ga4_install')->first());
     }
 
+    public function test_marketing_integrity_lane_does_not_run_quote_handoff_for_moveroo_subdomain_only_targets(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('subdomain-only.example.au', 'Subdomain Only');
+        $property->forceFill([
+            'target_moveroo_subdomain_url' => 'https://quotes.subdomain-only.example.au',
+        ])->save();
+
+        Http::fake([
+            'https://subdomain-only.example.au/' => Http::response($this->homepageHtml(
+                canonical: 'https://subdomain-only.example.au/'
+            ), 200),
+            'https://subdomain-only.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\nSitemap: https://subdomain-only.example.au/sitemap.xml\n", 200),
+            'https://subdomain-only.example.au/sitemap.xml' => Http::response('<urlset></urlset>', 200),
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        $brain->shouldNotReceive('sendAsync');
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertNull(MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.quote_handoff_integrity')
+            ->first());
+    }
+
     public function test_seo_agent_readiness_lane_reports_missing_structured_data_and_agent_files(): void
     {
         config()->set('services.brain.base_url', 'https://brain.example.test');


### PR DESCRIPTION
## Summary
- add quote handoff integrity checks to the marketing integrity lane so link drift is caught even when GA4 is not configured
- make the deep audit lane runnable with a deduped broken-links pass that refreshes the persisted crawl result and emits Brain-backed findings
- dedupe `/api/issues` by issue id so monitoring-lane findings replace duplicate queue rows for the same issue

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Services/PropertySiteSignalScanner.php app/Services/DetectedIssueSummaryService.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
