### PR TITLE
Downgrade unfetchable GA4 inventory gaps

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -116,13 +116,18 @@ class RunMonitoringLane extends Command
             $verdicts = [];
 
             foreach ($audits as $findingType => $definition) {
+                $audit = (array) $definition['audit'];
                 $outcome = $this->syncFinding(
                     findings: $findings,
                     property: $property,
                     findingType: $findingType,
-                    issueType: (string) $definition['issue_type'],
+                    issueType: $this->issueTypeForAudit(
+                        findingType: $findingType,
+                        defaultIssueType: (string) $definition['issue_type'],
+                        audit: $audit
+                    ),
                     title: (string) $definition['title'],
-                    audit: (array) $definition['audit'],
+                    audit: $audit,
                     primaryDomainId: $primaryDomain?->id
                 );
 
@@ -308,6 +313,34 @@ class RunMonitoringLane extends Command
             recoveryEvidence: $audit['evidence'] ?? [],
             primaryDomainId: $primaryDomainId
         );
+    }
+
+    /**
+     * @param  array<string, mixed>  $audit
+     */
+    private function issueTypeForAudit(string $findingType, string $defaultIssueType, array $audit): string
+    {
+        if ($findingType !== 'marketing.ga4_install') {
+            return $defaultIssueType;
+        }
+
+        $evidence = is_array($audit['evidence'] ?? null) ? $audit['evidence'] : [];
+
+        if (($evidence['verdict'] ?? null) !== 'missing_expected_measurement_id') {
+            return $defaultIssueType;
+        }
+
+        $bestUrl = $evidence['best_url'] ?? null;
+        $detectedMeasurementIds = $evidence['detected_measurement_ids'] ?? [];
+
+        if (
+            ! is_string($bestUrl)
+            && (is_countable($detectedMeasurementIds) ? count($detectedMeasurementIds) : 0) === 0
+        ) {
+            return 'cleanup';
+        }
+
+        return $defaultIssueType;
     }
 
     private function optionString(string $name): ?string

--- a/app/Livewire/Dashboard.php
+++ b/app/Livewire/Dashboard.php
@@ -6,6 +6,7 @@ use App\Models\Domain;
 use App\Models\DomainCheck;
 use App\Models\Subdomain;
 use App\Services\DashboardIssueQueueService;
+use App\Services\DetectedIssueSummaryService;
 use App\Services\DomainMonitorSettings;
 use App\Services\ManualCsvBacklogService;
 use Illuminate\Support\Collection;
@@ -60,6 +61,17 @@ class Dashboard extends Component
         $stats['must_fix'] = (int) data_get($queueSnapshot, 'stats.must_fix', 0);
         $stats['should_fix'] = (int) data_get($queueSnapshot, 'stats.should_fix', 0);
 
+        $detectedIssueSnapshot = app(DetectedIssueSummaryService::class)->snapshot();
+        /** @var array<int, array<string, mixed>> $detectedIssueRows */
+        $detectedIssueRows = is_array($detectedIssueSnapshot['issues'] ?? null) ? $detectedIssueSnapshot['issues'] : [];
+        $detectedIssues = collect($detectedIssueRows);
+        $detectedMustFixIssues = $detectedIssues
+            ->where('severity', 'must_fix')
+            ->values();
+
+        $stats['detected_must_fix'] = (int) data_get($detectedIssueSnapshot, 'stats.must_fix', 0);
+        $stats['detected_should_fix'] = (int) data_get($detectedIssueSnapshot, 'stats.should_fix', 0);
+
         $manualCsvBacklog = app(ManualCsvBacklogService::class)->snapshot();
         $manualCsvPendingItems = $manualCsvBacklog['items'];
         $manualCsvPendingStats = $manualCsvBacklog['stats'];
@@ -93,6 +105,7 @@ class Dashboard extends Component
             'stats' => $stats,
             'mustFixDomains' => new Collection($mustFixDomains),
             'shouldFixDomains' => new Collection($shouldFixDomains),
+            'detectedMustFixIssues' => $detectedMustFixIssues->take(8),
             'manualCsvPendingItems' => $manualCsvPendingItems->take(6),
             'manualCsvPendingStats' => $manualCsvPendingStats,
             'unresolvedWebSubdomainDomains' => $unresolvedWebSubdomains->take(8),

