### PR TITLE
[codex] Close out runtime brand surfaces

### DIFF
--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -116,6 +116,321 @@ return [
             'removalportal.interstate-removals.com.au',
             'removalquotes.backloading-services.com.au',
             'moving.allianceremovals.com.au',
+            'quoteandbook.mover.com.au',
+        ],
+        'classified_runtime_hostnames' => [
+            'acraustralia.com' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Legacy/non-MoverooCombined runtime analytics host; not a current app-served brand surface.',
+            ],
+            'again.com.au' => [
+                'classification' => 'operations_apex',
+                'reason' => 'Operations/control-plane apex; not a customer quote or booking brand surface.',
+            ],
+            'allianceremovals.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is moving.allianceremovals.com.au.',
+            ],
+            'backload.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'backloading-au.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.backloading-au.com.au.',
+            ],
+            'backloading-services.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surfaces are mymovehub.backloading-services.com.au and removalquotes.backloading-services.com.au.',
+            ],
+            'backloading.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'backloadingremovalist.com.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'backloadingremovals.com' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'backloadingremovals.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is mymovehub.backloadingremovals.com.au.',
+            ],
+            'backloadingremovals.moveroo.com.au' => [
+                'classification' => 'retired',
+                'reason' => 'Runtime override marks this Moveroo subdomain as retired and superseded.',
+            ],
+            'backloads.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'beauy.com.au' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Non-MoverooCombined website/brand; not safe for MoverooCombined runtime brand resolution.',
+            ],
+            'bestinterstateremovals.com.au' => [
+                'classification' => 'legacy_marketing',
+                'reason' => 'Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'car-carrying.com.au' => [
+                'classification' => 'legacy_marketing',
+                'reason' => 'Legacy vehicle marketing/analytics host; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'cartransport.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.cartransport.au.',
+            ],
+            'cartransport.movingagain.com.au' => [
+                'classification' => 'marketing_website',
+                'reason' => 'Fleet website candidate; not confirmed as a MoverooCombined app-served runtime surface.',
+            ],
+            'cartransport.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy/alias domain only; no confirmed current MoverooCombined app-served surface.',
+            ],
+            'cartransportaus.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.cartransportaus.com.au.',
+            ],
+            'cartransportwithpersonalitems.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.cartransportwithpersonalitems.com.au.',
+            ],
+            'deftly.com.au' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Non-MoverooCombined/personal or portfolio host; not a runtime brand surface.',
+            ],
+            'discountbackloading.com' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias; current published surface uses discountbackloading.com.au and mymoveportal.discountbackloading.com.au.',
+            ],
+            'discountbackloading.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is mymoveportal.discountbackloading.com.au.',
+            ],
+            'discountbackloading.moveroo.com.au' => [
+                'classification' => 'retired',
+                'reason' => 'Runtime override marks this Moveroo subdomain as retired and superseded.',
+            ],
+            'furnitureremovalist.com' => [
+                'classification' => 'legacy_marketing',
+                'reason' => 'Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'interstate-car-transport.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.interstate-car-transport.com.au.',
+            ],
+            'interstate-removalists.net.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing/brand apex; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'interstate-removals.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surfaces are quotes.interstate-removals.com.au and removalportal.interstate-removals.com.au.',
+            ],
+            'interstate-removals.moveroo.com.au' => [
+                'classification' => 'legacy_moveroo_subdomain',
+                'reason' => 'Legacy Moveroo subdomain; not confirmed as current app-served for this feed.',
+            ],
+            'interstatecarcarriers.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.interstatecarcarriers.com.au.',
+            ],
+            'interstateremovalists.au' => [
+                'classification' => 'marketing_alias',
+                'reason' => 'Marketing/alias apex; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'interstateremovalists.net.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing/brand apex; retired quote subdomain is quotes.interstateremovalists.net.au.',
+            ],
+            'jasonhill.com.au' => [
+                'classification' => 'personal_non_business',
+                'reason' => 'Personal/non-business host; not a MoverooCombined customer runtime surface.',
+            ],
+            'jhmh.com.au' => [
+                'classification' => 'personal_non_business',
+                'reason' => 'Personal/family host; not a MoverooCombined customer runtime surface.',
+            ],
+            'konradhill.com' => [
+                'classification' => 'personal_non_business',
+                'reason' => 'Personal/non-business host; not a MoverooCombined customer runtime surface.',
+            ],
+            'mandyhill.com.au' => [
+                'classification' => 'personal_non_business',
+                'reason' => 'Personal/non-business host; not a MoverooCombined customer runtime surface.',
+            ],
+            'movemycar.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is portal.movemycar.com.au.',
+            ],
+            'mover.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoteandbook.mover.com.au.',
+            ],
+            'moveroo.au' => [
+                'classification' => 'brand_alias',
+                'reason' => 'Moveroo brand TLD sibling/alias; not an app-served quote or booking surface.',
+            ],
+            'moveroo.click' => [
+                'classification' => 'parked_or_campaign_alias',
+                'reason' => 'Parked/campaign-style Moveroo alias; not an app-served quote or booking surface.',
+            ],
+            'moveroo.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quotes.moveroo.com.au.',
+            ],
+            'moving.au' => [
+                'classification' => 'brand_alias',
+                'reason' => 'Brand/alias domain; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'moving.com.au' => [
+                'classification' => 'brand_alias',
+                'reason' => 'Brand/alias domain; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movingagain.com' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias for Moving Again; current marketing apex is movingagain.com.au.',
+            ],
+            'movingagain.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is removalistquotes.movingagain.com.au.',
+            ],
+            'movingagain.net' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movingagain.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movingcars.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.movingcars.com.au.',
+            ],
+            'movingcars.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movingcartons.com.au' => [
+                'classification' => 'non_app_marketing',
+                'reason' => 'Cartons/marketing host; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'movinghome.com.au' => [
+                'classification' => 'legacy_marketing',
+                'reason' => 'Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movinginsurance.com.au' => [
+                'classification' => 'non_moveroocombined_product',
+                'reason' => 'Insurance marketing/product site; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'movinginterstate.com.au' => [
+                'classification' => 'legacy_marketing',
+                'reason' => 'Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'movingreviews.com.au' => [
+                'classification' => 'content_marketing',
+                'reason' => 'Reviews/content host; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'nfgseo.com.au' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Non-MoverooCombined/internal SEO host; not a runtime brand surface.',
+            ],
+            'olliehill.com.au' => [
+                'classification' => 'personal_non_business',
+                'reason' => 'Personal/non-business host; not a MoverooCombined customer runtime surface.',
+            ],
+            'perth.moveroo.com.au' => [
+                'classification' => 'retired',
+                'reason' => 'Retired and superseded by quoting.perthinterstateremovalists.com.au.',
+            ],
+            'perthinterstateremovalists.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.perthinterstateremovalists.com.au.',
+            ],
+            'pngchambers.com' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Non-MoverooCombined host; not a runtime brand surface.',
+            ],
+            'prepack.com.au' => [
+                'classification' => 'non_app_marketing',
+                'reason' => 'Packing/cartons style host; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'quotes.interstateremovalists.net.au' => [
+                'classification' => 'retired',
+                'reason' => 'Runtime override marks this quote subdomain as retired/decommissioned.',
+            ],
+            'quoting.mover.com.au' => [
+                'classification' => 'retired',
+                'reason' => 'Retired and superseded by quoteandbook.mover.com.au.',
+            ],
+            'quoting.vehicle.net.au' => [
+                'classification' => 'legacy_vehicle_quoting',
+                'reason' => 'Legacy vehicle quoting attached to the older vehicle runtime, not the active MoverooCombined pilot.',
+            ],
+            'redirection.com.au' => [
+                'classification' => 'non_app_redirect_utility',
+                'reason' => 'Redirect/utility domain; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'removalist.backloadingremovals.com.au' => [
+                'classification' => 'legacy_expected_miss',
+                'reason' => 'Runtime override records this as a legacy portal host expected to miss.',
+            ],
+            'removalist.net' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing/brand apex; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'removals.au' => [
+                'classification' => 'brand_alias',
+                'reason' => 'Brand/alias domain; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'removals.com.au' => [
+                'classification' => 'brand_alias',
+                'reason' => 'Brand/alias domain; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'removalsinterstate.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.removalsinterstate.com.au.',
+            ],
+            'rollover.com.au' => [
+                'classification' => 'non_app_redirect_utility',
+                'reason' => 'Redirect/utility domain; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'supercheapcartransport.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is portal.supercheapcartransport.com.au.',
+            ],
+            'supercheapcartransport.net.au' => [
+                'classification' => 'legacy_alias',
+                'reason' => 'Legacy alias; no current app-served MoverooCombined surface confirmed.',
+            ],
+            'synonymous.com.au' => [
+                'classification' => 'non_moveroocombined',
+                'reason' => 'Non-MoverooCombined host; not a runtime brand surface.',
+            ],
+            'tinyurl.com.au' => [
+                'classification' => 'non_app_redirect_utility',
+                'reason' => 'Short-link/redirect-style host; not a MoverooCombined quote or booking runtime surface.',
+            ],
+            'transportnondrivablecars.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quoting.transportnondrivablecars.com.au.',
+            ],
+            'vehicle.net.au' => [
+                'classification' => 'legacy_vehicle_runtime',
+                'reason' => 'Legacy vehicle apex associated with older vehicle quoting; not a current MoverooCombined brand surface.',
+            ],
+            'wemove.com.au' => [
+                'classification' => 'marketing_apex',
+                'reason' => 'Marketing apex; app-served quote surface is quotes.wemove.com.au.',
+            ],
+            'wemove.moveroo.com.au' => [
+                'classification' => 'legacy_expected_miss',
+                'reason' => 'Runtime override records this as a portal host without runtime attribution and expected to miss.',
+            ],
         ],
         'hostnames' => [
             'quotes.moveroo.com.au' => [
@@ -1691,6 +2006,77 @@ return [
                     'source' => 'domain_monitor',
                     'change_ref' => 'domain-monitor#217',
                     'source_marketing_url' => 'https://allianceremovals.com.au',
+                ],
+            ],
+            'quoteandbook.mover.com.au' => [
+                'property_slug' => 'mover-com-au',
+                'surface_slug' => 'mover-quoteandbook-v1',
+                'surface_type' => 'quote',
+                'journey_type' => 'mixed_quote',
+                'canonical_role' => 'primary',
+                'owning_marketing_domain' => 'mover.com.au',
+                'brand' => [
+                    'display_name' => 'Mover',
+                    'brand_key' => 'mover',
+                    'tagline' => 'Moving quotes and bookings',
+                    'mark_text' => 'M',
+                ],
+                'copy' => [
+                    'eyebrow' => 'Mover Quotes',
+                    'headline' => 'Get your Mover quote and booking started',
+                    'subheading' => 'Use the current Mover app-served quote and booking host for household and vehicle quote paths.',
+                    'primary_cta_label' => 'Start your quote',
+                    'secondary_cta_label' => 'Contact us',
+                    'footer_blurb' => 'Mover is published as the final confirmed app-served runtime brand surface from the remaining MoverooCombined list.',
+                ],
+                'theme' => [
+                    'theme_key' => 'mover',
+                    'mode' => 'auto',
+                    'fonts' => [
+                        'body_family' => 'Inter',
+                        'heading_family' => 'Inter',
+                    ],
+                    'colors' => [
+                        'accent' => '#2563eb',
+                        'accent_strong' => '#1d4ed8',
+                        'background' => '#eff6ff',
+                        'text' => '#111827',
+                        'muted_text' => '#4b5563',
+                        'surface' => '#ffffff',
+                        'border' => '#dbeafe',
+                    ],
+                    'radius_scale' => 'rounded',
+                    'shadow_style' => 'soft',
+                    'exact_tokens' => [],
+                ],
+                'navigation' => [
+                    'show_household_quote_link' => true,
+                    'show_vehicle_quote_link' => true,
+                    'show_booking_link' => true,
+                    'show_contact_link' => true,
+                    'show_customer_portal_link' => false,
+                    'show_customer_portal_in_header' => false,
+                    'show_provider_login_link' => false,
+                    'show_admin_link' => false,
+                ],
+                'links' => [
+                    'primary_cta_route' => 'household.quote',
+                    'primary_cta_url' => 'https://quoteandbook.mover.com.au/quote/household',
+                    'household_quote_url' => 'https://quoteandbook.mover.com.au/quote/household',
+                    'vehicle_quote_url' => 'https://quoteandbook.mover.com.au/quote/vehicle',
+                    'booking_url' => 'https://quoteandbook.mover.com.au/booking/create',
+                    'contact_url' => 'https://quoteandbook.mover.com.au/contact',
+                    'customer_portal_url' => null,
+                ],
+                'contact' => [
+                    'public_email' => 'removals@moveroo.com.au',
+                ],
+                'provenance' => [
+                    'approved_by' => 'domain-monitor',
+                    'approved_at' => '2026-05-19T19:20:00+10:00',
+                    'source' => 'domain_monitor',
+                    'change_ref' => 'domain-monitor#219',
+                    'source_marketing_url' => 'https://mover.com.au',
                 ],
             ],
         ],

