### PR TITLE
Fix Fleet quote/contact link matching

### DIFF
--- a/app/Services/FleetTechnicalSeoAuditRunner.php
+++ b/app/Services/FleetTechnicalSeoAuditRunner.php
@@ -204,9 +204,16 @@ class FleetTechnicalSeoAuditRunner
         $canonical = $this->canonicalUrl($homepageHtml, $baseUrl.'/');
         $brokenInternalLinks = $this->brokenInternalLinks($context['internal_links']);
         $declaredUrls = $this->declaredUrlsForProperty($property);
-        $visibleLinks = $context['internal_links'];
+        $visibleHomepageLinks = collect([...$context['internal_links'], ...$context['external_links']])
+            ->unique()
+            ->values()
+            ->all();
+        $matchedDeclaredUrls = collect($declaredUrls)
+            ->filter(fn (string $url): bool => in_array($url, $visibleHomepageLinks, true))
+            ->values()
+            ->all();
         $missingDeclaredUrls = collect($declaredUrls)
-            ->reject(fn (string $url): bool => in_array($url, $visibleLinks, true))
+            ->reject(fn (string $url): bool => in_array($url, $visibleHomepageLinks, true))
             ->values()
             ->all();
 
@@ -232,7 +239,12 @@ class FleetTechnicalSeoAuditRunner
         $results['redirects.no_key_route_chains_or_loops'] = $this->result($this->isSuccessful($homepage) ? 'pass' : 'unknown', $this->isSuccessful($homepage) ? 'high' : 'low', ['homepage' => Arr::except($homepage, ['body'])], $baseUrl.'/');
         $results['links.internal_key_links_resolve'] = $this->result($brokenInternalLinks === [] ? 'pass' : 'fail', 'high', ['broken_internal_links' => $brokenInternalLinks, 'checked_internal_link_count' => count($context['internal_links'])]);
         $results['links.external_inventory_classified'] = $this->result('manual_review', 'medium', ['external_links' => array_slice($context['external_links'], 0, 25), 'external_link_count' => count($context['external_links'])]);
-        $results['links.quote_contact_targets_current'] = $this->result($declaredUrls === [] ? 'not_applicable' : ($missingDeclaredUrls === [] ? 'pass' : 'fail'), 'high', ['declared_urls' => $declaredUrls, 'missing_declared_urls' => $missingDeclaredUrls]);
+        $results['links.quote_contact_targets_current'] = $this->result($declaredUrls === [] ? 'not_applicable' : ($missingDeclaredUrls === [] ? 'pass' : 'fail'), 'high', [
+            'declared_urls' => $declaredUrls,
+            'matched_declared_urls' => $matchedDeclaredUrls,
+            'missing_declared_urls' => $missingDeclaredUrls,
+            'homepage_link_count' => count($visibleHomepageLinks),
+        ]);
         $results['images.alt_text_meaningful'] = $this->imageResult($context['pages'], 'alt');
         $results['images.dimensions_declared_for_fixed_assets'] = $this->imageResult($context['pages'], 'dimensions');
         $results['mobile.usability_basic_rendering'] = $this->mobileRenderedResult($context['browser_render'] ?? []);

--- a/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
+++ b/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
@@ -128,6 +128,50 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         $this->assertNotEmpty($result->evidence['skipped_urls']);
     }
 
