### PR TITLE
Flag missing GA4 registry config in marketing scans

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -222,14 +222,14 @@ class RunMonitoringLane extends Command
                 'issue_type' => 'regression',
                 'audit' => $siteScanner->auditIndexability($property, $timeout),
             ],
-        ];
-
-        if ($expectedMeasurementId !== null) {
-            $audits['marketing.ga4_install'] = [
+            'marketing.ga4_install' => [
                 'title' => 'GA4 install mismatch on live property',
                 'issue_type' => 'regression',
                 'audit' => $ga4Scanner->auditPropertyHomepage($property, $timeout),
-            ];
+            ],
+        ];
+
+        if ($expectedMeasurementId !== null) {
             $audits['marketing.conversion_surface_ga4'] = [
                 'title' => 'GA4 mismatch on conversion surfaces',
                 'issue_type' => 'regression',

--- a/app/Services/Ga4SignalScanner.php
+++ b/app/Services/Ga4SignalScanner.php
@@ -24,20 +24,47 @@ class Ga4SignalScanner
     public function auditPropertyHomepage(WebProperty $property, int $timeout = 10): array
     {
         $expectedMeasurementId = $this->expectedMeasurementId($property->primaryAnalyticsSource('ga4'));
+        $candidateUrls = $this->candidateUrlsForProperty($property);
 
         if ($expectedMeasurementId === null) {
+            $probe = $this->firstSuccessfulProbe($candidateUrls, $timeout);
+
+            if ($probe === null) {
+                return [
+                    'status' => 'fail',
+                    'verdict' => 'missing_expected_measurement_id',
+                    'summary' => 'Property does not have an active GA4 measurement ID configured in domain-monitor, and no live page could be fetched to verify the current install.',
+                    'evidence' => [
+                        'verdict' => 'missing_expected_measurement_id',
+                        'expected_measurement_id' => null,
+                        'detected_measurement_ids' => [],
+                        'detected_script_hosts' => [],
+                        'best_url' => null,
+                        'urls' => $candidateUrls->all(),
+                    ],
+                ];
+            }
+
+            $analysis = $this->analyzeHtml($probe['html'], $probe['url'], $timeout);
+            $summary = $analysis['measurement_ids'] === []
+                ? 'Property does not have an active GA4 measurement ID configured in domain-monitor, and no GA4 measurement ID was detected on the live page.'
+                : 'Property does not have an active GA4 measurement ID configured in domain-monitor.';
+
             return [
-                'status' => 'skipped',
+                'status' => 'fail',
                 'verdict' => 'missing_expected_measurement_id',
-                'summary' => 'Property does not have an active GA4 measurement ID configured.',
+                'summary' => $summary,
                 'evidence' => [
                     'verdict' => 'missing_expected_measurement_id',
-                    'urls' => [],
+                    'expected_measurement_id' => null,
+                    'detected_measurement_ids' => $analysis['measurement_ids'],
+                    'detected_script_hosts' => $analysis['tracker_hosts'],
+                    'best_url' => $probe['url'],
+                    'urls' => $candidateUrls->all(),
                 ],
             ];
         }
 
-        $candidateUrls = $this->candidateUrlsForProperty($property);
         $probe = $this->firstSuccessfulProbe($candidateUrls, $timeout);
 
         if ($probe === null) {

--- a/database/factories/MonitoringFindingFactory.php
+++ b/database/factories/MonitoringFindingFactory.php
@@ -19,6 +19,13 @@ class MonitoringFindingFactory extends Factory
     {
         $firstDetectedAt = fake()->dateTimeBetween('-7 days', '-1 day');
         $lastDetectedAt = (clone $firstDetectedAt)->modify('+'.fake()->numberBetween(1, 48).' hours');
+        $status = fake()->randomElement([MonitoringFinding::STATUS_OPEN, MonitoringFinding::STATUS_RECOVERED]);
+        $now = now();
+        $recoveredAt = null;
+
+        if ($status === MonitoringFinding::STATUS_RECOVERED && $lastDetectedAt <= $now) {
+            $recoveredAt = fake()->dateTimeBetween($lastDetectedAt, $now);
+        }
 
         return [
             'issue_id' => 'dm:'.fake()->uuid().':'.fake()->lexify('????????????????'),
@@ -33,14 +40,14 @@ class MonitoringFindingFactory extends Factory
             'scope_type' => 'web_property',
             'domain_id' => \App\Models\Domain::factory(),
             'web_property_id' => \App\Models\WebProperty::factory(),
-            'status' => fake()->randomElement([\App\Models\MonitoringFinding::STATUS_OPEN, \App\Models\MonitoringFinding::STATUS_RECOVERED]),
+            'status' => $status,
             'title' => fake()->sentence(6),
             'summary' => fake()->sentence(),
             'first_detected_at' => $firstDetectedAt,
             'last_detected_at' => $lastDetectedAt,
-            'recovered_at' => fake()->optional()->dateTimeBetween($lastDetectedAt, 'now'),
+            'recovered_at' => $recoveredAt,
             'evidence' => [
-                'verdict' => fake()->randomElement(['missing_ga4', 'wrong_measurement_id', 'duplicate_streams']),
+                'verdict' => fake()->randomElement(['missing_expected_measurement_id', 'missing_ga4', 'wrong_measurement_id', 'duplicate_streams']),
             ],
         ];
     }

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -206,7 +206,7 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame('quotes.brand.example.au', data_get($conversionFinding->evidence, 'failing_surfaces.0.hostname'));
     }
 
-    public function test_marketing_integrity_lane_skips_properties_without_an_active_primary_ga4_source(): void
+    public function test_marketing_integrity_lane_flags_properties_without_an_active_primary_ga4_source(): void
     {
         config()->set('services.brain.base_url', 'https://brain.example.test');
         config()->set('services.brain.api_key', 'test-key');
@@ -268,7 +268,17 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $brain = Mockery::mock(BrainEventClient::class);
         $this->instance(BrainEventClient::class, $brain);
-        $brain->shouldNotReceive('sendAsync');
+        /** @var Mockery\Expectation $updatedExpectation */
+        $updatedExpectation = $brain->shouldReceive('sendAsync');
+        $updatedExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.updated', $eventType);
+            $this->assertSame('marketing.ga4_install', $payload['finding_type']);
+            $this->assertSame('regression', $payload['issue_type']);
+            $this->assertSame('missing_expected_measurement_id', data_get($payload, 'evidence.verdict'));
+            $this->assertSame(['G-ACTIVE999'], data_get($payload, 'evidence.detected_measurement_ids'));
+
+            return true;
+        });
 
         $this->assertSame(0, Artisan::call('monitoring:run-lane', [
             'lane' => 'marketing_integrity',
@@ -282,7 +292,16 @@ class RunMonitoringLaneCommandTest extends TestCase
                 'marketing.ga4_install'
             ),
             'status' => MonitoringFinding::STATUS_OPEN,
+            'summary' => 'Property does not have an active GA4 measurement ID configured in domain-monitor.',
         ]);
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.ga4_install')
+            ->firstOrFail();
+
+        $this->assertSame('missing_expected_measurement_id', data_get($finding->evidence, 'verdict'));
+        $this->assertSame(['G-ACTIVE999'], data_get($finding->evidence, 'detected_measurement_ids'));
 
         $this->assertDatabaseHas('property_analytics_sources', [
             'id' => $primarySource->id,
@@ -369,6 +388,15 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $brain = Mockery::mock(BrainEventClient::class);
         $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $ga4Expectation */
+        $ga4Expectation = $brain->shouldReceive('sendAsync');
+        $ga4Expectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.ga4_install', $payload['finding_type']);
+            $this->assertSame('missing_expected_measurement_id', data_get($payload, 'evidence.verdict'));
+
+            return true;
+        });
         /** @var Mockery\Expectation $quoteHandoffExpectation */
         $quoteHandoffExpectation = $brain->shouldReceive('sendAsync');
         $quoteHandoffExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
@@ -392,7 +420,11 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
         $this->assertSame('wrong_handoff_target', data_get($finding->evidence, 'verdict'));
         $this->assertSame('household_quote', data_get($finding->evidence, 'mismatches.0.slot'));
-        $this->assertNull(MonitoringFinding::query()->where('finding_type', 'marketing.ga4_install')->first());
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'marketing.ga4_install',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
     }
 
     public function test_marketing_integrity_lane_does_not_run_quote_handoff_for_moveroo_subdomain_only_targets(): void
@@ -415,13 +447,26 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $brain = Mockery::mock(BrainEventClient::class);
         $this->instance(BrainEventClient::class, $brain);
-        $brain->shouldNotReceive('sendAsync');
+        /** @var Mockery\Expectation $ga4Expectation */
+        $ga4Expectation = $brain->shouldReceive('sendAsync');
+        $ga4Expectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('marketing.ga4_install', $payload['finding_type']);
+            $this->assertSame('missing_expected_measurement_id', data_get($payload, 'evidence.verdict'));
+
+            return true;
+        });
 
         $this->assertSame(0, Artisan::call('monitoring:run-lane', [
             'lane' => 'marketing_integrity',
             '--property' => $property->slug,
         ]));
 
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'marketing.ga4_install',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
         $this->assertNull(MonitoringFinding::query()
             ->where('web_property_id', $property->id)
             ->where('finding_type', 'marketing.quote_handoff_integrity')


### PR DESCRIPTION
## Summary
- always emit the GA4 homepage finding during `marketing_integrity`, even when the registry is missing an active primary GA4 binding
- treat missing expected GA4 config as a real regression finding instead of silently skipping it
- include detected live GA4 IDs in the evidence when the registry config is missing, so fleet can see whether the site has no GA or just unmanaged GA

## Testing
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
- ./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php app/Services/Ga4SignalScanner.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty
- composer pr:preflight
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