--- a/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
+++ b/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
@@ -1,7 +1,7 @@
 # Published Brand Surfaces Contract
 
 Status: v1 pilot publisher
-Issue: #208, updated by #213, #215, and #217
+Issue: #208, updated by #213, #215, #217, and #219
 Consumer: MoverooCombined issues #2083 and #2084
 
 Domain Monitor publishes the read-only `domain-monitor-published-brand-surfaces` feed for MoverooCombined runtime consumption. The feed is pilot scoped and must not be treated as permission to import or render the full estate.
@@ -57,6 +57,7 @@ Current pilot hostnames:
 - Interstate Removals removal portal: `removalportal.interstate-removals.com.au`
 - Backloading Services removal quotes host: `removalquotes.backloading-services.com.au`
 - Alliance Removals moving quote host: `moving.allianceremovals.com.au`
+- Mover quote and booking host: `quoteandbook.mover.com.au`
 
 Second-pilot host classifications:
 
@@ -93,6 +94,13 @@ Third-pilot host classifications:
 - `quoting.vehicle.net.au`: legacy vehicle quoting, not the active vehicle pilot.
 - `removalist.backloadingremovals.com.au`: legacy portal host recorded as an expected miss.
 - `interstate-removals.moveroo.com.au`: legacy Moveroo subdomain, not confirmed as a current app-served brand surface for this controlled batch.