--- a/resources/views/livewire/dashboard.blade.php
+++ b/resources/views/livewire/dashboard.blade.php
@@ -97,7 +97,7 @@
         </a>
 
         <!-- Must Fix -->
-        <a href="{{ route('dashboard') }}#must-fix" wire:navigate class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg hover:shadow-md transition-shadow cursor-pointer">
+        <a href="{{ route('dashboard') }}#detected-must-fix" wire:navigate class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg hover:shadow-md transition-shadow cursor-pointer">
             <div class="p-6">
                 <div class="flex items-center">
                     <div class="shrink-0 bg-red-700 rounded-md p-3">
@@ -109,7 +109,7 @@
                     <div class="ml-5 min-w-0 flex-1">
                         <dl>
                             <dt class="text-sm font-medium leading-snug text-gray-500 dark:text-gray-400">Must Fix</dt>
-                            <dd class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats['must_fix'] }}</dd>
+                            <dd class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats['detected_must_fix'] }}</dd>
                         </dl>
                     </div>
                 </div>
@@ -173,6 +173,66 @@
             </div>
         </a>
 
+    </div>
+
+    <!-- Detected Issue Feed -->
+    <div id="detected-must-fix" class="mb-8">
+        <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-xs sm:rounded-lg">
+            <div class="p-6">
+                <div class="flex items-center justify-between gap-4 mb-4">
+                    <div>
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">Detected Must Fix</h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Live monitoring, marketing, Search Console, and queue findings that currently rank as urgent.</p>
+                    </div>
+                    <div class="text-right shrink-0">
+                        <div class="text-2xl font-semibold text-gray-900 dark:text-gray-100">{{ $stats['detected_must_fix'] }}</div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">Open Issues</div>
+                    </div>
+                </div>
+
+                @if($detectedMustFixIssues->isNotEmpty())
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                        @foreach($detectedMustFixIssues as $issue)
+                            <div class="rounded-lg border border-red-200 dark:border-red-900/60 bg-red-50/50 dark:bg-red-950/20 p-4">
+                                <div class="flex items-start justify-between gap-3">
+                                    <div class="min-w-0">
+                                        <div class="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                                            {{ $issue['domain'] ?? $issue['property_name'] ?? $issue['property_slug'] ?? 'Unknown property' }}
+                                        </div>
+                                        <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                                            {{ $issue['issue_class'] ?? 'detected_issue' }}
+                                            @if(!empty($issue['detector']))
+                                                · {{ $issue['detector'] }}
+                                            @endif
+                                        </div>
+                                    </div>
+                                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+                                        Must fix
+                                    </span>
+                                </div>
+
+                                <p class="mt-3 text-sm text-gray-700 dark:text-gray-300">
+                                    {{ data_get($issue, 'evidence.primary_reasons.0') ?? data_get($issue, 'evidence.summary') ?? $issue['summary'] ?? 'Detected issue needs review.' }}
+                                </p>
+
+                                <div class="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                                    @if(!empty($issue['property_slug']))
+                                        <a href="{{ route('web-properties.show', $issue['property_slug']) }}" wire:navigate class="text-blue-600 dark:text-blue-400 hover:underline">Open property</a>
+                                    @endif
+                                    @if(!empty($issue['detected_at']))
+                                        <span>Detected {{ $issue['detected_at'] }}</span>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <div class="rounded-lg border border-green-200 dark:border-green-900/60 bg-green-50 dark:bg-green-950/20 p-4">
+                        <p class="text-sm text-green-800 dark:text-green-200">No urgent detected issues are currently flagged.</p>
+                    </div>
+                @endif
+            </div>
+        </div>
     </div>
 
     <!-- Priority Queue -->

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -9,6 +9,7 @@ use App\Models\DomainAlert;
 use App\Models\DomainCheck;
 use App\Models\DomainSeoBaseline;
 use App\Models\DomainTag;
+use App\Models\MonitoringFinding;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
 use App\Models\SearchConsoleCoverageStatus;
@@ -139,6 +140,56 @@ class DashboardTest extends TestCase
             ->assertSee('Broken links need review')
             ->assertSee('1 issue')
             ->assertDontSee('0 issues');
