### PR TITLE
Respect query variants in live sitemap rechecks

### DIFF
--- a/app/Services/SearchConsoleIssueLiveRecheckService.php
+++ b/app/Services/SearchConsoleIssueLiveRecheckService.php
@@ -388,7 +388,7 @@ class SearchConsoleIssueLiveRecheckService
         $uncheckableUrls = [];
 
         foreach ($candidateUrls as $url) {
-            $normalizedUrl = $this->normalizeComparableUrl($url);
+            $normalizedUrl = $this->normalizeComparableUrl($url, includeQuery: true);
 
             if ($normalizedUrl === null) {
                 $uncheckableUrls[$url] = true;
@@ -437,7 +437,7 @@ class SearchConsoleIssueLiveRecheckService
             }
 
             foreach ($document['urls'] as $url) {
-                $normalizedUrl = $this->normalizeComparableUrl($url);
+                $normalizedUrl = $this->normalizeComparableUrl($url, includeQuery: true);
 
                 if ($normalizedUrl === null || ! isset($candidateMap[$normalizedUrl])) {
                     continue;
@@ -754,7 +754,7 @@ class SearchConsoleIssueLiveRecheckService
         return $sanitizedUrl.($path !== '' ? $path : '/');
     }
 
-    private function normalizeComparableUrl(?string $url): ?string
+    private function normalizeComparableUrl(?string $url, bool $includeQuery = false): ?string
     {
         if (! is_string($url) || $url === '') {
             return null;
@@ -773,8 +773,19 @@ class SearchConsoleIssueLiveRecheckService
         }
 
         $path = (string) ($parts['path'] ?? '/');
+        $normalizedUrl .= ($path !== '' ? $path : '/');
 
-        return $normalizedUrl.($path !== '' ? $path : '/');
+        if (! $includeQuery) {
+            return $normalizedUrl;
+        }
+
+        $query = isset($parts['query']) ? trim((string) $parts['query']) : '';
+
+        if ($query === '') {
+            return $normalizedUrl;
+        }
+
+        return $normalizedUrl.'?'.$query;
     }
 
     private function hostResolvesPublicly(string $host): bool

--- a/tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
+++ b/tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
@@ -147,6 +147,70 @@ class RefreshSearchConsoleLiveRechecksCommandTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_it_does_not_mark_query_variant_present_when_only_base_url_exists_in_sitemap(): void
+    {
+        $property = $this->makeProperty('query-variant-live-rechecks-site', 'query-variant.example.au');
+        $domain = $property->primaryDomainModel();
+
+        SearchConsoleIssueSnapshot::factory()->create([
+            'domain_id' => $domain?->id,
+            'web_property_id' => $property->id,
+            'issue_class' => 'page_with_redirect_in_sitemap',
+            'source_issue_label' => 'Page with redirect',
+            'capture_method' => 'gsc_drilldown_zip',
+            'source_report' => 'search_console_page_indexing_drilldown',
+            'source_property' => 'sc-domain:query-variant.example.au',
+            'captured_at' => now()->subDay(),
+            'captured_by' => 'test',
+            'affected_url_count' => 1,
+            'sample_urls' => [
+                'https://query-variant.example.au/?elementor_library=default-kit',
+            ],
+            'normalized_payload' => [
+                'affected_urls' => [
+                    'https://query-variant.example.au/?elementor_library=default-kit',
+                ],
+            ],
+        ]);
+
+        Http::fake([
+            'https://query-variant.example.au/sitemap.xml' => Http::response('', 404),
+            'https://query-variant.example.au/sitemaps.xml' => Http::response('', 404),
+            'https://query-variant.example.au/sitemap_index.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <sitemap><loc>https://query-variant.example.au/page-sitemap.xml</loc></sitemap>
+                </sitemapindex>
+            XML, 200),
+            'https://query-variant.example.au/page-sitemap.xml' => Http::response(<<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                    <url><loc>https://query-variant.example.au/</loc></url>
+                </urlset>
+            XML, 200),
+        ]);
+
+        $exitCode = Artisan::call('analytics:refresh-search-console-live-rechecks', [
+            '--property' => $property->slug,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $liveSnapshot = SearchConsoleIssueSnapshot::query()
+            ->where('web_property_id', $property->id)
+            ->where('issue_class', 'page_with_redirect_in_sitemap')
+            ->where('capture_method', 'gsc_live_recheck')
+            ->latest('captured_at')
+            ->first();
+
+        $this->assertInstanceOf(SearchConsoleIssueSnapshot::class, $liveSnapshot);
+        $this->assertSame(
+            false,
+            data_get($liveSnapshot->issueEvidence(), 'live_sitemap_checks.0.present_in_current_sitemap')
+        );
+        $this->assertNull(data_get($liveSnapshot->issueEvidence(), 'live_sitemap_checks.0.matched_sitemap'));
+    }
+
     private function makeProperty(string $slug, string $domainName): WebProperty
     {
         $domain = Domain::factory()->create([


### PR DESCRIPTION
## Summary
- preserve query strings when comparing live recheck candidate URLs against sitemap entries
- avoid false positives where a bare URL in a sitemap is treated as matching a query-string variant
- add regression coverage for query-only variants in the live recheck command

## Testing
- php artisan test tests/Feature/RefreshSearchConsoleLiveRechecksCommandTest.php
- ./vendor/bin/pint --dirty
- pre-commit staged checks (includes PHPStan on staged files)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