+
+Final runtime closeout classification:
+
+- `quoteandbook.mover.com.au`: app-served mixed quote surface and published.
+- The remaining 78 runtime-only hostnames from issue #219 are intentionally classified out in `domain_monitor.published_brand_surfaces.classified_runtime_hostnames` and mirrored in `docs/fixtures/published-brand-surfaces/final-runtime-closeout.json`.
+- Classifications cover marketing apexes, aliases, retired Moveroo subdomains, legacy vehicle/runtime hosts, personal/non-business hosts, redirect utilities, and non-MoverooCombined hosts.
+- This closes the Domain Monitor publisher side of the runtime-only list without changing MoverooCombined code, live websites, DNS, redirects, cron, secrets, or deployment settings.
 
 `quoting.vehicle.net.au` is legacy quoting and is not the active #2084 pilot test host. Discount Backloading is the selected pilot because Domain Monitor production records the current property-specific quote portal and target links:
 
@@ -133,3 +141,4 @@ Example payload fixtures live in:
 - `docs/fixtures/published-brand-surfaces/discountbackloading-quote.json`
 - `docs/fixtures/published-brand-surfaces/second-pilot-batch.json`
 - `docs/fixtures/published-brand-surfaces/third-pilot-batch.json`
+- `docs/fixtures/published-brand-surfaces/final-runtime-closeout.json`

