### PR TITLE
Reduce shared-host uptime alert noise

### DIFF
--- a/app/Console/Commands/RunHealthChecks.php
+++ b/app/Console/Commands/RunHealthChecks.php
@@ -18,7 +18,8 @@ class RunHealthChecks extends Command
     protected $signature = 'domains:health-check 
                             {--domain= : Specific domain to check (optional)}
                             {--type=http : Check type (http, ssl, dns, uptime)}
-                            {--all : Check all active domains}';
+                            {--all : Check all active domains}
+                            {--representative-hosts : For --all uptime checks, check one representative domain per hosting IP}';
 
     /**
      * The console command description.
@@ -63,6 +64,17 @@ class RunHealthChecks extends Command
                 ->excludeEmailOnly($excludeEmailOnly)
                 ->get();
 
+            if ($type === 'uptime' && (bool) $this->option('representative-hosts')) {
+                $originalCount = $domains->count();
+                $domains = $this->representativeHostDomains($domains);
+
+                $this->line(sprintf(
+                    'Representative host mode selected %d domain(s) from %d active web domain(s).',
+                    $domains->count(),
+                    $originalCount
+                ));
+            }
+
             if ($domains->isEmpty()) {
                 $this->warn('No active domains found.');
 
@@ -93,6 +105,19 @@ class RunHealthChecks extends Command
         $this->error('Please specify --domain=<domain> or --all');
 
         return Command::FAILURE;
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection<int, Domain>  $domains
+     * @return \Illuminate\Support\Collection<int, Domain>
+     */
+    private function representativeHostDomains(\Illuminate\Support\Collection $domains): \Illuminate\Support\Collection
+    {
+        return $domains
+            ->sortBy('domain')
+            ->groupBy(fn (Domain $domain): string => $domain->ip_address ? 'ip:'.$domain->ip_address : 'domain:'.$domain->domain)
+            ->map(fn (\Illuminate\Support\Collection $group): Domain => $group->first())
+            ->values();
     }
 
     /**

--- a/app/Services/DomainCheckAlertingService.php
+++ b/app/Services/DomainCheckAlertingService.php
@@ -14,7 +14,7 @@ class DomainCheckAlertingService
     /**
      * @var array<int, string>
      */
-    private const array THREE_STRIKE_TYPES = ['http', 'ssl'];
+    private const array THREE_STRIKE_TYPES = ['http', 'ssl', 'uptime'];
 
     /**
      * @var array<int, string>
@@ -32,11 +32,6 @@ class DomainCheckAlertingService
         }
 
         $isFailure = in_array($check->status, self::FAILURE_STATUSES, true);
-
-        // Handle Uptime History (Incident Logging)
-        if ($check->check_type === 'uptime') {
-            $this->handleUptimeIncident($check, $isFailure);
-        }
 
         if (! in_array($check->check_type, self::THREE_STRIKE_TYPES, true)) {
             $check->emitBrainEvent();
@@ -57,6 +52,10 @@ class DomainCheckAlertingService
                         'threshold' => self::THRESHOLD,
                     ]);
 
+                    if ($check->check_type === 'uptime') {
+                        $this->handleUptimeIncident($check, true);
+                    }
+
                     $check->emitBrainEvent();
 
                     $state->alert_active = true;
@@ -66,6 +65,10 @@ class DomainCheckAlertingService
                 $state->save();
 
                 return;
+            }
+
+            if ($check->check_type === 'uptime') {
+                $this->handleUptimeIncident($check, false);
             }
 
             if ($state->alert_active) {

--- a/routes/console.php
+++ b/routes/console.php
@@ -643,8 +643,9 @@ Schedule::command('domains:update-ip-info --all --hours=24')
     ->at('03:00')
     ->timezone('UTC');
 
-// Uptime checks - run every 10 minutes for active domains
-Schedule::command('domains:health-check --all --type=uptime')
+// Fast uptime checks monitor one representative hostname per hosting IP to avoid
+// hammering shared servers that host many parked/holding domains.
+Schedule::command('domains:health-check --all --type=uptime --representative-hosts')
     ->everyTenMinutes()
     ->timezone('UTC');
 

--- a/tests/Feature/RunHealthChecksRepresentativeHostsTest.php
+++ b/tests/Feature/RunHealthChecksRepresentativeHostsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Services\UptimeHealthCheck;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class RunHealthChecksRepresentativeHostsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_representative_host_mode_checks_one_domain_per_ip_for_uptime(): void
+    {
+        Domain::factory()->create([
+            'domain' => 'alpha.example.com',
+            'ip_address' => '203.0.113.10',
+        ]);
+        Domain::factory()->create([
+            'domain' => 'beta.example.com',
+            'ip_address' => '203.0.113.10',
+        ]);
+        Domain::factory()->create([
+            'domain' => 'gamma.example.com',
+            'ip_address' => '203.0.113.20',
+        ]);
+
+        $this->app->instance(UptimeHealthCheck::class, new class extends UptimeHealthCheck
+        {
+            /**
+             * @return array{is_valid: bool, status_code: int|null, duration_ms: int, error_message: string|null, payload: array<string, mixed>}
+             */
+            public function check(string $domain, int $timeout = 5): array
+            {
+                return [
+                    'is_valid' => true,
+                    'status_code' => 200,
+                    'duration_ms' => 1,
+                    'error_message' => null,
+                    'payload' => [
+                        'url' => 'https://'.$domain,
+                        'status_code' => 200,
+                        'duration_ms' => 1,
+                    ],
+                ];
+            }
+        });
+
+        $exitCode = Artisan::call('domains:health-check', [
+            '--all' => true,
+            '--type' => 'uptime',
+            '--representative-hosts' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('domain_checks', 2);
+        $this->assertDatabaseHas('domain_checks', [
+            'check_type' => 'uptime',
+            'status' => 'ok',
+        ]);
+    }
+}

