### PR TITLE
Document Fleet technical SEO runtime verification

### DIFF
--- a/docs/FLEET-ASTRO-TECHNICAL-SEO-MONITORING-PLAN.md
+++ b/docs/FLEET-ASTRO-TECHNICAL-SEO-MONITORING-PLAN.md
@@ -1,11 +1,13 @@
-# Fleet Astro Technical SEO Monitoring Plan
+# Fleet Technical SEO Runtime Verification
 
-Last updated: 2026-04-28
+Last updated: 2026-05-16
 
 ## Why This Exists
 
 Fleet already owns the canonical Astro technical standard and migration
 compliance gate.
+
+This program is called `Fleet Technical SEO Runtime Verification`.
 
 `domain-monitor` should not create a second standard.
 
@@ -52,19 +54,146 @@ Those documents already define the standard for:
 - alert state and issue flow when a previously healthy site regresses
 - cross-domain verification that should keep running after launch
 
-## What `domain-monitor` Should Verify
+## Program Boundary
 
-The first monitoring slice should stay narrow and verify the Fleet standard at
-runtime rather than rebuilding it.
+`Fleet Technical SEO Runtime Verification` means:
 
-Recommended first checks:
+- `domain-monitor` checks live Fleet-managed website properties against the
+  Fleet-owned technical SEO standard
+- Fleet defines the standard, sign-off language, and remediation routing rules
+- site repos fix site-specific failures surfaced by runtime verification
+- `MM-Google` contributes Google/Search Console/GA4 evidence only where that
+  source owns the truth
 
-- homepage and key-route PageSpeed snapshot
-- robots presence and correctness
-- sitemap presence and basic discovery
-- canonical tag presence on homepage and key routes
-- obvious indexability blockers on key routes
-- preferred-root and key-route redirect sanity
+It does not mean building a generic competitor-style SEO crawler or duplicating
+Fleet standards inside `domain-monitor`.
+
+Any actionable runtime verification issue should be visible in Control
+Attention at `https://control.again.com.au/admin/attention` so an operator can
+decide whether to route, suppress, accept, or investigate it. `domain-monitor`
+remains the source truth for live findings; Control is the operator decision
+surface.
+
+Control Attention should receive failures only. Clean passes, healthy coverage
+rows, and informational catalog entries should stay in Fleet or `domain-monitor`
+evidence and should not become Attention noise.
+
+## Signal Classes
+
+Each catalog check should declare one signal class:
+
+- `failure`: opens or updates a `domain-monitor` finding and appears in Control
+  Attention
+- `review`: is recorded in catalog or evidence, but only appears in Control if
+  Fleet or an operator promotes it
+- `evidence_only`: is stored for proof, benchmarking, sign-off, or trend context
+  and never appears in Control Attention by default
+
+Hard technical failures such as invalid SSL, HTTP 5XX, broken internal links,
+bad canonicals, or unexpected noindex signals should normally be `failure`.
+Softer thresholds such as title length, social preview dimensions, optional
+AI-discovery files, or benchmark scores should usually start as `review` or
+`evidence_only` unless Fleet defines them as launch blockers for a site type.
+
+## Applicability By Site Type
+
+The catalog should not apply one universal checklist to every property. Each
+check should declare the site types it applies to, using at least:
+
+- `fleet_astro_marketing_site`
+- `wordpress_holding_site`
+- `plain_html_static_site`
+- `app_shell_or_operational_domain`
+- `domain_asset_or_parked`
+- `email_only`
+
+For example, missing JSON-LD or `llms.txt` may be a real finding for a Fleet
+Astro marketing site but should not create Control Attention noise for a parked
+domain, email-only domain, or app shell unless Fleet has recorded an explicit
+expectation for that property.
+
+## Catalog Artifact
+
+Fleet should own a machine-readable technical SEO check catalog in addition to
+the human-readable policy docs.
+
+The catalog should include fields such as:
+
+- `id`
+- `category`
+- `description`
+- `applicability`
+- `coverage_state`
+- `signal_class`
+- `owner_system`
+- `current_evidence`
+- `runtime_mapping`
+
+`domain-monitor` should consume or mirror the Fleet-owned catalog rather than
+hard-coding an undocumented checklist. The runtime implementation can still
+keep its own local mapping where needed, but the standard and check taxonomy
+belong to Fleet.
+
+## Coverage Inventory Rule
+
+The first pass through the catalog should classify existing coverage before
+building new checks.
+
+If a check cannot be clearly classified from current docs, code, live evidence,
+or imported source truth, it should not remain as an ambiguous note. Create a
+GitHub issue in the relevant owning repo so the ambiguity can be resolved,
+implemented, marked not applicable, or deliberately excluded.
+
+## Issue Routing
+
+Use this default owner map when catalog coverage is missing, unclear, or failing:
+
+- Fleet issue: catalog taxonomy, applicability, signal class, launch-gate
+  wording, or site-type policy is unclear
+- `domain-monitor` issue: live runtime check, finding generation, cadence,
+  evidence packet, or Control export mapping is missing or unclear
+- Control issue: a valid `domain-monitor` failure is not visible or actionable
+  in `/admin/attention`
+- `MM-Google` issue: GA4, Search Console, BigQuery, or Search Intelligence
+  evidence is missing, stale, or ambiguous
+- site-repo issue: the failure is specific to one website implementation, such
+  as missing canonical, broken internal links, bad schema, robots or sitemap
+  output, image alt, H1, or PageSpeed regression
+- Bossman issue: cross-repo decision or routing is unclear and no single repo
+  owner can be chosen safely
+
+## Verification Scope
+
+The program should maintain a complete technical SEO check catalog rather than
+only a small MVP checklist.
+
+Each check in that catalog should be classified by:
+
+- whether it is already covered
+- which repo or system owns it
+- its coverage state
+- whether it applies to all Fleet websites or only specific site types
+- what evidence proves the check passed or failed
+
+The purpose is to stop repeatedly reopening broad technical SEO discovery and
+instead give operators one durable coverage map for the whole estate.
+
+## Coverage States
+
+Use these states when classifying each check:
+
+- `automated_runtime`: checked by recurring live monitoring, usually in
+  `domain-monitor`
+- `automated_repo`: checked inside the owning site repo, build, test, or static
+  analysis path
+- `evidence_imported`: covered by an imported evidence source such as
+  `MM-Google`, Search Console, GA4, or a preserved benchmark artifact
+- `manual_gate`: checked during Fleet sign-off or migration review with durable
+  evidence recorded
+- `planned`: accepted as relevant but not yet covered strongly enough
+- `not_applicable`: does not apply to this site type or property
+- `out_of_scope`: deliberately excluded from Fleet Technical SEO Runtime
+  Verification
 
 ## How This Fits Existing Monitoring Lanes
 
