### PR TITLE
Add external link inventory deep audit

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -197,7 +197,8 @@ class RunMonitoringLane extends Command
                     $primaryDomain = $property->primaryDomainModel();
 
                     return $primaryDomain !== null
-                        && $primaryDomain->monitoringSkipReason('broken_links') === null;
+                        && $primaryDomain->monitoringSkipReason('broken_links') === null
+                        && $primaryDomain->monitoringSkipReason('external_links') === null;
                 }
 
                 return $property->production_url !== null || $property->primaryDomainName() !== null;
@@ -265,6 +266,11 @@ class RunMonitoringLane extends Command
                 'title' => 'Broken links found during deep audit crawl',
                 'issue_type' => 'cleanup',
                 'audit' => $siteScanner->auditBrokenLinks($property, $healthCheckRunner),
+            ],
+            'cleanup.external_links_inventory' => [
+                'title' => 'Off-host links found during deep audit inventory',
+                'issue_type' => 'cleanup',
+                'audit' => $siteScanner->auditExternalLinks($property, $healthCheckRunner),
             ],
         ];
     }

--- a/app/Services/DomainHealthCheckRunner.php
+++ b/app/Services/DomainHealthCheckRunner.php
@@ -14,6 +14,7 @@ class DomainHealthCheckRunner
         private readonly SecurityHeadersHealthCheck $securityHeadersHealthCheck,
         private readonly SeoHealthCheck $seoHealthCheck,
         private readonly BrokenLinkHealthCheck $brokenLinkHealthCheck,
+        private readonly ExternalLinkInventoryHealthCheck $externalLinkInventoryHealthCheck,
     ) {}
 
     /**
@@ -25,7 +26,7 @@ class DomainHealthCheckRunner
      */
     public function run(Domain $domain, string $type): array
     {
-        if (! in_array($type, ['security_headers', 'seo', 'broken_links'], true)) {
+        if (! in_array($type, ['security_headers', 'seo', 'broken_links', 'external_links'], true)) {
             throw new InvalidArgumentException("Unsupported Fleet health check type [{$type}].");
         }
 
@@ -49,9 +50,12 @@ class DomainHealthCheckRunner
             } elseif ($type === 'seo') {
                 $result = $this->seoHealthCheck->check($domain->domain);
                 $status = $this->determineWarnStatus($result);
-            } else {
+            } elseif ($type === 'broken_links') {
                 $result = $this->brokenLinkHealthCheck->check($domain->domain);
                 $status = $this->determineBrokenLinksStatus($result);
+            } else {
+                $result = $this->externalLinkInventoryHealthCheck->check($domain->domain);
+                $status = $this->determineInventoryStatus($result);
             }
 
             $payload = $result['payload'];
@@ -127,5 +131,19 @@ class DomainHealthCheckRunner
         }
 
         return $result['is_valid'] ? 'ok' : 'fail';
+    }
+
+    /**
+     * @param  array{verified?: bool, payload?: array{page_failures_count?: int}}  $result
+     */
+    private function determineInventoryStatus(array $result): string
+    {
+        if (($result['verified'] ?? false) !== true) {
+            return 'unknown';
+        }
+
+        $payload = is_array($result['payload'] ?? null) ? $result['payload'] : [];
+
+        return ((int) ($payload['page_failures_count'] ?? 0)) > 0 ? 'warn' : 'ok';
     }
 }

--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -610,6 +610,139 @@ class PropertySiteSignalScanner
      *   evidence: array<string, mixed>
      * }
      */