--- a/tests/Feature/UptimeIncidentTest.php
+++ b/tests/Feature/UptimeIncidentTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Models\Domain;
 use App\Models\DomainCheck;
 use App\Models\UptimeIncident;
-use App\Services\DomainCheckAlertingService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -13,23 +12,22 @@ class UptimeIncidentTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_failing_uptime_check_creates_incident(): void
+    public function test_failing_uptime_check_creates_incident_after_three_strikes(): void
     {
         $domain = Domain::factory()->create(['domain' => 'test-uptime.com']);
 
-        $check = DomainCheck::create([
-            'domain_id' => $domain->id,
-            'check_type' => 'uptime',
-            'status' => 'fail',
-            'error_message' => 'Connection timed out',
-            'started_at' => now()->subMinutes(1),
-            'finished_at' => now(),
-            'duration_ms' => 1000,
-            'retry_count' => 0,
-        ]);
-
-        // Trigger alerting service
-        app(DomainCheckAlertingService::class)->handle($check);
+        foreach (range(1, 3) as $attempt) {
+            DomainCheck::create([
+                'domain_id' => $domain->id,
+                'check_type' => 'uptime',
+                'status' => 'fail',
+                'error_message' => 'Connection timed out',
+                'started_at' => now()->subMinutes(3 - $attempt),
+                'finished_at' => now(),
+                'duration_ms' => 1000,
+                'retry_count' => 0,
+            ]);
+        }
 
         $this->assertDatabaseHas('uptime_incidents', [
             'domain_id' => $domain->id,
@@ -60,9 +58,6 @@ class UptimeIncidentTest extends TestCase
             'retry_count' => 0,
         ]);
 
-        // Trigger alerting service
-        app(DomainCheckAlertingService::class)->handle($check);
-
         $incident->refresh();
         $this->assertNotNull($incident->ended_at);
         $this->assertEquals($check->finished_at->toDateTimeString(), $incident->ended_at->toDateTimeString());
@@ -72,30 +67,27 @@ class UptimeIncidentTest extends TestCase
     {
         $domain = Domain::factory()->create(['domain' => 'test-uptime.com']);
 
-        $service = app(DomainCheckAlertingService::class);
+        foreach (range(1, 3) as $attempt) {
+            DomainCheck::create([
+                'domain_id' => $domain->id,
+                'check_type' => 'uptime',
+                'status' => 'fail',
+                'started_at' => now()->subMinutes(4 - $attempt),
+                'finished_at' => now()->subMinutes(3 - $attempt),
+            ]);
+        }
 
-        // First failure
-        $check1 = DomainCheck::create([
-            'domain_id' => $domain->id,
-            'check_type' => 'uptime',
-            'status' => 'fail',
-            'started_at' => now()->subMinutes(2),
-            'finished_at' => now()->subMinutes(1),
-        ]);
-        $service->handle($check1);
-
-        $this->assertEquals(1, UptimeIncident::count());
+        $this->assertSame(1, UptimeIncident::count());
 
         // Second failure
-        $check2 = DomainCheck::create([
+        DomainCheck::create([
             'domain_id' => $domain->id,
             'check_type' => 'uptime',
             'status' => 'fail',
             'started_at' => now()->subSeconds(30),
             'finished_at' => now(),
         ]);
-        $service->handle($check2);
 
-        $this->assertEquals(1, UptimeIncident::count());
+        $this->assertSame(1, UptimeIncident::count());
     }
 }


### PR DESCRIPTION
## Summary
- add representative host mode for all-domain uptime checks so shared hosting IPs are checked once per fast cadence
- schedule the 10-minute uptime job with representative host mode
- require three consecutive uptime failures before opening an uptime incident or emitting the alert event
- add coverage for representative host selection and the uptime incident threshold

## Tests
- php artisan test tests/Feature/UptimeIncidentTest.php tests/Feature/RunHealthChecksRepresentativeHostsTest.php tests/Feature/MonitoringNoiseSuppressionTest.php
- composer check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
