### PR TITLE
[codex] Classify and export runtime analytics host contexts

### DIFF
--- a/app/Http/Controllers/Api/RuntimeAnalyticsContextController.php
+++ b/app/Http/Controllers/Api/RuntimeAnalyticsContextController.php
@@ -3,14 +3,13 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Http\Resources\RuntimeAnalyticsContextResource;
-use App\Models\WebPropertyConversionSurface;
+use App\Services\RuntimeAnalyticsContextFeedBuilder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class RuntimeAnalyticsContextController extends Controller
 {
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(Request $request, RuntimeAnalyticsContextFeedBuilder $contextFeedBuilder): JsonResponse
     {
         $validated = $request->validate([
             'hostname' => 'nullable|string|max:255',
@@ -18,34 +17,17 @@ class RuntimeAnalyticsContextController extends Controller
             'site_key' => 'nullable|string|max:100',
         ]);
 
-        $query = WebPropertyConversionSurface::query()
-            ->with([
-                'webProperty.analyticsSources',
-                'webProperty.eventContractAssignments.eventContract',
-                'analyticsSource',
-                'eventContractAssignment.eventContract',
-            ])
-            ->orderBy('hostname');
-
-        if (isset($validated['hostname']) && trim((string) $validated['hostname']) !== '') {
-            $query->where('hostname', strtolower(trim((string) $validated['hostname'], ". \t\n\r\0\x0B")));
-        }
-
-        if (isset($validated['runtime_path']) && trim((string) $validated['runtime_path']) !== '') {
-            $query->where('runtime_path', trim((string) $validated['runtime_path']));
-        }
-
-        if (isset($validated['site_key']) && trim((string) $validated['site_key']) !== '') {
-            $query->whereHas('webProperty', fn ($builder) => $builder->where('site_key', trim((string) $validated['site_key'])));
-        }
-
-        $contexts = $query->get();
+        $contexts = $contextFeedBuilder->build(
+            hostname: $validated['hostname'] ?? null,
+            runtimePath: $validated['runtime_path'] ?? null,
+            siteKey: $validated['site_key'] ?? null
+        );
 
         return response()->json([
             'source_system' => 'domain-monitor-runtime-analytics',
             'contract_version' => 1,
             'generated_at' => now()->toIso8601String(),
-            'runtime_contexts' => RuntimeAnalyticsContextResource::collection($contexts)->resolve(),
+            'runtime_contexts' => $contexts->all(),
         ]);
     }
 }