@@ -81,15 +210,15 @@ Current lanes already cover part of this space:
 - `critical_live`
   - redirect policy
 
-The best next step is not a giant new crawler lane.
+The best next step is not a blind giant crawler lane.
 
-The best next step is to extend the existing lanes with a small Fleet-Astro
-verification slice, most likely by:
+The best next step is to inventory the full check catalog against existing
+Fleet, `domain-monitor`, `MM-Google`, and site-repo evidence, then create
+targeted issues only for uncovered or weakly covered checks.
 
-- expanding `seo_agent_readiness` and or `marketing_integrity` with a narrow
-  technical SEO baseline check set
-- keeping PageSpeed snapshots weekly rather than trying to run them too often
-- opening alerts only after repeated regression, not one noisy sample
+Likely implementation work should still extend existing lanes where possible,
+keep noisy checks on sensible cadences, and open alerts only when the evidence
+is strong enough to avoid churn.
 
 ## What Should Stay Out Of Scope
 

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -1283,6 +1283,7 @@ class WebPropertyApiTest extends TestCase
         $domain = Domain::factory()->create([
             'domain' => 'health-fresh.example.com',
             'is_active' => true,
+            'last_checked_at' => null,
         ]);
 
         $property = WebProperty::factory()->create([
@@ -1816,6 +1817,7 @@ class WebPropertyApiTest extends TestCase
     public function test_web_properties_summary_surfaces_current_search_console_coverage(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+        Carbon::setTestNow(Carbon::parse('2026-05-07 09:00:00', 'Australia/Brisbane'));
 
         $domain = Domain::factory()->create([
             'domain' => 'movingagain.com.au',
@@ -1877,6 +1879,8 @@ class WebPropertyApiTest extends TestCase
             ->assertJsonPath('web_properties.0.search_console.checked_at', '2026-05-06T22:00:33+10:00')
             ->assertJsonPath('web_properties.0.search_console.next_action', 'No Search Console coverage action is required while evidence remains fresh.')
             ->assertJsonPath('web_properties.0.gsc_evidence_summary.latest_issue_detail_captured_at', '2026-04-01T06:08:41+00:00');
+
+        Carbon::setTestNow();
     }
 
     public function test_web_property_health_summary_endpoint_returns_property_health(): void


### PR DESCRIPTION
## Summary\n\n- records the Fleet Technical SEO Runtime Verification boundary in Domain Monitor docs\n- captures the failures-only Control Attention rule\n- documents coverage states, signal classes, site-type applicability, catalog ownership, and issue routing\n\n## Verification\n\n- git diff --check\n- pre-commit hook passed for docs-only commit\n\nRelated Fleet catalog work: iamjasonhill/MM-fleet-program#54