--- a/docs/fixtures/published-brand-surfaces/final-runtime-closeout.json
+++ b/docs/fixtures/published-brand-surfaces/final-runtime-closeout.json
@@ -1,0 +1,514 @@
+{
+    "source_system": "domain-monitor-published-brand-surfaces",
+    "contract_version": 1,
+    "snapshot_id": "pbs-fixture-final-runtime-closeout-2026-05-19T092000Z",
+    "published_at": "2026-05-19T19:20:00+10:00",
+    "generated_by": "domain-monitor.published-brand-surfaces",
+    "pilot": {
+        "host_allowlist": [
+            "quoteandbook.mover.com.au"
+        ],
+        "scope": "moveroo_v1_final_runtime_closeout"
+    },
+    "surfaces": [
+        {
+            "hostname": "quoteandbook.mover.com.au",
+            "property_slug": "mover-com-au",
+            "surface_slug": "mover-quoteandbook-v1",
+            "status": "published",
+            "surface_type": "quote",
+            "canonical_role": "primary",
+            "updated_at": "2026-05-19T19:20:00+10:00",
+            "canonical_hostname": "quoteandbook.mover.com.au",
+            "linked_hostnames": [
+                "quoteandbook.mover.com.au"
+            ],
+            "owning_marketing_domain": "mover.com.au",
+            "controller_owner": "domain-monitor",
+            "controller_repo": "_wp-house",
+            "ownership": {
+                "published_truth_owner": "Domain Monitor",
+                "runtime_renderer_owner": "MoverooCombined",
+                "site_repo_owner": "_wp-house",
+                "portfolio_routing_owner": "Bossman"
+            },
+            "brand": {
+                "display_name": "Mover",
+                "brand_key": "mover",
+                "tagline": "Moving quotes and bookings",
+                "mark_text": "M"
+            },
+            "copy": {
+                "eyebrow": "Mover Quotes",
+                "headline": "Get your Mover quote and booking started",
+                "subheading": "Use the current Mover app-served quote and booking host for household and vehicle quote paths.",
+                "primary_cta_label": "Start your quote",
+                "secondary_cta_label": "Contact us",
+                "footer_blurb": "Mover is published as the final confirmed app-served runtime brand surface from the remaining MoverooCombined list."
+            },
+            "theme": {
+                "theme_key": "mover",
+                "mode": "auto",
+                "fonts": {
+                    "body_family": "Inter",
+                    "heading_family": "Inter"
+                },
+                "colors": {
+                    "accent": "#2563eb",
+                    "accent_strong": "#1d4ed8",
+                    "background": "#eff6ff",
+                    "text": "#111827",
+                    "muted_text": "#4b5563",
+                    "surface": "#ffffff",
+                    "border": "#dbeafe"
+                },
+                "radius_scale": "rounded",
+                "shadow_style": "soft",
+                "exact_tokens": []
+            },
+            "navigation": {
+                "show_household_quote_link": true,
+                "show_vehicle_quote_link": true,
+                "show_booking_link": true,
+                "show_contact_link": true,
+                "show_customer_portal_link": false,
+                "show_customer_portal_in_header": false,
+                "show_provider_login_link": false,
+                "show_admin_link": false
+            },
+            "behavior": {
+                "show_phone_publicly": true,
+                "show_email_publicly": true,
+                "prefer_contact_page_over_direct_contact": false,
+                "allow_customer_portal_links": true,
+                "allow_provider_login_links": false,
+                "allow_admin_links": false
+            },
+            "links": {
+                "primary_cta_route": "household.quote",
+                "primary_cta_url": "https://quoteandbook.mover.com.au/quote/household",
+                "household_quote_url": "https://quoteandbook.mover.com.au/quote/household",
+                "vehicle_quote_url": "https://quoteandbook.mover.com.au/quote/vehicle",
+                "booking_url": "https://quoteandbook.mover.com.au/booking/create",
+                "contact_url": "https://quoteandbook.mover.com.au/contact"
+            },
+            "contact": {
+                "public_email": "removals@moveroo.com.au"
+            },
+            "analytics": {
+                "status": "linked",
+                "runtime_context_key": "quoteandbook.mover.com.au",
+                "property_slug": "mover-com-au",
+                "site_key": "mover",
+                "journey_type": "mixed_quote",
+                "ga4": {
+                    "measurement_id": "G-MOVERCOMAU"
+                },
+                "event_contract": {
+                    "key": "mover-com-au-full-funnel-v1",
+                    "version": "v1",
+                    "rollout_status": "instrumented"
+                }
+            },
+            "provenance": {
+                "approved_by": "domain-monitor",
+                "approved_at": "2026-05-19T19:20:00+10:00",
+                "source": "domain_monitor",
+                "change_ref": "domain-monitor#219",
+                "source_marketing_url": "https://mover.com.au"
+            }
+        }
+    ],
+    "classified_not_published": [
+        {
+            "hostname": "acraustralia.com",
+            "classification": "non_moveroocombined",
+            "reason": "Legacy/non-MoverooCombined runtime analytics host; not a current app-served brand surface."
+        },
+        {
+            "hostname": "again.com.au",
+            "classification": "operations_apex",
+            "reason": "Operations/control-plane apex; not a customer quote or booking brand surface."
+        },
+        {
+            "hostname": "allianceremovals.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is moving.allianceremovals.com.au."
+        },
+        {
+            "hostname": "backload.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "backloading-au.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.backloading-au.com.au."
+        },
+        {
+            "hostname": "backloading-services.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surfaces are mymovehub.backloading-services.com.au and removalquotes.backloading-services.com.au."
+        },
+        {
+            "hostname": "backloading.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "backloadingremovalist.com.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "backloadingremovals.com",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "backloadingremovals.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is mymovehub.backloadingremovals.com.au."
+        },
+        {
+            "hostname": "backloadingremovals.moveroo.com.au",
+            "classification": "retired",
+            "reason": "Runtime override marks this Moveroo subdomain as retired and superseded."
+        },
+        {
+            "hostname": "backloads.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "beauy.com.au",
+            "classification": "non_moveroocombined",
+            "reason": "Non-MoverooCombined website/brand; not safe for MoverooCombined runtime brand resolution."
+        },
+        {
+            "hostname": "bestinterstateremovals.com.au",
+            "classification": "legacy_marketing",
+            "reason": "Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "car-carrying.com.au",
+            "classification": "legacy_marketing",
+            "reason": "Legacy vehicle marketing/analytics host; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "cartransport.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.cartransport.au."
+        },
+        {
+            "hostname": "cartransport.movingagain.com.au",
+            "classification": "marketing_website",
+            "reason": "Fleet website candidate; not confirmed as a MoverooCombined app-served runtime surface."
+        },
+        {
+            "hostname": "cartransport.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy/alias domain only; no confirmed current MoverooCombined app-served surface."
+        },
+        {
+            "hostname": "cartransportaus.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.cartransportaus.com.au."
+        },
+        {
+            "hostname": "cartransportwithpersonalitems.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.cartransportwithpersonalitems.com.au."
+        },
+        {
+            "hostname": "deftly.com.au",
+            "classification": "non_moveroocombined",
+            "reason": "Non-MoverooCombined/personal or portfolio host; not a runtime brand surface."
+        },
+        {
+            "hostname": "discountbackloading.com",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias; current published surface uses discountbackloading.com.au and mymoveportal.discountbackloading.com.au."
+        },
+        {
+            "hostname": "discountbackloading.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is mymoveportal.discountbackloading.com.au."
+        },
+        {
+            "hostname": "discountbackloading.moveroo.com.au",
+            "classification": "retired",
+            "reason": "Runtime override marks this Moveroo subdomain as retired and superseded."
+        },
+        {
+            "hostname": "furnitureremovalist.com",
+            "classification": "legacy_marketing",
+            "reason": "Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "interstate-car-transport.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.interstate-car-transport.com.au."
+        },
+        {
+            "hostname": "interstate-removalists.net.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing/brand apex; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "interstate-removals.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surfaces are quotes.interstate-removals.com.au and removalportal.interstate-removals.com.au."
+        },
+        {
+            "hostname": "interstate-removals.moveroo.com.au",
+            "classification": "legacy_moveroo_subdomain",
+            "reason": "Legacy Moveroo subdomain; not confirmed as current app-served for this feed."
+        },
+        {
+            "hostname": "interstatecarcarriers.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.interstatecarcarriers.com.au."
+        },
+        {
+            "hostname": "interstateremovalists.au",
+            "classification": "marketing_alias",
+            "reason": "Marketing/alias apex; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "interstateremovalists.net.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing/brand apex; retired quote subdomain is quotes.interstateremovalists.net.au."
+        },
+        {
+            "hostname": "jasonhill.com.au",
+            "classification": "personal_non_business",
+            "reason": "Personal/non-business host; not a MoverooCombined customer runtime surface."
+        },
+        {
+            "hostname": "jhmh.com.au",
+            "classification": "personal_non_business",
+            "reason": "Personal/family host; not a MoverooCombined customer runtime surface."
+        },
+        {
+            "hostname": "konradhill.com",
+            "classification": "personal_non_business",
+            "reason": "Personal/non-business host; not a MoverooCombined customer runtime surface."
+        },
+        {
+            "hostname": "mandyhill.com.au",
+            "classification": "personal_non_business",
+            "reason": "Personal/non-business host; not a MoverooCombined customer runtime surface."
+        },
+        {
+            "hostname": "movemycar.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is portal.movemycar.com.au."
+        },
+        {
+            "hostname": "mover.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoteandbook.mover.com.au."
+        },
+        {
+            "hostname": "moveroo.au",
+            "classification": "brand_alias",
+            "reason": "Moveroo brand TLD sibling/alias; not an app-served quote or booking surface."
+        },
+        {
+            "hostname": "moveroo.click",
+            "classification": "parked_or_campaign_alias",
+            "reason": "Parked/campaign-style Moveroo alias; not an app-served quote or booking surface."
+        },
+        {
+            "hostname": "moveroo.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quotes.moveroo.com.au."
+        },
+        {
+            "hostname": "moving.au",
+            "classification": "brand_alias",
+            "reason": "Brand/alias domain; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "moving.com.au",
+            "classification": "brand_alias",
+            "reason": "Brand/alias domain; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movingagain.com",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias for Moving Again; current marketing apex is movingagain.com.au."
+        },
+        {
+            "hostname": "movingagain.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is removalistquotes.movingagain.com.au."
+        },
+        {
+            "hostname": "movingagain.net",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movingagain.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movingcars.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.movingcars.com.au."
+        },
+        {
+            "hostname": "movingcars.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movingcartons.com.au",
+            "classification": "non_app_marketing",
+            "reason": "Cartons/marketing host; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "movinghome.com.au",
+            "classification": "legacy_marketing",
+            "reason": "Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movinginsurance.com.au",
+            "classification": "non_moveroocombined_product",
+            "reason": "Insurance marketing/product site; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "movinginterstate.com.au",
+            "classification": "legacy_marketing",
+            "reason": "Legacy marketing/analytics host; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "movingreviews.com.au",
+            "classification": "content_marketing",
+            "reason": "Reviews/content host; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "nfgseo.com.au",
+            "classification": "non_moveroocombined",
+            "reason": "Non-MoverooCombined/internal SEO host; not a runtime brand surface."
+        },
+        {
+            "hostname": "olliehill.com.au",
+            "classification": "personal_non_business",
+            "reason": "Personal/non-business host; not a MoverooCombined customer runtime surface."
+        },
+        {
+            "hostname": "perth.moveroo.com.au",
+            "classification": "retired",
+            "reason": "Retired and superseded by quoting.perthinterstateremovalists.com.au."
+        },
+        {
+            "hostname": "perthinterstateremovalists.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.perthinterstateremovalists.com.au."
+        },
+        {
+            "hostname": "pngchambers.com",
+            "classification": "non_moveroocombined",
+            "reason": "Non-MoverooCombined host; not a runtime brand surface."
+        },
+        {
+            "hostname": "prepack.com.au",
+            "classification": "non_app_marketing",
+            "reason": "Packing/cartons style host; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "quotes.interstateremovalists.net.au",
+            "classification": "retired",
+            "reason": "Runtime override marks this quote subdomain as retired/decommissioned."
+        },
+        {
+            "hostname": "quoting.mover.com.au",
+            "classification": "retired",
+            "reason": "Retired and superseded by quoteandbook.mover.com.au."
+        },
+        {
+            "hostname": "quoting.vehicle.net.au",
+            "classification": "legacy_vehicle_quoting",
+            "reason": "Legacy vehicle quoting attached to the older vehicle runtime, not the active MoverooCombined pilot."
+        },
+        {
+            "hostname": "redirection.com.au",
+            "classification": "non_app_redirect_utility",
+            "reason": "Redirect/utility domain; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "removalist.backloadingremovals.com.au",
+            "classification": "legacy_expected_miss",
+            "reason": "Runtime override records this as a legacy portal host expected to miss."
+        },
+        {
+            "hostname": "removalist.net",
+            "classification": "marketing_apex",
+            "reason": "Marketing/brand apex; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "removals.au",
+            "classification": "brand_alias",
+            "reason": "Brand/alias domain; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "removals.com.au",
+            "classification": "brand_alias",
+            "reason": "Brand/alias domain; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "removalsinterstate.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.removalsinterstate.com.au."
+        },
+        {
+            "hostname": "rollover.com.au",
+            "classification": "non_app_redirect_utility",
+            "reason": "Redirect/utility domain; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "supercheapcartransport.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is portal.supercheapcartransport.com.au."
+        },
+        {
+            "hostname": "supercheapcartransport.net.au",
+            "classification": "legacy_alias",
+            "reason": "Legacy alias; no current app-served MoverooCombined surface confirmed."
+        },
+        {
+            "hostname": "synonymous.com.au",
+            "classification": "non_moveroocombined",
+            "reason": "Non-MoverooCombined host; not a runtime brand surface."
+        },
+        {
+            "hostname": "tinyurl.com.au",
+            "classification": "non_app_redirect_utility",
+            "reason": "Short-link/redirect-style host; not a MoverooCombined quote or booking runtime surface."
+        },
+        {
+            "hostname": "transportnondrivablecars.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quoting.transportnondrivablecars.com.au."
+        },
+        {
+            "hostname": "vehicle.net.au",
+            "classification": "legacy_vehicle_runtime",
+            "reason": "Legacy vehicle apex associated with older vehicle quoting; not a current MoverooCombined brand surface."
+        },
+        {
+            "hostname": "wemove.com.au",
+            "classification": "marketing_apex",
+            "reason": "Marketing apex; app-served quote surface is quotes.wemove.com.au."
+        },
+        {
+            "hostname": "wemove.moveroo.com.au",
+            "classification": "legacy_expected_miss",
+            "reason": "Runtime override records this as a portal host without runtime attribution and expected to miss."
+        }
+    ]
+}

