### PR TITLE
Consume MM-Google evidence in Fleet SEO audit

### DIFF
--- a/app/Services/FleetTechnicalSeoAuditRunner.php
+++ b/app/Services/FleetTechnicalSeoAuditRunner.php
@@ -5,6 +5,8 @@ namespace App\Services;
 use App\Models\FleetTechnicalSeoAuditResult;
 use App\Models\FleetTechnicalSeoAuditRun;
 use App\Models\MonitoringFinding;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\SearchConsoleCoverageStatus;
 use App\Models\WebProperty;
 use DOMDocument;
 use Illuminate\Http\Client\Response;
@@ -61,7 +63,7 @@ class FleetTechnicalSeoAuditRunner
 
     public function run(WebProperty $property, int $urlCap = 25, string $triggerType = 'manual'): FleetTechnicalSeoAuditRun
     {
-        $property->loadMissing(['primaryDomain', 'primaryDomain.tags', 'propertyDomains.domain', 'conversionSurfaces']);
+        $property->loadMissing(['primaryDomain', 'primaryDomain.tags', 'propertyDomains.domain', 'conversionSurfaces', 'analyticsSources.latestSearchConsoleCoverage']);
         $urlCap = max(1, $urlCap);
         $startedAt = now();
         $modes = collect(self::CHECKS)->pluck('mode')->unique()->values()->all();
@@ -256,7 +258,7 @@ class FleetTechnicalSeoAuditRunner
         $results['accessibility.semantic_baseline'] = $this->accessibilityRenderedResult($context['browser_render'] ?? []);
         $results['social.open_graph_baseline'] = $this->socialResult($homepageHtml);
         $results['ai.llms_txt_expected'] = $this->result($this->isSuccessful($context['llms']) ? 'pass' : 'manual_review', 'medium', ['llms' => Arr::except($context['llms'], ['body'])], $baseUrl.'/llms.txt');
-        $results['analytics.google_evidence_owned_by_mm_google'] = $this->result('unknown', 'low', ['owner_system' => 'MM-Google', 'reason' => 'No imported MM-Google evidence attached to this deterministic run.']);
+        $results['analytics.google_evidence_owned_by_mm_google'] = $this->mmGoogleAnalyticsEvidenceResult($property);
 
         return $results;
     }
@@ -654,6 +656,73 @@ class FleetTechnicalSeoAuditRunner
             'checked_route_count' => count($checkedRoutes),
             'failed_route_count' => count($failedRoutes),
         ]);
