### PR TITLE
Expose monitoring summaries on web properties

### DIFF
--- a/app/Http/Controllers/Api/WebPropertyController.php
+++ b/app/Http/Controllers/Api/WebPropertyController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\WebPropertyHealthSummaryResource;
 use App\Http\Resources\WebPropertyResource;
 use App\Http\Resources\WebPropertySummaryResource;
+use App\Models\MonitoringFinding;
 use App\Models\WebProperty;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -110,6 +111,10 @@ class WebPropertyController extends Controller
                 'conversionSurfaces.domain',
                 'conversionSurfaces.analyticsSource',
                 'conversionSurfaces.eventContractAssignment.eventContract',
+                'monitoringFindings' => fn ($query) => $query
+                    ->where('status', MonitoringFinding::STATUS_OPEN)
+                    ->with('domain:id,domain')
+                    ->orderByDesc('last_detected_at'),
                 'seoBaselines' => fn ($query) => $query
                     ->orderByDesc('captured_at')
                     ->orderByDesc('created_at')

--- a/app/Models/WebProperty.php
+++ b/app/Models/WebProperty.php
@@ -6,6 +6,7 @@ use App\Services\PropertyExecutionReadinessResolver;
 use App\Services\WebPropertyAnalyticsSummaryBuilder;
 use App\Services\WebPropertyCanonicalOriginSummaryBuilder;
 use App\Services\WebPropertyGscEvidenceSummaryBuilder;
+use App\Services\WebPropertyMonitoringSummaryBuilder;
 use App\Services\WebPropertyPlatformMigrationSummaryBuilder;
 use App\Services\WebPropertySeoBaselineSummaryBuilder;
 use App\Services\WebPropertySiteIdentitySummaryBuilder;
@@ -968,6 +969,7 @@ class WebProperty extends Model
             ],
             'conversion_surfaces' => $this->conversionSurfaceSummaries(),
             'health_summary' => $this->healthSummary(),
+            'monitoring_summary' => $this->monitoringSummary(),
             'deployment_summary' => $this->deploymentSummary(),
             'tags' => $this->tagSummaries(),
             'control_state' => $executionReadiness['control_state'],
