### PR TITLE
Ignore gov.au links in deep audit cleanup

### DIFF
--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -673,6 +673,7 @@ class PropertySiteSignalScanner
             ->values();
         $reviewableLinks = $externalLinks
             ->filter(fn (array $item): bool => $item['relationship'] === 'external')
+            ->reject(fn (array $item): bool => $this->isAllowedExternalReferenceHost($item['host'] ?? null))
             ->values();
         $uniqueHosts = $reviewableLinks
             ->pluck('host')
@@ -733,6 +734,18 @@ class PropertySiteSignalScanner
                 'unique_hosts' => $uniqueHosts,
             ],
         ];
+    }
+
+    private function isAllowedExternalReferenceHost(mixed $host): bool
+    {
+        if (! is_string($host) || trim($host) === '') {
+            return false;
+        }
+
+        $normalizedHost = Str::lower(trim($host));
+
+        return $normalizedHost === 'gov.au'
+            || Str::endsWith($normalizedHost, '.gov.au');
     }
 
     /**

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -1006,6 +1006,100 @@ class RunMonitoringLaneCommandTest extends TestCase
             ->first());
     }
 
+    public function test_deep_audit_lane_does_not_open_external_link_inventory_findings_for_gov_au_hosts(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('government-links.example.au', 'Government Links');
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksClearExpectation */
+        $brokenLinksClearExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksClearExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'broken_links_count' => 0,
+            'pages_scanned' => 2,
+            'broken_links' => [],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 0,
+                'pages_scanned' => 2,
+                'broken_links' => [],
+                'duration_ms' => 10,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $governmentInventoryExpectation */
+        $governmentInventoryExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $governmentInventoryExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 2,
+            'pages_scanned' => 4,
+            'external_links' => [
+                [
+                    'url' => 'https://www.oaic.gov.au/privacy',
+                    'host' => 'www.oaic.gov.au',
+                    'relationship' => 'external',
+                    'found_on' => 'https://government-links.example.au/privacy/',
+                    'found_on_pages' => ['https://government-links.example.au/privacy/'],
+                ],
+                [
+                    'url' => 'https://www.servicesaustralia.gov.au/',
+                    'host' => 'www.servicesaustralia.gov.au',
+                    'relationship' => 'external',
+                    'found_on' => 'https://government-links.example.au/support/',
+                    'found_on_pages' => ['https://government-links.example.au/support/'],
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 4,
+                'external_links_count' => 2,
+                'unique_hosts_count' => 2,
+                'page_failures_count' => 0,
+                'external_links' => [
+                    [
+                        'url' => 'https://www.oaic.gov.au/privacy',
+                        'host' => 'www.oaic.gov.au',
+                        'relationship' => 'external',
+                        'found_on' => 'https://government-links.example.au/privacy/',
+                        'found_on_pages' => ['https://government-links.example.au/privacy/'],
+                    ],
+                    [
+                        'url' => 'https://www.servicesaustralia.gov.au/',
+                        'host' => 'www.servicesaustralia.gov.au',
+                        'relationship' => 'external',
+                        'found_on' => 'https://government-links.example.au/support/',
+                        'found_on_pages' => ['https://government-links.example.au/support/'],
+                    ],
+                ],
+                'duration_ms' => 12,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        $brain->shouldIgnoreMissing();
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertSame(0, MonitoringFinding::query()->count());
+        $this->assertNull(MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'cleanup.external_links_inventory')
+            ->first());
+    }
+
     private function makeProperty(string $domainName, string $name): WebProperty
     {
         $domain = Domain::factory()->create([


### PR DESCRIPTION
## Summary
- ignore `.gov.au` hosts when turning external-link inventory into deep-audit cleanup findings
- keep true broken links separate so government links still matter if they become 404s
- add regression coverage for government-only external inventories

## Why
- the live prove-out opened cleanup findings for privacy-policy links to government resources like `www.oaic.gov.au`
- those are acceptable external references and should not create cleanup issues by default

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- ./vendor/bin/phpstan analyse app/Services/PropertySiteSignalScanner.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