+    }
+
+    /**
+     * @return array{status: string, confidence: string, evidence: array<string, mixed>}
+     */
+    private function mmGoogleAnalyticsEvidenceResult(WebProperty $property): array
+    {
+        $ga4Source = $property->primaryAnalyticsSource('ga4');
+
+        if (! $ga4Source instanceof PropertyAnalyticsSource || ! $this->isMmGoogleAnalyticsSource($ga4Source)) {
+            return $this->result('unknown', 'low', [
+                'owner_system' => 'MM-Google',
+                'reason' => 'No imported MM-Google evidence attached to this deterministic run.',
+            ]);
+        }
+
+        $coverage = $ga4Source->relationLoaded('latestSearchConsoleCoverage')
+            ? $ga4Source->latestSearchConsoleCoverage
+            : $ga4Source->latestSearchConsoleCoverage()->first();
+        $evidence = [
+            'owner_system' => 'MM-Google',
+            'provider' => $ga4Source->provider,
+            'external_id' => $ga4Source->external_id,
+            'external_name' => $ga4Source->external_name,
+            'source_workspace' => 'MM-Google',
+            'is_primary' => $ga4Source->is_primary,
+            'source_status' => $ga4Source->status,
+            'source_updated_at' => $ga4Source->updated_at?->toIso8601String(),
+            'search_console' => $coverage instanceof SearchConsoleCoverageStatus
+                ? $this->searchConsoleCoverageEvidence($coverage)
+                : null,
+        ];
+
+        if ($ga4Source->is_primary && $ga4Source->status === 'active') {
+            return $this->result('pass', 'high', [
+                ...$evidence,
+                'reason' => 'Imported MM-Google GA4 evidence is active and primary for this property.',
+            ]);
+        }
+
+        return $this->result('manual_review', 'medium', [
+            ...$evidence,
+            'reason' => 'Imported MM-Google GA4 evidence exists but is not active primary evidence.',
+        ]);
+    }
+
+    private function isMmGoogleAnalyticsSource(PropertyAnalyticsSource $source): bool
+    {
+        return is_string($source->workspace_path) && str_contains($source->workspace_path, 'MM-Google');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function searchConsoleCoverageEvidence(SearchConsoleCoverageStatus $coverage): array
+    {
+        return [
+            'source_provider' => $coverage->source_provider,
+            'mapping_state' => $coverage->mapping_state,
+            'property_uri' => $coverage->property_uri,
+            'property_type' => $coverage->property_type,
+            'latest_completed_job_type' => $coverage->latest_completed_job_type,
+            'latest_completed_job_at' => $coverage->latest_completed_job_at?->toIso8601String(),
+            'latest_metric_date' => $coverage->latest_metric_date?->toDateString(),
+            'checked_at' => $coverage->checked_at->toIso8601String(),
+            'freshness_state' => $coverage->freshnessState(),
+        ];
     }
 
     /**

--- a/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
+++ b/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
@@ -6,6 +6,8 @@ use App\Models\Domain;
 use App\Models\FleetTechnicalSeoAuditResult;
 use App\Models\FleetTechnicalSeoAuditRun;
 use App\Models\MonitoringFinding;
+use App\Models\PropertyAnalyticsSource;
+use App\Models\SearchConsoleCoverageStatus;
 use App\Models\WebProperty;
 use App\Models\WebPropertyDomain;
 use App\Services\FleetTechnicalSeoBrowserRenderer;
@@ -169,6 +171,71 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         ], $result->evidence['matched_declared_urls']);
         $this->assertSame([], $result->evidence['missing_declared_urls']);
         $this->assertGreaterThanOrEqual(6, $result->evidence['homepage_link_count']);
+        $this->assertDatabaseCount('monitoring_findings', 0);
+    }
+
+    public function test_mm_google_analytics_evidence_passes_when_active_primary_ga4_source_is_imported(): void
+    {
+        $property = $this->makeProperty('mm-google-covered-site', 'mm-google-covered.example');
+        $source = PropertyAnalyticsSource::create([
+            'web_property_id' => $property->id,
+            'provider' => 'ga4',
+            'external_id' => 'G-EXAMPLE123',
+            'external_name' => 'MM Google Covered',
+            'workspace_path' => '/Users/jasonhill/Projects/Business/operations/MM-Google',
+            'is_primary' => true,
+            'status' => 'active',
+        ]);
+        SearchConsoleCoverageStatus::create([
+            'web_property_id' => $property->id,
+            'property_analytics_source_id' => $source->id,
+            'source_provider' => 'mm_google',
+            'matomo_site_id' => 'mm-google-covered-example',
+            'mapping_state' => 'domain_property',
+            'property_uri' => 'sc-domain:mm-google-covered.example',
+            'property_type' => 'domain',
+            'latest_completed_job_type' => 'mm_google_export',
+            'latest_completed_job_at' => now()->subDay(),
+            'latest_metric_date' => now()->toDateString(),
+            'checked_at' => now(),
+        ]);
+        $this->fakeHealthySite('https://mm-google-covered.example');
+
+        $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
+            '--property' => $property->slug,
+            '--url-cap' => 10,
+        ]));
+
+        $result = FleetTechnicalSeoAuditResult::query()
+            ->where('check_id', 'analytics.google_evidence_owned_by_mm_google')
+            ->firstOrFail();
+
+        $this->assertSame(FleetTechnicalSeoAuditResult::STATUS_PASS, $result->result_status);
+        $this->assertSame(FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH, $result->evidence_confidence);
+        $this->assertSame('MM-Google', $result->evidence['owner_system']);
+        $this->assertSame('G-EXAMPLE123', $result->evidence['external_id']);
+        $this->assertSame('MM-Google', $result->evidence['source_workspace']);
+        $this->assertSame('domain_property', $result->evidence['search_console']['mapping_state']);
+        $this->assertDatabaseCount('monitoring_findings', 0);
+    }
+
+    public function test_mm_google_analytics_evidence_stays_unknown_when_no_imported_source_exists(): void
+    {
+        $property = $this->makeProperty('no-mm-google-source-site', 'no-mm-google-source.example');
+        $this->fakeHealthySite('https://no-mm-google-source.example');
+
+        $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
+            '--property' => $property->slug,
+            '--url-cap' => 10,
+        ]));
+
+        $result = FleetTechnicalSeoAuditResult::query()
+            ->where('check_id', 'analytics.google_evidence_owned_by_mm_google')
+            ->firstOrFail();
+
+        $this->assertSame(FleetTechnicalSeoAuditResult::STATUS_UNKNOWN, $result->result_status);
+        $this->assertSame(FleetTechnicalSeoAuditResult::CONFIDENCE_LOW, $result->evidence_confidence);
+        $this->assertSame('No imported MM-Google evidence attached to this deterministic run.', $result->evidence['reason']);
         $this->assertDatabaseCount('monitoring_findings', 0);
     }
 


### PR DESCRIPTION
## Summary
- replace the hard-coded MM-Google analytics unknown with a read-only imported evidence consumer
- classify active primary GA4 sources from the MM-Google workspace as high-confidence pass evidence
- attach safe GA4 and Search Console coverage evidence fields when present
- preserve low-confidence unknown when no imported MM-Google source exists

## Checks
- `php artisan test tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php --filter=mm_google`
- `php artisan test tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php`
- `./vendor/bin/phpstan analyse app/Services/FleetTechnicalSeoAuditRunner.php tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php --memory-limit=2G --no-progress`
- `vendor/bin/pint --dirty`
- `git diff --check`

Fixes #227