@@ -1089,6 +1091,32 @@ class WebProperty extends Model
     public function seoBaselineSummary(): array
     {
         return app(WebPropertySeoBaselineSummaryBuilder::class)->build($this);
+    }
+
+    /**
+     * @return array{
+     *   open_findings_count: int,
+     *   must_fix_count: int,
+     *   should_fix_count: int,
+     *   latest_detected_at: string|null,
+     *   lane_counts: array<string, int>,
+     *   open_findings: array<int, array{
+     *     issue_id: string,
+     *     issue_class: string,
+     *     severity: string,
+     *     lane: string,
+     *     issue_type: string,
+     *     title: string,
+     *     summary: string|null,
+     *     status: string,
+     *     detected_at: string|null,
+     *     domain: string|null
+     *   }>
+     * }
+     */
+    public function monitoringSummary(): array
+    {
+        return app(WebPropertyMonitoringSummaryBuilder::class)->build($this);
     }
 
     /**

--- a/app/Services/WebPropertyMonitoringSummaryBuilder.php
+++ b/app/Services/WebPropertyMonitoringSummaryBuilder.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\MonitoringFinding;
+use App\Models\WebProperty;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+
+class WebPropertyMonitoringSummaryBuilder
+{
+    /**
+     * @return array{
+     *   open_findings_count: int,
+     *   must_fix_count: int,
+     *   should_fix_count: int,
+     *   latest_detected_at: string|null,
+     *   lane_counts: array<string, int>,
+     *   open_findings: array<int, array{
+     *     issue_id: string,
+     *     issue_class: string,
+     *     severity: string,
+     *     lane: string,
+     *     issue_type: string,
+     *     title: string,
+     *     summary: string|null,
+     *     status: string,
+     *     detected_at: string|null,
+     *     domain: string|null
+     *   }>
+     * }
+     */
+    public function build(WebProperty $property): array
+    {
+        $openFindings = $this->openFindings($property);
+
+        return [
+            'open_findings_count' => $openFindings->count(),
+            'must_fix_count' => $openFindings
+                ->filter(fn (MonitoringFinding $finding): bool => $this->severityFor($finding) === 'must_fix')
+                ->count(),
+            'should_fix_count' => $openFindings
+                ->filter(fn (MonitoringFinding $finding): bool => $this->severityFor($finding) === 'should_fix')
+                ->count(),
+            'latest_detected_at' => $openFindings->first()?->last_detected_at?->toIso8601String(),
+            'lane_counts' => $openFindings
+                ->countBy(fn (MonitoringFinding $finding): string => $finding->lane)
+                ->map(fn (int $count): int => $count)
+                ->all(),
+            'open_findings' => $openFindings
+                ->map(fn (MonitoringFinding $finding): array => [
+                    'issue_id' => $finding->issue_id,
+                    'issue_class' => $finding->finding_type,
+                    'severity' => $this->severityFor($finding),
+                    'lane' => $finding->lane,
+                    'issue_type' => $finding->issue_type,
+                    'title' => $finding->title,
+                    'summary' => $finding->summary,
+                    'status' => $finding->status,
+                    'detected_at' => $finding->last_detected_at?->toIso8601String(),
+                    'domain' => $finding->domain instanceof Domain ? $finding->domain->domain : null,
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+
+    /**
+     * @return EloquentCollection<int, MonitoringFinding>
+     */
+    private function openFindings(WebProperty $property): EloquentCollection
+    {
+        if ($property->relationLoaded('monitoringFindings')) {
+            /** @var EloquentCollection<int, MonitoringFinding> $loadedFindings */
+            $loadedFindings = $property->getRelation('monitoringFindings');
+            $loadedFindings->loadMissing('domain:id,domain');
+
+            return $loadedFindings
+                ->filter(fn (MonitoringFinding $finding): bool => $finding->status === MonitoringFinding::STATUS_OPEN)
+                ->sortByDesc(fn (MonitoringFinding $finding): int => $finding->last_detected_at?->getTimestamp() ?? 0)
+                ->values();
+        }
+
+        return $property->monitoringFindings()
+            ->where('status', MonitoringFinding::STATUS_OPEN)
+            ->with('domain:id,domain')
+            ->orderByDesc('last_detected_at')
+            ->get();
+    }
+
+    private function severityFor(MonitoringFinding $finding): string
+    {
+        return in_array($finding->issue_type, ['incident', 'regression'], true)
+            ? 'must_fix'
+            : 'should_fix';
+    }
+}

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -9,6 +9,7 @@ use App\Models\DomainAlert;
 use App\Models\DomainCheck;
 use App\Models\DomainSeoBaseline;
 use App\Models\DomainTag;
+use App\Models\MonitoringFinding;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
 use App\Models\SearchConsoleIssueSnapshot;
@@ -300,6 +301,54 @@ class WebPropertyApiTest extends TestCase
             'auto_resolve' => false,
         ]);
 
+        MonitoringFinding::factory()->create([
+            'issue_id' => 'dm:test:moveroo-ga4',
+            'lane' => 'marketing_integrity',
+            'finding_type' => 'marketing.ga4_install',
+            'issue_type' => 'regression',
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'GA4 install mismatch on live property',
+            'summary' => 'Expected measurement ID is missing from the homepage.',
+            'first_detected_at' => now()->subHours(2),
+            'last_detected_at' => now()->subMinutes(5),
+            'recovered_at' => null,
+        ]);
+
+        MonitoringFinding::factory()->create([
+            'issue_id' => 'dm:test:moveroo-agent',
+            'lane' => 'seo_agent_readiness',
+            'finding_type' => 'seo.agent_readiness',
+            'issue_type' => 'readiness_gap',
+            'scope_type' => 'web_property',
+            'domain_id' => $redirectDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'Agent-readiness files missing on live property',
+            'summary' => 'llms.txt is missing.',
+            'first_detected_at' => now()->subHours(3),
+            'last_detected_at' => now()->subMinutes(10),
+            'recovered_at' => null,
+        ]);
+
+        MonitoringFinding::factory()->create([
+            'issue_id' => 'dm:test:moveroo-old',
+            'lane' => 'critical_live',
+            'finding_type' => 'critical.ssl',
+            'issue_type' => 'incident',
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_RECOVERED,
+            'title' => 'Recovered SSL issue',
+            'summary' => 'Recovered.',
+            'first_detected_at' => now()->subDay(),
+            'last_detected_at' => now()->subHours(6),
+            'recovered_at' => now()->subHours(5),
+        ]);
+
         $response = $this->withHeaders([
             'Authorization' => 'Bearer test-api-key',
         ])->getJson('/api/web-properties-summary');
@@ -345,6 +394,17 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.health_summary.checks.uptime', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.http', 'ok')
             ->assertJsonPath('web_properties.0.health_summary.checks.ssl', 'warn')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings_count', 2)
