### PR TITLE
Treat rate-limited links as monitor noise

### DIFF
--- a/app/Console/Commands/SyncMmGoogleSearchConsoleExport.php
+++ b/app/Console/Commands/SyncMmGoogleSearchConsoleExport.php
@@ -237,6 +237,9 @@ class SyncMmGoogleSearchConsoleExport extends Command
         return self::SUCCESS;
     }
 
+    /**
+     * @param  array<string, mixed>  $record
+     */
     private function resolveProperty(array $record): ?WebProperty
     {
         $host = $this->hostFromUrl($record['websiteUrl'] ?? null);
@@ -275,6 +278,9 @@ class SyncMmGoogleSearchConsoleExport extends Command
         return $property->primaryAnalyticsSource('ga4');
     }
 
+    /**
+     * @param  array<string, mixed>  $record
+     */
     private function mappedStateForRecord(array $record): string
     {
         $coverageStatus = $this->stringOrNull($record['coverageStatus'] ?? null);

--- a/app/Services/BrokenLinkHealthCheck.php
+++ b/app/Services/BrokenLinkHealthCheck.php
@@ -15,6 +15,9 @@ class BrokenLinkHealthCheck
     /** @var array<int, array{url: string, status: int, found_on: string, error?: string}> */
     private array $brokenLinks = [];
 
+    /** @var array<int, array{url: string, status: int, found_on: string}> */
+    private array $rateLimitedLinks = [];
+
     private int $pagesScanned = 0;
 
     private int $maxPages = 50;
@@ -28,13 +31,14 @@ class BrokenLinkHealthCheck
      *
      * @param  string  $domain  Domain name (with or without protocol)
      * @param  int  $timeout  Timeout in seconds (default 10 per request)
-     * @return array{is_valid: bool, verified: bool, broken_links_count: int, pages_scanned: int, broken_links: array<int, array{url: string, status: int, found_on: string}>, error_message: string|null, payload: array<string, mixed>}
+     * @return array{is_valid: bool, verified: bool, broken_links_count: int, rate_limited_links_count: int, pages_scanned: int, broken_links: array<int, array{url: string, status: int, found_on: string}>, rate_limited_links: array<int, array{url: string, status: int, found_on: string}>, error_message: string|null, payload: array<string, mixed>}
      */
     public function check(string $domain, int $timeout = 10): array
     {
         $startTime = microtime(true);
         $this->visited = [];
         $this->brokenLinks = [];
+        $this->rateLimitedLinks = [];
         $this->pagesScanned = 0;
 
         // Ensure protocol
@@ -51,6 +55,7 @@ class BrokenLinkHealthCheck
 
             $duration = (int) ((microtime(true) - $startTime) * 1000);
             $brokenCount = count($this->brokenLinks);
+            $rateLimitedCount = count($this->rateLimitedLinks);
             $verified = $this->pagesScanned > 0;
             $errorMessage = null;
 
@@ -62,14 +67,18 @@ class BrokenLinkHealthCheck
                 'is_valid' => $brokenCount === 0,
                 'verified' => $verified,
                 'broken_links_count' => $brokenCount,
+                'rate_limited_links_count' => $rateLimitedCount,
                 'pages_scanned' => $this->pagesScanned,
                 'broken_links' => $this->brokenLinks,
+                'rate_limited_links' => $this->rateLimitedLinks,
                 'error_message' => $errorMessage,
                 'payload' => [
                     'domain' => $this->host,
                     'broken_links_count' => $brokenCount,
+                    'rate_limited_links_count' => $rateLimitedCount,
                     'pages_scanned' => $this->pagesScanned,
                     'broken_links' => $this->brokenLinks,
+                    'rate_limited_links' => $this->rateLimitedLinks,
                     'duration_ms' => $duration,
                 ],
             ];
@@ -81,8 +90,10 @@ class BrokenLinkHealthCheck
                 'is_valid' => false,
                 'verified' => false,
                 'broken_links_count' => 0,
+                'rate_limited_links_count' => 0,
                 'pages_scanned' => $this->pagesScanned,
                 'broken_links' => [],
+                'rate_limited_links' => [],
                 'error_message' => 'Check failed: '.$e->getMessage(),
                 'payload' => [
                     'domain' => $this->host,
@@ -158,6 +169,16 @@ class BrokenLinkHealthCheck
                     /** @var \Illuminate\Http\Client\Response $response */
                     $response = Http::timeout($timeout)->get($url);
                     $status = $response->status();
+                }
+
+                if ($status === 429) {
+                    $this->rateLimitedLinks[] = [
+                        'url' => $url,
+                        'status' => $status,
+                        'found_on' => $foundOn,
+                    ];
+
+                    return;
                 }
 
                 if ($status >= 400) {

--- a/app/Services/BrokenLinkHealthCheck.php
+++ b/app/Services/BrokenLinkHealthCheck.php
@@ -131,6 +131,12 @@ class BrokenLinkHealthCheck
             $status = $response->status();
             $contentType = $response->header('Content-Type');
 
+            if ($status === 429) {
+                $this->recordRateLimitedLink($url, $foundOn);
+
+                return;
+            }
+
             if ($status >= 400) {
                 $this->brokenLinks[] = [
                     'url' => $url,
@@ -172,11 +178,7 @@ class BrokenLinkHealthCheck
                 }
 
                 if ($status === 429) {
-                    $this->rateLimitedLinks[] = [
-                        'url' => $url,
-                        'status' => $status,
-                        'found_on' => $foundOn,
-                    ];
+                    $this->recordRateLimitedLink($url, $foundOn);
 
                     return;
                 }
@@ -255,5 +257,14 @@ class BrokenLinkHealthCheck
         $host = $parsed['host'] ?? '';
 
         return $host === $this->host || empty($host); // Empty host implies relative path which is internal
+    }
+
+    private function recordRateLimitedLink(string $url, string $foundOn): void
+    {
+        $this->rateLimitedLinks[] = [
+            'url' => $url,
+            'status' => 429,
+            'found_on' => $foundOn,
+        ];
     }
 }

--- a/tests/Feature/BrokenLinkHealthCheckServiceTest.php
+++ b/tests/Feature/BrokenLinkHealthCheckServiceTest.php
@@ -47,4 +47,33 @@ class BrokenLinkHealthCheckServiceTest extends TestCase
         $this->assertFalse($result['is_valid']);
         $this->assertStringContainsString('Connection failed', $result['error_message']);
     }