+    }
+
+    public function test_dashboard_surfaces_monitoring_lane_must_fix_issues(): void
+    {
+        $user = User::factory()->create();
+        $property = $this->makeProperty('quotes-gap.example.au', 'Quotes Gap');
+        $primaryDomain = $property->primaryDomainModel();
+
+        $this->assertNotNull($primaryDomain);
+
+        MonitoringFinding::factory()->create([
+            'issue_id' => app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
+                $primaryDomain->id,
+                $property->slug,
+                'marketing.conversion_surface_ga4'
+            ),
+            'lane' => 'marketing_integrity',
+            'finding_type' => 'marketing.conversion_surface_ga4',
+            'issue_type' => 'regression',
+            'scope_type' => 'web_property',
+            'domain_id' => $primaryDomain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'GA4 mismatch on conversion surfaces',
+            'summary' => '1 conversion surface is not resolving to the expected GA4 measurement ID.',
+            'evidence' => [
+                'verdict' => 'wrong_measurement_id',
+                'primary_reasons' => [
+                    '1 conversion surface is not resolving to the expected GA4 measurement ID.',
+                ],
+            ],
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response
+            ->assertOk()
+            ->assertSee('Detected Must Fix')
+            ->assertSee('quotes-gap.example.au')
+            ->assertSee('marketing.conversion_surface_ga4')
+            ->assertSee('1 conversion surface is not resolving to the expected GA4 measurement ID.');
+
+        Livewire::test(Dashboard::class)
+            ->assertViewHas('stats', function (array $stats): bool {
+                return $stats['detected_must_fix'] === 1;
+            })
+            ->assertViewHas('detectedMustFixIssues', function (Collection $items): bool {
+                return $items->count() === 1
+                    && $items->first()['issue_class'] === 'marketing.conversion_surface_ga4';
+            });
     }
 
     public function test_dashboard_excludes_domains_marked_as_parked_in_synergy(): void

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -310,6 +310,47 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
     }
 
+    public function test_marketing_integrity_lane_downgrades_unfetchable_ga4_inventory_gaps(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $property = $this->makeProperty('parked.example.au', 'Parked Example');
+
+        Http::fake([
+            'https://parked.example.au/' => Http::failedConnection(),
+            'https://parked.example.au/robots.txt' => Http::failedConnection(),
+        ]);
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'marketing_integrity',
+            '--property' => $property->slug,
+        ]));
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'marketing.ga4_install')
+            ->firstOrFail();
+
+        $this->assertSame(MonitoringFinding::STATUS_OPEN, $finding->status);
+        $this->assertSame('cleanup', $finding->issue_type);
+        $this->assertSame('missing_expected_measurement_id', data_get($finding->evidence, 'verdict'));
+        $this->assertNull(data_get($finding->evidence, 'best_url'));
+        $this->assertSame([], data_get($finding->evidence, 'detected_measurement_ids'));
+
+        $issues = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/issues')
+            ->assertOk()
+            ->json('issues');
+
+        $this->assertIsArray($issues);
+        /** @var array<int, array<string, mixed>> $issues */
+        $matchingIssue = collect($issues)->firstWhere('issue_id', $finding->issue_id);
+
+        $this->assertIsArray($matchingIssue);
+        $this->assertSame('should_fix', $matchingIssue['severity']);
+    }
+
     public function test_marketing_integrity_lane_reports_indexability_failures(): void
     {
         config()->set('services.brain.base_url', 'https://brain.example.test');


### PR DESCRIPTION
## Summary
- keep live GA4 install mismatches urgent when a page is reachable or a GA ID is detected
- classify unfetchable/no-detected-GA marketing.ga4_install findings as cleanup so parked inventory domains do not flood must_fix
- add feature coverage that these inventory gaps surface as should_fix

## Production data note
- Backfilled backloadingremovals.com.au with detected GA4 measurement ID G-E7ENFRP195 before this PR, because that one was a real live-site Domain Monitor config gap.

## Tests
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php --filter=ga4
- php artisan test tests/Feature/RunMonitoringLaneCommandTest.php
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/iamjasonhill/domain-monitor/pull/148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