+    public function auditExternalLinks(WebProperty $property, DomainHealthCheckRunner $healthCheckRunner): array
+    {
+        $primaryDomain = $property->primaryDomainModel();
+
+        if ($primaryDomain === null) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'missing_primary_domain',
+                'summary' => 'Property does not have a primary domain for external-link inventory.',
+                'evidence' => [
+                    'verdict' => 'missing_primary_domain',
+                    'property_slug' => $property->slug,
+                ],
+            ];
+        }
+
+        $refresh = $healthCheckRunner->run($primaryDomain, 'external_links');
+        $latestCheck = $primaryDomain->checks()
+            ->where('check_type', 'external_links')
+            ->latest('finished_at')
+            ->latest('created_at')
+            ->first();
+
+        if (! $latestCheck instanceof DomainCheck) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'external_link_inventory_refresh_failed',
+                'summary' => 'External-link inventory crawl did not produce a persisted result.',
+                'evidence' => [
+                    'verdict' => 'external_link_inventory_refresh_failed',
+                    'refresh_status' => $refresh['status'],
+                    'refresh_reason' => $refresh['reason'] ?? null,
+                ],
+            ];
+        }
+
+        $payload = is_array($latestCheck->payload) ? $latestCheck->payload : [];
+        $pagesScanned = is_numeric($payload['pages_scanned'] ?? null)
+            ? (int) $payload['pages_scanned']
+            : 0;
+        $pageFailuresCount = is_numeric($payload['page_failures_count'] ?? null)
+            ? (int) $payload['page_failures_count']
+            : 0;
+        $externalLinks = collect(is_array($payload['external_links'] ?? null) ? $payload['external_links'] : [])
+            ->filter(fn (mixed $item): bool => is_array($item))
+            ->map(function (array $item): array {
+                $foundOnPages = collect(is_array($item['found_on_pages'] ?? null) ? $item['found_on_pages'] : [])
+                    ->filter(fn (mixed $page): bool => is_string($page) && $page !== '')
+                    ->values()
+                    ->all();
+
+                return [
+                    'url' => is_string($item['url'] ?? null) ? $item['url'] : null,
+                    'host' => is_string($item['host'] ?? null) ? $item['host'] : null,
+                    'relationship' => is_string($item['relationship'] ?? null) ? $item['relationship'] : 'external',
+                    'found_on' => is_string($item['found_on'] ?? null) ? $item['found_on'] : ($foundOnPages[0] ?? null),
+                    'found_on_pages' => $foundOnPages,
+                ];
+            })
+            ->filter(fn (array $item): bool => $item['url'] !== null)
+            ->values();
+        $reviewableLinks = $externalLinks
+            ->filter(fn (array $item): bool => $item['relationship'] === 'external')
+            ->values();
+        $uniqueHosts = $reviewableLinks
+            ->pluck('host')
+            ->filter(fn (mixed $host): bool => is_string($host) && $host !== '')
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($latestCheck->status === 'unknown' || $pagesScanned === 0) {
+            return [
+                'status' => 'fail',
+                'verdict' => 'inventory_unverified',
+                'summary' => 'External-link inventory could not verify any live pages.',
+                'evidence' => [
+                    'verdict' => 'inventory_unverified',
+                    'refresh_status' => $refresh['status'],
+                    'refresh_reason' => $refresh['reason'] ?? null,
+                    'pages_scanned' => $pagesScanned,
+                    'page_failures_count' => $pageFailuresCount,
+                    'error_message' => $latestCheck->error_message,
+                ],
+            ];
+        }
+
+        if ($reviewableLinks->isEmpty()) {
+            return [
+                'status' => 'ok',
+                'verdict' => 'external_links_clear',
+                'summary' => 'Deep audit inventory did not find off-host links that need review.',
+                'evidence' => [
+                    'verdict' => 'external_links_clear',
+                    'pages_scanned' => $pagesScanned,
+                    'page_failures_count' => $pageFailuresCount,
+                    'reviewable_external_links_count' => 0,
+                    'reviewable_unique_hosts_count' => 0,
+                    'external_links' => [],
+                    'unique_hosts' => [],
+                ],
+            ];
+        }
+
+        return [
+            'status' => 'fail',
+            'verdict' => 'external_links_detected',
+            'summary' => sprintf(
+                'Deep audit inventory found %d off-host link(s) across %d unique host(s).',
+                $reviewableLinks->count(),
+                count($uniqueHosts)
+            ),
+            'evidence' => [
+                'verdict' => 'external_links_detected',
+                'pages_scanned' => $pagesScanned,
+                'page_failures_count' => $pageFailuresCount,
+                'reviewable_external_links_count' => $reviewableLinks->count(),
+                'reviewable_unique_hosts_count' => count($uniqueHosts),
+                'external_links' => $reviewableLinks->all(),
+                'unique_hosts' => $uniqueHosts,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   status: 'ok'|'fail',
+     *   verdict: string,
+     *   summary: string,
+     *   evidence: array<string, mixed>
+     * }
+     */
     public function auditRedirectPolicy(WebProperty $property, int $timeout = 10): array
     {
         $expectedOrigin = $this->expectedOrigin($property);

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -898,6 +898,7 @@ return [
             'issue_type' => 'cleanup',
             'checks' => [
                 'broken_links',
+                'external_links',
             ],
         ],
     ],

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -9,6 +9,7 @@ use App\Models\WebProperty;
 use App\Models\WebPropertyConversionSurface;
 use App\Models\WebPropertyDomain;
 use App\Services\BrokenLinkHealthCheck;
+use App\Services\ExternalLinkInventoryHealthCheck;
 use App\Services\HttpHealthCheck;
 use App\Services\PropertySiteSignalScanner;
 use App\Services\SslHealthCheck;
@@ -710,6 +711,28 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
         $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
 
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $externalLinksClearExpectation */
+        $externalLinksClearExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $externalLinksClearExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 0,
+            'pages_scanned' => 4,
+            'external_links' => [],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 4,
+                'external_links_count' => 0,
+                'unique_hosts_count' => 0,
+                'page_failures_count' => 0,
+                'external_links' => [],
+                'duration_ms' => 12,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
         $brain = Mockery::mock(BrainEventClient::class);
         $this->instance(BrainEventClient::class, $brain);
         /** @var Mockery\Expectation $deepAuditExpectation */
@@ -755,6 +778,232 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertIsArray($brokenLinksIssue);
         $this->assertSame('domain_monitor.monitoring_lane', $brokenLinksIssue['detector']);
         $this->assertSame(2, data_get($brokenLinksIssue, 'evidence.broken_links_count'));
+    }
+
+    public function test_deep_audit_lane_opens_external_link_inventory_findings_for_off_host_links(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('external-links.example.au', 'External Links');
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksClearExpectation */
+        $brokenLinksClearExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksClearExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'broken_links_count' => 0,
+            'pages_scanned' => 3,
+            'broken_links' => [],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 0,
+                'pages_scanned' => 3,
+                'broken_links' => [],
+                'duration_ms' => 10,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $externalLinksDetectedExpectation */
+        $externalLinksDetectedExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $externalLinksDetectedExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 3,
+            'pages_scanned' => 5,
+            'external_links' => [
+                [
+                    'url' => 'https://partner.example.org/quote',
+                    'host' => 'partner.example.org',
+                    'relationship' => 'external',
+                    'found_on' => 'https://external-links.example.au/services/',
+                    'found_on_pages' => ['https://external-links.example.au/services/'],
+                ],
+                [
+                    'url' => 'https://facebook.com/example',
+                    'host' => 'facebook.com',
+                    'relationship' => 'external',
+                    'found_on' => 'https://external-links.example.au/contact/',
+                    'found_on_pages' => ['https://external-links.example.au/contact/'],
+                ],
+                [
+                    'url' => 'https://blog.external-links.example.au/post',
+                    'host' => 'blog.external-links.example.au',
+                    'relationship' => 'subdomain',
+                    'found_on' => 'https://external-links.example.au/',
+                    'found_on_pages' => ['https://external-links.example.au/'],
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 5,
+                'external_links_count' => 3,
+                'unique_hosts_count' => 3,
+                'page_failures_count' => 0,
+                'external_links' => [
+                    [
+                        'url' => 'https://partner.example.org/quote',
+                        'host' => 'partner.example.org',
+                        'relationship' => 'external',
+                        'found_on' => 'https://external-links.example.au/services/',
+                        'found_on_pages' => ['https://external-links.example.au/services/'],
+                    ],
+                    [
+                        'url' => 'https://facebook.com/example',
+                        'host' => 'facebook.com',
+                        'relationship' => 'external',
+                        'found_on' => 'https://external-links.example.au/contact/',
+                        'found_on_pages' => ['https://external-links.example.au/contact/'],
+                    ],
+                    [
+                        'url' => 'https://blog.external-links.example.au/post',
+                        'host' => 'blog.external-links.example.au',
+                        'relationship' => 'subdomain',
+                        'found_on' => 'https://external-links.example.au/',
+                        'found_on_pages' => ['https://external-links.example.au/'],
+                    ],
+                ],
+                'duration_ms' => 14,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $externalLinksOpenedExpectation */
+        $externalLinksOpenedExpectation = $brain->shouldReceive('sendAsync');
+        $externalLinksOpenedExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('cleanup.external_links_inventory', $payload['finding_type']);
+            $this->assertSame('cleanup', $payload['issue_type']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'cleanup.external_links_inventory',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+
+        /** @var array<string, mixed>|null $externalLinksIssue */
+        $externalLinksIssue = collect($issues)->firstWhere('issue_class', 'cleanup.external_links_inventory');
+        $this->assertIsArray($externalLinksIssue);
+        $this->assertSame('should_fix', $externalLinksIssue['severity']);
+        $this->assertSame(2, data_get($externalLinksIssue, 'evidence.reviewable_external_links_count'));
+        $this->assertSame(['facebook.com', 'partner.example.org'], data_get($externalLinksIssue, 'evidence.unique_hosts'));
+    }
+
+    public function test_deep_audit_lane_does_not_open_external_link_inventory_findings_for_subdomains_only(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('subdomain-inventory.example.au', 'Subdomain Inventory');
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksStillClearExpectation */
+        $brokenLinksStillClearExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksStillClearExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'broken_links_count' => 0,
+            'pages_scanned' => 2,
+            'broken_links' => [],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 0,
+                'pages_scanned' => 2,
+                'broken_links' => [],
+                'duration_ms' => 10,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $subdomainInventoryExpectation */
+        $subdomainInventoryExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $subdomainInventoryExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 2,
+            'pages_scanned' => 4,
+            'external_links' => [
+                [
+                    'url' => 'https://blog.subdomain-inventory.example.au/post',
+                    'host' => 'blog.subdomain-inventory.example.au',
+                    'relationship' => 'subdomain',
+                    'found_on' => 'https://subdomain-inventory.example.au/',
+                    'found_on_pages' => ['https://subdomain-inventory.example.au/'],
+                ],
+                [
+                    'url' => 'https://example.au/about',
+                    'host' => 'example.au',
+                    'relationship' => 'parent_domain',
+                    'found_on' => 'https://subdomain-inventory.example.au/contact/',
+                    'found_on_pages' => ['https://subdomain-inventory.example.au/contact/'],
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 4,
+                'external_links_count' => 2,
+                'unique_hosts_count' => 2,
+                'page_failures_count' => 0,
+                'external_links' => [
+                    [
+                        'url' => 'https://blog.subdomain-inventory.example.au/post',
+                        'host' => 'blog.subdomain-inventory.example.au',
+                        'relationship' => 'subdomain',
+                        'found_on' => 'https://subdomain-inventory.example.au/',
+                        'found_on_pages' => ['https://subdomain-inventory.example.au/'],
+                    ],
+                    [
+                        'url' => 'https://example.au/about',
+                        'host' => 'example.au',
+                        'relationship' => 'parent_domain',
+                        'found_on' => 'https://subdomain-inventory.example.au/contact/',
+                        'found_on_pages' => ['https://subdomain-inventory.example.au/contact/'],
+                    ],
+                ],
+                'duration_ms' => 12,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        $brain->shouldIgnoreMissing();
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertSame(0, MonitoringFinding::query()->count());
+        $this->assertNull(MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'cleanup.external_links_inventory')
+            ->first());
     }
 
     private function makeProperty(string $domainName, string $name): WebProperty


### PR DESCRIPTION
## Summary
- add external link inventory execution to the deep audit monitoring lane
- open cleanup findings only for truly off-host links from the inventory payload
- keep subdomain and parent-domain inventory links out of cleanup noise

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- php artisan test tests/Feature/DetectedIssueApiTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Services/DomainHealthCheckRunner.php app/Services/PropertySiteSignalScanner.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