--- a/app/Services/RuntimeAnalyticsContextFeedBuilder.php
+++ b/app/Services/RuntimeAnalyticsContextFeedBuilder.php
@@ -1,0 +1,337 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PropertyAnalyticsSource;
+use App\Models\WebProperty;
+use App\Models\WebPropertyConversionSurface;
+use App\Models\WebPropertyEventContract;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class RuntimeAnalyticsContextFeedBuilder
+{
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function build(?string $hostname = null, ?string $runtimePath = null, ?string $siteKey = null): Collection
+    {
+        $normalizedHostname = $this->normalizeHostname($hostname);
+        $normalizedRuntimePath = $this->normalizeRuntimePath($runtimePath);
+        $normalizedSiteKey = $this->normalizeSiteKey($siteKey);
+
+        $properties = WebProperty::query()
+            ->where('status', 'active')
+            ->with([
+                'analyticsSources',
+                'eventContractAssignments.eventContract',
+                'conversionSurfaces.analyticsSource',
+                'conversionSurfaces.eventContractAssignment.eventContract',
+                'conversionSurfaces.domain',
+                'primaryDomain',
+                'propertyDomains.domain',
+            ])
+            ->orderBy('slug')
+            ->get();
+
+        $contexts = $properties
+            ->flatMap(fn (WebProperty $property): array => $this->contextsForProperty($property))
+            ->values();
+
+        if ($normalizedHostname !== null) {
+            $contexts = $contexts->where('hostname', $normalizedHostname)->values();
+        }
+
+        if ($normalizedRuntimePath !== null) {
+            $contexts = $contexts->filter(
+                fn (array $context): bool => (($context['runtime']['path'] ?? null) === $normalizedRuntimePath)
+            )->values();
+        }
+
+        if ($normalizedSiteKey !== null) {
+            $contexts = $contexts->filter(
+                fn (array $context): bool => (($context['site_key'] ?? null) === $normalizedSiteKey)
+            )->values();
+        }
+
+        return collect(
+            $contexts
+                ->sortBy(fn (array $context): string => (string) ($context['hostname'] ?? ''))
+                ->values()
+                ->all()
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function contextsForProperty(WebProperty $property): array
+    {
+        $contexts = [];
+
+        $propertyAnalyticsSource = $property->primaryAnalyticsSource('ga4');
+        $propertyEventAssignment = $property->primaryEventContractAssignment();
+        $defaultRuntime = $this->defaultRuntimeFromProperty($property);
+        $includedHostnames = [];
+
+        foreach ($property->conversionSurfaces as $surface) {
+            $hostname = $this->normalizeHostname($surface->hostname);
+
+            if ($hostname === null) {
+                continue;
+            }
+
+            $includedHostnames[$hostname] = true;
+
+            $contexts[] = $this->conversionSurfaceContextRecord(
+                property: $property,
+                surface: $surface,
+                fallbackAnalyticsSource: $propertyAnalyticsSource,
+                fallbackEventAssignment: $propertyEventAssignment
+            );
+        }
+
+        $hostnamePolicies = $property->hostnameLinkPolicySummary()['hostnames'];
+
+        foreach ($hostnamePolicies as $hostnamePolicy) {
+            $hostname = $this->normalizeHostname($hostnamePolicy['hostname'] ?? null);
+
+            if ($hostname === null || isset($includedHostnames[$hostname])) {
+                continue;
+            }
+
+            $classification = $this->classificationFromPolicy($hostnamePolicy);
+
+            $contexts[] = [
+                'hostname' => $hostname,
+                'property_slug' => $property->slug,
+                'site_key' => $property->siteKey(),
+                'journey_type' => $this->journeyTypeFromPolicy($hostnamePolicy),
+                'runtime' => $defaultRuntime,
+                'ga4' => $this->ga4Summary($propertyAnalyticsSource),
+                'event_contract' => $this->eventContractSummary($propertyEventAssignment),
+                'conversion_surface' => [
+                    'rollout_status' => null,
+                    'verified_at' => null,
+                ],
+                'host_classification' => [
+                    'class' => $classification['class'],
+                    'decision' => $classification['decision'],
+                    'reason' => $classification['reason'],
+                    'provenance' => 'hostname_link_policy',
+                    'role' => $hostnamePolicy['role'] ?? null,
+                    'property_kind' => $hostnamePolicy['property_kind'] ?? null,
+                ],
+            ];
+        }
+
+        return $contexts;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function conversionSurfaceContextRecord(
+        WebProperty $property,
+        WebPropertyConversionSurface $surface,
+        ?PropertyAnalyticsSource $fallbackAnalyticsSource,
+        ?WebPropertyEventContract $fallbackEventAssignment
+    ): array {
+        $analyticsSource = $surface->analytics_binding_mode !== 'inherits_property'
+            && $surface->analyticsSource instanceof PropertyAnalyticsSource
+            ? $surface->analyticsSource
+            : $fallbackAnalyticsSource;
+
+        $eventAssignment = $surface->event_contract_binding_mode !== 'inherits_property'
+            && $surface->eventContractAssignment instanceof WebPropertyEventContract
+            ? $surface->eventContractAssignment
+            : $fallbackEventAssignment;
+
+        return [
+            'hostname' => $this->normalizeHostname($surface->hostname),
+            'property_slug' => $property->slug,
+            'site_key' => $property->siteKey(),
+            'journey_type' => $surface->journey_type,
+            'runtime' => [
+                'driver' => $surface->runtime_driver,
+                'label' => $surface->runtime_label,
+                'path' => $surface->runtime_path,
+            ],
+            'ga4' => $this->ga4Summary($analyticsSource),
+            'event_contract' => $this->eventContractSummary($eventAssignment),
+            'conversion_surface' => [
+                'rollout_status' => $surface->rollout_status,
+                'verified_at' => $surface->verified_at?->toIso8601String(),
+            ],
+            'host_classification' => [
+                'class' => 'conversion_host',
+                'decision' => 'exported',
+                'reason' => 'first_class_conversion_surface',
+                'provenance' => 'conversion_surface',
+                'role' => $surface->surface_type === 'portal_subdomain'
+                    ? 'customer_portal_hostname'
+                    : 'quote_or_app_hostname',
+                'property_kind' => 'quote_conversion_surface',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $hostnamePolicy
+     * @return array{class: string, decision: string, reason: string}
+     */
+    private function classificationFromPolicy(array $hostnamePolicy): array
+    {
+        $role = $hostnamePolicy['role'] ?? null;
+        $propertyKind = $hostnamePolicy['property_kind'] ?? null;
+        $expectedLinks = is_array($hostnamePolicy['expected_links'] ?? null)
+            ? $hostnamePolicy['expected_links']
+            : [];
+
+        $hasRuntimeAttributionLinks = collect($expectedLinks)
+            ->map(fn (mixed $slot): ?string => is_array($slot) ? ($slot['status'] ?? null) : null)
+            ->filter(fn (mixed $status): bool => in_array($status, ['required', 'optional'], true))
+            ->isNotEmpty();
+
+        if ($role === 'marketing_domain' && $propertyKind === 'normal_marketing_site' && $hasRuntimeAttributionLinks) {
+            return [
+                'class' => 'public_brand_root_host',
+                'decision' => 'exported',
+                'reason' => 'marketing_domain_with_runtime_attribution',
+            ];
+        }
+
+        if ($propertyKind === 'quote_conversion_surface' && $hasRuntimeAttributionLinks) {
+            return [
+                'class' => 'conversion_host',
+                'decision' => 'exported',
+                'reason' => 'quote_or_portal_host_with_runtime_attribution',
+            ];
+        }
+
+        if ($propertyKind === 'operational_app_shell_apex' && $hasRuntimeAttributionLinks) {
+            return [
+                'class' => 'login_customer_provider_app_shell_host',
+                'decision' => 'exported',
+                'reason' => 'operational_app_shell_host_with_runtime_attribution',
+            ];
+        }
+
+        return [
+            'class' => 'retired_or_unknown',
+            'decision' => 'excluded',
+            'reason' => 'no_runtime_attribution_links',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $hostnamePolicy
+     */
+    private function journeyTypeFromPolicy(array $hostnamePolicy): ?string
+    {
+        $propertyKind = $hostnamePolicy['property_kind'] ?? null;
+
+        if ($propertyKind === 'quote_conversion_surface') {
+            return 'mixed_quote';
+        }
+
+        if ($propertyKind === 'operational_app_shell_apex') {
+            return 'app_shell';
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array{driver: string|null, label: string|null, path: string|null}
+     */
+    private function defaultRuntimeFromProperty(WebProperty $property): array
+    {
+        $surface = $property->conversionSurfaces
+            ->first(fn (WebPropertyConversionSurface $candidate): bool => is_string($candidate->runtime_path) && $candidate->runtime_path !== '')
+            ?? $property->conversionSurfaces->first();
+
+        if (! $surface instanceof WebPropertyConversionSurface) {
+            return [
+                'driver' => null,
+                'label' => null,
+                'path' => null,
+            ];
+        }
+
+        return [
+            'driver' => $surface->runtime_driver,
+            'label' => $surface->runtime_label,
+            'path' => $surface->runtime_path,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   provider: string|null,
+     *   property_id: string|null,
+     *   stream_id: string|null,
+     *   measurement_id: string|null,
+     *   bigquery_project: string|null
+     * }
+     */
+    private function ga4Summary(?PropertyAnalyticsSource $source): array
+    {
+        $config = $source?->provider_config;
+
+        return [
+            'provider' => $source?->provider,
+            'property_id' => is_array($config) ? ($config['property_id'] ?? null) : null,
+            'stream_id' => is_array($config) ? ($config['stream_id'] ?? null) : null,
+            'measurement_id' => is_array($config) ? ($config['measurement_id'] ?? null) : null,
+            'bigquery_project' => is_array($config) ? ($config['bigquery_project'] ?? null) : null,
+        ];
+    }
+
+    /**
+     * @return array{key: string|null, version: string|null, rollout_status: string|null}
+     */
+    private function eventContractSummary(?WebPropertyEventContract $assignment): array
+    {
+        $contract = $assignment?->eventContract;
+
+        return [
+            'key' => $contract?->key,
+            'version' => $contract?->version,
+            'rollout_status' => $assignment?->rollout_status,
+        ];
+    }
+
+    private function normalizeHostname(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = Str::lower(trim($value, ". \t\n\r\0\x0B"));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeRuntimePath(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeSiteKey(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/docs/RUNTIME-ANALYTICS-RESOLUTION-CONTRACT.md
+++ b/docs/RUNTIME-ANALYTICS-RESOLUTION-CONTRACT.md
@@ -68,6 +68,7 @@ The runtime contexts feed already includes:
 - `ga4`
 - `event_contract`
 - `conversion_surface`
+- `host_classification`
 
 The runtime should prefer this feed for lightweight hostname resolution.
 
@@ -115,6 +116,12 @@ The runtime should treat this as the minimum resolved contract per hostname:
   },
   "conversion_surface": {
     "rollout_status": "instrumented"
+  },
+  "host_classification": {
+    "class": "conversion_host",
+    "decision": "exported",
+    "reason": "first_class_conversion_surface",
+    "provenance": "conversion_surface"
   }
 }
 ```
@@ -126,6 +133,10 @@ The runtime should treat this as the minimum resolved contract per hostname:
   slug or analytics metadata.
 - Transitional fallback from `ga4.provider_config.site_key` is acceptable only
   while older rows are being backfilled.
+- Runtime feed records can also be inferred from `hostname_link_policy` for
+  active non-conversion runtime hosts. These records expose
+  `host_classification` so consumers can distinguish exported runtime contexts
+  from intentionally excluded host classes.
 
 ## Binding Rules
 

--- a/tests/Feature/RuntimeAnalyticsContextApiTest.php
+++ b/tests/Feature/RuntimeAnalyticsContextApiTest.php
@@ -34,6 +34,7 @@ class RuntimeAnalyticsContextApiTest extends TestCase
             'slug' => 'moveroo-com-au',
             'name' => 'Moveroo Website',
             'site_key' => 'moveroo',
+            'status' => 'active',
             'primary_domain_id' => $primaryDomain->id,
         ]);
 
@@ -105,6 +106,104 @@ class RuntimeAnalyticsContextApiTest extends TestCase
             ->assertJsonPath('runtime_contexts.0.ga4.measurement_id', 'G-9F3Y80LEQL')
             ->assertJsonPath('runtime_contexts.0.event_contract.key', 'moveroo-full-funnel-v1')
             ->assertJsonPath('runtime_contexts.0.event_contract.rollout_status', 'instrumented')
-            ->assertJsonPath('runtime_contexts.0.conversion_surface.rollout_status', 'instrumented');
+            ->assertJsonPath('runtime_contexts.0.conversion_surface.rollout_status', 'instrumented')
+            ->assertJsonPath('runtime_contexts.0.host_classification.class', 'conversion_host')
+            ->assertJsonPath('runtime_contexts.0.host_classification.decision', 'exported')
+            ->assertJsonPath('runtime_contexts.0.host_classification.provenance', 'conversion_surface');
+    }
+
+    public function test_runtime_analytics_context_feed_exports_non_conversion_operational_hostname_with_classification(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $primaryDomain = Domain::factory()->create([
+            'domain' => 'moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $surfaceDomain = Domain::factory()->create([
+            'domain' => 'quotes.moveroo.com.au',
+            'is_active' => true,
+        ]);
+
+        $property = WebProperty::factory()->create([
+            'slug' => 'moveroo-com-au',
+            'name' => 'Moveroo Website',
+            'site_key' => 'moveroo',
+            'status' => 'active',
+            'property_type' => 'website',
+            'primary_domain_id' => $primaryDomain->id,
+            'target_moveroo_subdomain_url' => 'https://wemove.moveroo.com.au',
+            'target_legacy_bookings_replacement_url' => 'https://removalist.net/booking/create',
+            'target_legacy_payments_replacement_url' => 'https://wemove.moveroo.com.au/contact',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $ga4 = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-9F3Y80LEQL',
+            'external_name' => 'Moveroo GA4',
+            'provider_config' => [
+                'site_key' => 'moveroo',
+                'property_id' => '457902172',
+                'stream_id' => '9677257871',
+                'measurement_id' => 'G-9F3Y80LEQL',
+                'bigquery_project' => 'mm-moveroo-analytics',
+            ],
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+
+        $contract = AnalyticsEventContract::create([
+            'key' => 'moveroo-full-funnel-v1',
+            'name' => 'Moveroo Full Funnel',
+            'version' => 'v1',
+            'contract_type' => 'ga4_web_and_backend',
+            'status' => 'active',
+        ]);
+
+        $assignment = WebPropertyEventContract::create([
+            'web_property_id' => $property->id,
+            'analytics_event_contract_id' => $contract->id,
+            'is_primary' => true,
+            'rollout_status' => 'instrumented',
+        ]);
+
+        WebPropertyConversionSurface::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $surfaceDomain->id,
+            'hostname' => 'quotes.moveroo.com.au',
+            'surface_type' => 'quote_subdomain',
+            'journey_type' => 'mixed_quote',
+            'runtime_driver' => 'Laravel',
+            'runtime_label' => 'Moveroo Removals 2026',
+            'runtime_path' => '/Users/jasonhill/Projects/laravel-projects/Moveroo Removals 2026',
+            'analytics_binding_mode' => 'inherits_property',
+            'event_contract_binding_mode' => 'inherits_property',
+            'rollout_status' => 'instrumented',
+            'property_analytics_source_id' => $ga4->id,
+            'web_property_event_contract_id' => $assignment->id,
+        ]);
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/runtime/analytics-contexts?hostname=removalist.net')
+            ->assertOk()
+            ->assertJsonPath('runtime_contexts.0.hostname', 'removalist.net')
+            ->assertJsonPath('runtime_contexts.0.property_slug', 'moveroo-com-au')
+            ->assertJsonPath('runtime_contexts.0.site_key', 'moveroo')
+            ->assertJsonPath('runtime_contexts.0.ga4.measurement_id', 'G-9F3Y80LEQL')
+            ->assertJsonPath('runtime_contexts.0.runtime.path', '/Users/jasonhill/Projects/laravel-projects/Moveroo Removals 2026')
+            ->assertJsonPath('runtime_contexts.0.conversion_surface.rollout_status', null)
+            ->assertJsonPath('runtime_contexts.0.host_classification.class', 'login_customer_provider_app_shell_host')
+            ->assertJsonPath('runtime_contexts.0.host_classification.decision', 'exported')
+            ->assertJsonPath('runtime_contexts.0.host_classification.provenance', 'hostname_link_policy');
     }
 }


### PR DESCRIPTION
## Summary

- add `RuntimeAnalyticsContextFeedBuilder` to build `/api/runtime/analytics-contexts` from both first-class conversion surfaces and inferred active hostnames from web-property hostname policy
- classify each runtime hostname with `host_classification` (`class`, `decision`, `reason`, `provenance`, `role`, `property_kind`) so consumers can distinguish exported contexts from intentionally excluded host classes
- preserve conversion-surface behavior while exporting additional active runtime hosts (for example non-conversion app-shell hosts) with safe GA4/site attribution context
- keep the feed lightweight and runtime-focused (no secrets, no unrelated monitoring payload)
- extend runtime analytics API tests for one conversion host and one non-conversion operational host (`removalist.net`) classification/export path
- update runtime contract doc with the added `host_classification` field and inferred-host behavior note

## Verification

- `php artisan test tests/Feature/RuntimeAnalyticsContextApiTest.php`
- `vendor/bin/pint --dirty`

Closes #205.