+            ->assertJsonPath('web_properties.0.monitoring_summary.must_fix_count', 1)
+            ->assertJsonPath('web_properties.0.monitoring_summary.should_fix_count', 1)
+            ->assertJsonPath('web_properties.0.monitoring_summary.lane_counts.marketing_integrity', 1)
+            ->assertJsonPath('web_properties.0.monitoring_summary.lane_counts.seo_agent_readiness', 1)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.issue_class', 'marketing.ga4_install')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.severity', 'must_fix')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.domain', 'moveroo.com.au')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.1.issue_class', 'seo.agent_readiness')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.1.severity', 'should_fix')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.1.domain', 'www.moveroo.com.au')
             ->assertJsonPath('web_properties.0.control_state', 'controlled')
             ->assertJsonPath('web_properties.0.execution_surface', 'astro_repo_controlled')
             ->assertJsonPath('web_properties.0.fleet_managed', true)
@@ -552,6 +612,14 @@ class WebPropertyApiTest extends TestCase
                         'target_platform',
                         'astro_cutover_at',
                     ],
+                    'monitoring_summary' => [
+                        'open_findings_count',
+                        'must_fix_count',
+                        'should_fix_count',
+                        'latest_detected_at',
+                        'lane_counts',
+                        'open_findings',
+                    ],
                     'conversion_links' => [
                         'scanned_at',
                         'current' => [
@@ -608,6 +676,12 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.platform_migration.current_platform', $property->platform)
             ->assertJsonPath('web_properties.0.platform_migration.target_platform', null)
             ->assertJsonPath('web_properties.0.platform_migration.astro_cutover_at', null)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings_count', 0)
+            ->assertJsonPath('web_properties.0.monitoring_summary.must_fix_count', 0)
+            ->assertJsonPath('web_properties.0.monitoring_summary.should_fix_count', 0)
+            ->assertJsonPath('web_properties.0.monitoring_summary.latest_detected_at', null)
+            ->assertJsonPath('web_properties.0.monitoring_summary.lane_counts', [])
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings', [])
             ->assertJsonPath('web_properties.0.conversion_links.scanned_at', null)
             ->assertJsonPath('web_properties.0.conversion_links.current.household_quote', null)
             ->assertJsonPath('web_properties.0.conversion_links.current.household_booking', null)
@@ -657,6 +731,14 @@ class WebPropertyApiTest extends TestCase
                         'current_platform',
                         'target_platform',
                         'astro_cutover_at',
+                    ],
+                    'monitoring_summary' => [
+                        'open_findings_count',
+                        'must_fix_count',
+                        'should_fix_count',
+                        'latest_detected_at',
+                        'lane_counts',
+                        'open_findings',
                     ],
                     'conversion_links' => [
                         'scanned_at',
@@ -714,6 +796,12 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('data.platform_migration.current_platform', $property->platform)
             ->assertJsonPath('data.platform_migration.target_platform', null)
             ->assertJsonPath('data.platform_migration.astro_cutover_at', null)
+            ->assertJsonPath('data.monitoring_summary.open_findings_count', 0)
+            ->assertJsonPath('data.monitoring_summary.must_fix_count', 0)
+            ->assertJsonPath('data.monitoring_summary.should_fix_count', 0)
+            ->assertJsonPath('data.monitoring_summary.latest_detected_at', null)
+            ->assertJsonPath('data.monitoring_summary.lane_counts', [])
+            ->assertJsonPath('data.monitoring_summary.open_findings', [])
             ->assertJsonPath('data.conversion_links.scanned_at', null)
             ->assertJsonPath('data.conversion_links.current.household_quote', null)
             ->assertJsonPath('data.conversion_links.current.household_booking', null)


### PR DESCRIPTION
## Summary
- add a compact property-level monitoring summary to the web property API contract
- eager-load open monitoring findings so the new summary does not introduce property API N+1s
- cover both populated and empty monitoring-summary shapes in the web property API tests

## Testing
- php artisan test tests/Feature/WebPropertyApiTest.php
- ./vendor/bin/phpstan analyse app/Models/WebProperty.php app/Http/Controllers/Api/WebPropertyController.php app/Services/WebPropertyMonitoringSummaryBuilder.php tests/Feature/WebPropertyApiTest.php --memory-limit=2G
- ./vendor/bin/pint --dirty

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