--- a/tests/Feature/PublishedBrandSurfaceApiTest.php
+++ b/tests/Feature/PublishedBrandSurfaceApiTest.php
@@ -280,6 +280,141 @@ class PublishedBrandSurfaceApiTest extends TestCase
         }
     }
 
+    public function test_published_brand_surface_feed_returns_final_runtime_closeout_host_and_classifies_the_rest(): void
+    {
+        config()->set('services.domain_monitor.moveroo_removals_api_key', 'moveroo-runtime-token');
+        config()->set('domain_monitor.published_brand_surfaces.pilot_host_allowlist', [
+            'quoteandbook.mover.com.au',
+        ]);
+
+        $metadataByHostname = config('domain_monitor.published_brand_surfaces.hostnames');
+        $this->assertIsArray($metadataByHostname);
+        $this->assertArrayHasKey('quoteandbook.mover.com.au', $metadataByHostname);
+
+        $metadata = $metadataByHostname['quoteandbook.mover.com.au'];
+        $this->createConfiguredProperty(
+            propertySlug: (string) $metadata['property_slug'],
+            propertyName: (string) $metadata['owning_marketing_domain'],
+            siteKey: (string) $metadata['brand']['brand_key'],
+            primaryDomainName: (string) $metadata['owning_marketing_domain'],
+            repoName: '_wp-house',
+            measurementId: 'G-MOVERFINAL',
+            eventContractKey: $metadata['property_slug'].'-full-funnel-v1',
+        );
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer moveroo-runtime-token',
+        ])->getJson('/api/published-brand-surfaces')
+            ->assertOk()
+            ->assertJsonCount(1, 'surfaces')
+            ->assertJsonPath('surfaces.0.hostname', 'quoteandbook.mover.com.au')
+            ->assertJsonPath('surfaces.0.property_slug', 'mover-com-au')
+            ->assertJsonPath('surfaces.0.navigation.show_household_quote_link', true)
+            ->assertJsonPath('surfaces.0.navigation.show_vehicle_quote_link', true)
+            ->assertJsonPath('surfaces.0.links.household_quote_url', 'https://quoteandbook.mover.com.au/quote/household')
+            ->assertJsonPath('surfaces.0.links.vehicle_quote_url', 'https://quoteandbook.mover.com.au/quote/vehicle')
+            ->assertJsonPath('surfaces.0.links.booking_url', 'https://quoteandbook.mover.com.au/booking/create')
+            ->assertJsonPath('surfaces.0.analytics.status', 'linked');
+
+        $remainingRuntimeHostnames = [
+            'acraustralia.com',
+            'again.com.au',
+            'allianceremovals.com.au',
+            'backload.net.au',
+            'backloading-au.com.au',
+            'backloading-services.com.au',
+            'backloading.net.au',
+            'backloadingremovalist.com.au',
+            'backloadingremovals.com',
+            'backloadingremovals.com.au',
+            'backloadingremovals.moveroo.com.au',
+            'backloads.net.au',
+            'beauy.com.au',
+            'bestinterstateremovals.com.au',
+            'car-carrying.com.au',
+            'cartransport.au',
+            'cartransport.movingagain.com.au',
+            'cartransport.net.au',
+            'cartransportaus.com.au',
+            'cartransportwithpersonalitems.com.au',
+            'deftly.com.au',
+            'discountbackloading.com',
+            'discountbackloading.com.au',
+            'discountbackloading.moveroo.com.au',
+            'furnitureremovalist.com',
+            'interstate-car-transport.com.au',
+            'interstate-removalists.net.au',
+            'interstate-removals.com.au',
+            'interstate-removals.moveroo.com.au',
+            'interstatecarcarriers.com.au',
+            'interstateremovalists.au',
+            'interstateremovalists.net.au',
+            'jasonhill.com.au',
+            'jhmh.com.au',
+            'konradhill.com',
+            'mandyhill.com.au',
+            'movemycar.com.au',
+            'mover.com.au',
+            'moveroo.au',
+            'moveroo.click',
+            'moveroo.com.au',
+            'moving.au',
+            'moving.com.au',
+            'movingagain.com',
+            'movingagain.com.au',
+            'movingagain.net',
+            'movingagain.net.au',
+            'movingcars.com.au',
+            'movingcars.net.au',
+            'movingcartons.com.au',
+            'movinghome.com.au',
+            'movinginsurance.com.au',
+            'movinginterstate.com.au',
+            'movingreviews.com.au',
+            'nfgseo.com.au',
+            'olliehill.com.au',
+            'perth.moveroo.com.au',
+            'perthinterstateremovalists.com.au',
+            'pngchambers.com',
+            'prepack.com.au',
+            'quoteandbook.mover.com.au',
+            'quotes.interstateremovalists.net.au',
+            'quoting.mover.com.au',
+            'quoting.vehicle.net.au',
+            'redirection.com.au',
+            'removalist.backloadingremovals.com.au',
+            'removalist.net',
+            'removals.au',
+            'removals.com.au',
+            'removalsinterstate.com.au',
+            'rollover.com.au',
+            'supercheapcartransport.com.au',
+            'supercheapcartransport.net.au',
+            'synonymous.com.au',
+            'tinyurl.com.au',
+            'transportnondrivablecars.com.au',
+            'vehicle.net.au',
+            'wemove.com.au',
+            'wemove.moveroo.com.au',
+        ];
+
+        $classifiedRuntimeHostnames = config('domain_monitor.published_brand_surfaces.classified_runtime_hostnames');
+        $this->assertIsArray($classifiedRuntimeHostnames);
+        $this->assertCount(78, $classifiedRuntimeHostnames);
+
+        foreach ($remainingRuntimeHostnames as $hostname) {
+            if ($hostname === 'quoteandbook.mover.com.au') {
+                $this->assertContains($hostname, config('domain_monitor.published_brand_surfaces.pilot_host_allowlist'));
+
+                continue;
+            }
+
+            $this->assertArrayHasKey($hostname, $classifiedRuntimeHostnames, "{$hostname} is not classified");
+            $this->assertNotEmpty($classifiedRuntimeHostnames[$hostname]['classification']);
+            $this->assertNotEmpty($classifiedRuntimeHostnames[$hostname]['reason']);
+        }
+    }
+
     public function test_published_brand_surface_fixtures_match_the_contract_shape(): void
     {
         foreach ([
@@ -287,6 +422,7 @@ class PublishedBrandSurfaceApiTest extends TestCase
             base_path('docs/fixtures/published-brand-surfaces/discountbackloading-quote.json'),
             base_path('docs/fixtures/published-brand-surfaces/second-pilot-batch.json'),
             base_path('docs/fixtures/published-brand-surfaces/third-pilot-batch.json'),
+            base_path('docs/fixtures/published-brand-surfaces/final-runtime-closeout.json'),
         ] as $fixturePath) {
             $payload = json_decode((string) file_get_contents($fixturePath), true);
 


### PR DESCRIPTION
## Summary
- publish the final confirmed remaining MoverooCombined app-served surface: `quoteandbook.mover.com.au`
- add a repo-owned `classified_runtime_hostnames` map for the other 78 runtime-only hostnames from #219
- add a final closeout fixture and tests that prove the issue list is fully accounted for

## Published
- `quoteandbook.mover.com.au`

## Classified out
The 78 non-published runtime hostnames are recorded with per-host reasons in:
- `config/domain_monitor.php` under `domain_monitor.published_brand_surfaces.classified_runtime_hostnames`
- `docs/fixtures/published-brand-surfaces/final-runtime-closeout.json`

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/PublishedBrandSurfaceApiTest.php`
- `php artisan test tests/Feature/IntegrationMetaApiTest.php`
- `./vendor/bin/phpstan analyse app/Services/PublishedBrandSurfaceFeedBuilder.php --memory-limit=2G --no-progress`
- `git diff --check`

## Scope
- No MoverooCombined code changes
- No live website, DNS, redirect, cron, secret, env var, billing, access, or external-system changes
- Does not handle redirect-policy issue #210

Refs #219.