+    public function test_quote_contact_targets_match_declared_app_host_links_on_homepage(): void
+    {
+        $property = $this->makeProperty('app-host-links-site', 'app-host-links.example', [
+            'target_household_quote_url' => 'https://quoting.app-host-links.example/quote/household',
+            'target_household_booking_url' => 'https://quoting.app-host-links.example/booking/create',
+            'target_vehicle_quote_url' => 'https://quoting.app-host-links.example/quote/vehicle',
+            'target_contact_us_page_url' => 'https://quoting.app-host-links.example/contact',
+        ]);
+        $this->fakeHealthySite('https://app-host-links.example', [
+            'homepage_links' => [
+                'https://quoting.app-host-links.example/quote/household' => 'Get a quote',
+                'https://quoting.app-host-links.example/booking/create' => 'Book now',
+                'https://quoting.app-host-links.example/quote/vehicle' => 'Vehicle quote',
+                'https://quoting.app-host-links.example/contact' => 'Contact',
+            ],
+            'extra_responses' => [
+                'https://quoting.app-host-links.example/quote/household' => Http::response('<html><body>Household quote</body></html>', 200, ['Content-Type' => 'text/html']),
+                'https://quoting.app-host-links.example/booking/create' => Http::response('<html><body>Booking</body></html>', 200, ['Content-Type' => 'text/html']),
+                'https://quoting.app-host-links.example/quote/vehicle' => Http::response('<html><body>Vehicle quote</body></html>', 200, ['Content-Type' => 'text/html']),
+                'https://quoting.app-host-links.example/contact' => Http::response('<html><body>Contact</body></html>', 200, ['Content-Type' => 'text/html']),
+            ],
+        ]);
+
+        $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
+            '--property' => $property->slug,
+            '--url-cap' => 10,
+        ]));
+
+        $result = FleetTechnicalSeoAuditResult::query()
+            ->where('check_id', 'links.quote_contact_targets_current')
+            ->firstOrFail();
+
+        $this->assertSame(FleetTechnicalSeoAuditResult::STATUS_PASS, $result->result_status);
+        $this->assertSame([
+            'https://quoting.app-host-links.example/quote/household',
+            'https://quoting.app-host-links.example/booking/create',
+            'https://quoting.app-host-links.example/quote/vehicle',
+            'https://quoting.app-host-links.example/contact',
+        ], $result->evidence['matched_declared_urls']);
+        $this->assertSame([], $result->evidence['missing_declared_urls']);
+        $this->assertGreaterThanOrEqual(6, $result->evidence['homepage_link_count']);
+        $this->assertDatabaseCount('monitoring_findings', 0);
+    }
+
     public function test_legacy_route_mapping_stays_unknown_when_no_manifest_is_configured(): void
     {
         $property = $this->makeProperty('no-legacy-manifest-site', 'no-legacy-manifest.example');
@@ -472,6 +516,7 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
      * @param  array{
      *   robots_status?: int,
      *   sitemap_urls?: array<int, string>,
+     *   homepage_links?: array<string, string>,
      *   extra_responses?: array<string, \GuzzleHttp\Promise\PromiseInterface>
      * }  $options
      */
@@ -485,7 +530,7 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         $sitemapXml = '<urlset>'.collect($sitemapUrls)
             ->map(fn (string $url): string => '<url><loc>'.$url.'</loc></url>')
             ->implode('').'</urlset>';
-        $html = $this->healthyHtml($baseUrl);
+        $html = $this->healthyHtml($baseUrl, $options['homepage_links'] ?? []);
 
         Http::fake(array_merge([
             $baseUrl.'/' => Http::response($html, 200, ['Content-Type' => 'text/html']),
@@ -499,8 +544,15 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         ], $options['extra_responses'] ?? []));
     }
 
-    private function healthyHtml(string $baseUrl): string
+    /**
+     * @param  array<string, string>  $extraLinks
+     */
+    private function healthyHtml(string $baseUrl, array $extraLinks = []): string
     {
+        $extraLinkHtml = collect($extraLinks)
+            ->map(fn (string $label, string $url): string => '<a href="'.$url.'">'.$label.'</a>')
+            ->implode("\n");
+
         return <<<HTML
             <!doctype html>
             <html lang="en">
@@ -517,6 +569,7 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
                 <h1>Example Site</h1>
                 <a href="{$baseUrl}/about">About</a>
                 <a href="{$baseUrl}/quote">Quote</a>
+                {$extraLinkHtml}
                 <img src="{$baseUrl}/logo.png" alt="Example logo" width="120" height="60">
             </body>
             </html>


### PR DESCRIPTION
## Summary
- compare declared quote/contact targets against the full homepage link inventory, including app-host/subdomain links
- preserve internal-link checking behavior for same-host broken links
- add matched declared URL evidence so future failures show what was seen vs missing
- add regression coverage for declared quote/contact targets on a separate app host

## Checks
- `php artisan test tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php --filter=quote_contact`
- `php artisan test tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php`
- `./vendor/bin/phpstan analyse app/Services/FleetTechnicalSeoAuditRunner.php tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php --memory-limit=2G --no-progress`
- `vendor/bin/pint --dirty`
- `git diff --check`

Fixes #226