+
+    public function test_it_treats_rate_limited_external_links_as_non_broken(): void
+    {
+        Http::fake(function (Request $request) {
+            if ($request->url() === 'https://example.com') {
+                return Http::response(
+                    '<html><body><a href="https://quote.example.com/quote/vehicle">Quote</a></body></html>',
+                    200,
+                    ['Content-Type' => 'text/html']
+                );
+            }
+
+            if ($request->method() === 'HEAD' && $request->url() === 'https://quote.example.com/quote/vehicle') {
+                return Http::response('rate limited', 429);
+            }
+
+            return Http::response('ok', 200, ['Content-Type' => 'text/html']);
+        });
+
+        $result = app(BrokenLinkHealthCheck::class)->check('example.com');
+
+        $this->assertTrue($result['verified']);
+        $this->assertTrue($result['is_valid']);
+        $this->assertSame(0, $result['broken_links_count']);
+        $this->assertSame(1, $result['rate_limited_links_count']);
+        $this->assertSame('https://quote.example.com/quote/vehicle', $result['rate_limited_links'][0]['url']);
+        $this->assertSame(429, $result['rate_limited_links'][0]['status']);
+        $this->assertSame('https://example.com', $result['rate_limited_links'][0]['found_on']);
+    }
 }

--- a/tests/Feature/BrokenLinkHealthCheckServiceTest.php
+++ b/tests/Feature/BrokenLinkHealthCheckServiceTest.php
@@ -76,4 +76,29 @@ class BrokenLinkHealthCheckServiceTest extends TestCase
         $this->assertSame(429, $result['rate_limited_links'][0]['status']);
         $this->assertSame('https://example.com', $result['rate_limited_links'][0]['found_on']);
     }
+
+    public function test_it_treats_rate_limited_internal_links_as_non_broken(): void
+    {
+        Http::fake(function (Request $request) {
+            return match ($request->url()) {
+                'https://example.com' => Http::response(
+                    '<html><body><a href="/quote/vehicle">Quote</a></body></html>',
+                    200,
+                    ['Content-Type' => 'text/html']
+                ),
+                'https://example.com/quote/vehicle' => Http::response('rate limited', 429),
+                default => Http::response('not found', 404),
+            };
+        });
+
+        $result = app(BrokenLinkHealthCheck::class)->check('example.com');
+
+        $this->assertTrue($result['verified']);
+        $this->assertTrue($result['is_valid']);
+        $this->assertSame(0, $result['broken_links_count']);
+        $this->assertSame(1, $result['rate_limited_links_count']);
+        $this->assertSame('https://example.com/quote/vehicle', $result['rate_limited_links'][0]['url']);
+        $this->assertSame(429, $result['rate_limited_links'][0]['status']);
+        $this->assertSame('https://example.com', $result['rate_limited_links'][0]['found_on']);
+    }
 }


### PR DESCRIPTION
## Summary
- record 429 link responses separately as rate-limited evidence instead of broken links
- expose rate-limited link counts in the broken-link payload for debugging
- add coverage for quote-style endpoints that rate-limit monitor crawlers
- add missing JSON record array annotations so the full repo check stays green

## Tests
- php artisan test tests/Feature/BrokenLinkHealthCheckServiceTest.php
- composer check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
