### PR TITLE
Expose Control link evidence for monitoring findings

### DIFF
--- a/app/Services/ExternalReferencePolicy.php
+++ b/app/Services/ExternalReferencePolicy.php
@@ -131,6 +131,37 @@ class ExternalReferencePolicy
      *   policy_reference: string|null
      * }
      */
+    public function classifyUrl(?string $url, ?string $sourceHost = null, ?WebProperty $property = null): array
+    {
+        $host = $this->hostFromUrl($url);
+
+        if ($this->isAcceptedAppHandoffUrl($url, $sourceHost, $property)) {
+            return $this->result(
+                classification: 'accepted_app_handoff',
+                action: 'approved',
+                approved: true,
+                reason: 'URL is an accepted quote, booking, contact, or app handoff for this property.',
+                category: 'app_handoff',
+                registrySource: 'property_runtime_policy',
+                scope: 'property',
+            );
+        }
+
+        return $this->classify($host, $sourceHost, $property);
+    }
+
+    /**
+     * @return array{
+     *   classification: string,
+     *   action: string,
+     *   approved: bool,
+     *   reason: string,
+     *   category: string|null,
+     *   registry_source: string|null,
+     *   scope: string|null,
+     *   policy_reference: string|null
+     * }
+     */
     private function result(
         string $classification,
         string $action,
@@ -186,6 +217,88 @@ class ExternalReferencePolicy
             : ($property->exists ? $property->conversionSurfaces()->get() : collect());
 
         return $surfaces->contains(fn (WebPropertyConversionSurface $surface): bool => $this->normalizedHost($surface->hostname) === $host);
+    }
+
+    private function isAcceptedAppHandoffUrl(mixed $url, ?string $sourceHost, ?WebProperty $property): bool
+    {
+        if (! is_string($url) || trim($url) === '') {
+            return false;
+        }
+
+        $parts = parse_url(trim($url));
+        if (! is_array($parts)) {
+            return false;
+        }
+
+        $host = $this->normalizedHost($parts['host'] ?? null);
+        if ($host === null) {
+            return false;
+        }
+
+        $path = '/'.ltrim((string) ($parts['path'] ?? '/'), '/');
+        if (! $this->isAcceptedAppHandoffPath($path)) {
+            return false;
+        }
+
+        $normalizedSourceHost = $this->normalizedHost($sourceHost);
+        if ($normalizedSourceHost !== null && $host === 'quoting.'.$normalizedSourceHost) {
+            return true;
+        }
+
+        if (! $property instanceof WebProperty) {
+            return false;
+        }
+
+        $configuredHosts = $this->configuredOperationalHosts($property);
+        if (in_array($host, $configuredHosts, true)) {
+            return true;
+        }
+
+        $surfaces = $property->relationLoaded('conversionSurfaces')
+            ? $property->conversionSurfaces
+            : ($property->exists ? $property->conversionSurfaces()->get() : collect());
+
+        return $surfaces->contains(fn (WebPropertyConversionSurface $surface): bool => $this->normalizedHost($surface->hostname) === $host);
+    }
+
+    private function isAcceptedAppHandoffPath(string $path): bool
+    {
+        $normalizedPath = '/'.ltrim(Str::lower($path), '/');
+
+        return Str::startsWith($normalizedPath, [
+            '/booking',
+            '/bookings',
+            '/contact',
+            '/quote',
+            '/customer',
+            '/login',
+            '/portal',
+        ]);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function configuredOperationalHosts(WebProperty $property): array
+    {
+        return collect([
+            $this->hostFromUrl($property->current_household_quote_url),
+            $this->hostFromUrl($property->current_household_booking_url),
+            $this->hostFromUrl($property->current_vehicle_quote_url),
+            $this->hostFromUrl($property->current_vehicle_booking_url),
+            $this->hostFromUrl($property->target_household_quote_url),
+            $this->hostFromUrl($property->target_household_booking_url),
+            $this->hostFromUrl($property->target_vehicle_quote_url),
+            $this->hostFromUrl($property->target_vehicle_booking_url),
+            $this->hostFromUrl($property->target_moveroo_subdomain_url),
+            $this->hostFromUrl($property->target_contact_us_page_url),
+            $this->hostFromUrl($property->target_legacy_bookings_replacement_url),
+            $this->hostFromUrl($property->target_legacy_payments_replacement_url),
+        ])
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 
     private function isOwnedEstateHost(string $host): bool

--- a/app/Services/PropertySiteSignalScanner.php
+++ b/app/Services/PropertySiteSignalScanner.php
@@ -561,6 +561,14 @@ class PropertySiteSignalScanner
         $brokenLinksCount = is_numeric($payload['broken_links_count'] ?? null)
             ? (int) $payload['broken_links_count']
             : count($brokenLinks);
+        $classifiedBrokenLinks = $this->classifiedBrokenLinks($brokenLinks, $primaryDomain->domain, $property);
+        $actionableBrokenLinks = $classifiedBrokenLinks
+            ->reject(fn (array $link): bool => (bool) ($link['suppressed'] ?? false))
+            ->values();
+        $suppressedBrokenLinks = $classifiedBrokenLinks
+            ->filter(fn (array $link): bool => (bool) ($link['suppressed'] ?? false))
+            ->values();
+        $actionableBrokenLinksCount = $actionableBrokenLinks->count();
         $pagesScanned = is_numeric($payload['pages_scanned'] ?? null)
             ? (int) $payload['pages_scanned']
             : 0;
@@ -580,29 +588,48 @@ class PropertySiteSignalScanner
             ];
         }
 
-        if ($brokenLinksCount === 0) {
+        if (($brokenLinksCount === 0 && $classifiedBrokenLinks->isEmpty()) || $actionableBrokenLinksCount === 0) {
+            $verdict = $suppressedBrokenLinks->isNotEmpty()
+                ? 'broken_links_clear_with_accepted_handoffs'
+                : 'broken_links_clear';
+
             return [
                 'status' => 'ok',
-                'verdict' => 'broken_links_clear',
+                'verdict' => $verdict,
                 'summary' => 'Deep audit crawl did not find broken links.',
                 'evidence' => [
-                    'verdict' => 'broken_links_clear',
+                    'verdict' => $verdict,
                     'pages_scanned' => $pagesScanned,
                     'broken_links_count' => 0,
                     'broken_links' => [],
+                    'suppressed_links_count' => $suppressedBrokenLinks->count(),
+                    'suppressed_links' => $suppressedBrokenLinks->all(),
                 ],
             ];
         }
 
+        $acceptedHandoffFailures = $actionableBrokenLinks
+            ->filter(fn (array $link): bool => ($link['classification'] ?? null) === 'accepted_app_handoff')
+            ->values();
+        $verdict = $acceptedHandoffFailures->isNotEmpty()
+            ? 'accepted_app_handoff_failed'
+            : 'broken_links_detected';
+        $summary = $acceptedHandoffFailures->isNotEmpty()
+            ? sprintf('Deep audit crawl found %d failed accepted app handoff link(s).', $acceptedHandoffFailures->count())
+            : sprintf('Deep audit crawl found %d broken link(s).', $actionableBrokenLinksCount);
+
         return [
             'status' => 'fail',
-            'verdict' => 'broken_links_detected',
-            'summary' => sprintf('Deep audit crawl found %d broken link(s).', $brokenLinksCount),
+            'verdict' => $verdict,
+            'summary' => $summary,
             'evidence' => [
-                'verdict' => 'broken_links_detected',
+                'verdict' => $verdict,
                 'pages_scanned' => $pagesScanned,
-                'broken_links_count' => $brokenLinksCount,
-                'broken_links' => $brokenLinks,
+                'broken_links_count' => $actionableBrokenLinksCount,
+                'raw_broken_links_count' => $brokenLinksCount,
+                'broken_links' => $actionableBrokenLinks->all(),
+                'suppressed_links_count' => $suppressedBrokenLinks->count(),
+                'suppressed_links' => $suppressedBrokenLinks->all(),
             ],
         ];
     }
@@ -665,8 +692,8 @@ class PropertySiteSignalScanner
                     ->filter(fn (mixed $page): bool => is_string($page) && $page !== '')
                     ->values()
                     ->all();
-                $policy = app(ExternalReferencePolicy::class)->classify(
-                    is_string($item['host'] ?? null) ? $item['host'] : null,
+                $policy = app(ExternalReferencePolicy::class)->classifyUrl(
+                    is_string($item['url'] ?? null) ? $item['url'] : null,
                     $primaryDomain->domain,
                     $property
                 );
@@ -790,6 +817,38 @@ class PropertySiteSignalScanner
         }
 
         return $counts;
+    }
+
+    /**
+     * @param  array<int, mixed>  $brokenLinks
+     * @return Collection<int, non-empty-array<string, mixed>>
+     */
+    private function classifiedBrokenLinks(array $brokenLinks, string $sourceHost, WebProperty $property): Collection
+    {
+        return collect($brokenLinks)
+            ->filter(fn (mixed $item): bool => is_array($item))
+            ->map(function (array $item) use ($sourceHost, $property): array {
+                $url = is_string($item['url'] ?? null) ? $item['url'] : null;
+                $policy = app(ExternalReferencePolicy::class)->classifyUrl($url, $sourceHost, $property);
+                $status = is_numeric($item['status'] ?? null) ? (int) $item['status'] : null;
+                $isReachable = $status !== null && $status < 400;
+                $isAcceptedHandoff = $policy['classification'] === 'accepted_app_handoff';
+
+                /** @var non-empty-array<string, mixed> $classified */
+                $classified = array_merge($item, [
+                    'classification' => $policy['classification'],
+                    'policy_action' => $policy['action'],
+                    'policy_approved' => $policy['approved'],
+                    'policy_reason' => $policy['reason'],
+                    'suppressed' => $isAcceptedHandoff && $isReachable,
+                    'suppression_reason' => $isAcceptedHandoff && $isReachable
+                        ? 'Accepted app handoff URL was reachable during crawl.'
+                        : null,
+                ]);
+
+                return $classified;
+            })
+            ->values();
     }
 
     /**

--- a/app/Services/WebPropertyMonitoringSummaryBuilder.php
+++ b/app/Services/WebPropertyMonitoringSummaryBuilder.php
@@ -62,6 +62,7 @@ class WebPropertyMonitoringSummaryBuilder
             'open_findings' => $openFindings
                 ->map(fn (MonitoringFinding $finding): array => [
                     'issue_id' => $finding->issue_id,
+                    'finding_identity' => $this->findingIdentity($finding, $property),
                     'issue_class' => $finding->finding_type,
                     'severity' => $this->severityFor($finding),
                     'lane' => $finding->lane,
@@ -71,6 +72,8 @@ class WebPropertyMonitoringSummaryBuilder
                     'status' => $finding->status,
                     'detected_at' => $finding->last_detected_at?->toIso8601String(),
                     'domain' => $finding->domain instanceof Domain ? $finding->domain->domain : null,
+                    'actionable_evidence' => $this->actionableEvidence($finding),
+                    'owner_issue_linkage' => $this->ownerIssueLinkage($finding, $property),
                 ])
                 ->values()
                 ->all(),
@@ -119,5 +122,258 @@ class WebPropertyMonitoringSummaryBuilder
         $domain = $finding->domain;
 
         return $domain instanceof Domain && $domain->isParkedForHosting();
+    }
+
+    /**
+     * @return array{
+     *   issue_id: string,
+     *   fingerprint: string,
+     *   issue_class: string,
+     *   lane: string,
+     *   property_slug: string,
+     *   domain: string|null
+     * }
+     */
+    private function findingIdentity(MonitoringFinding $finding, WebProperty $property): array
+    {
+        return [
+            'issue_id' => $finding->issue_id,
+            'fingerprint' => $this->findingFingerprint($finding, $property),
+            'issue_class' => $finding->finding_type,
+            'lane' => $finding->lane,
+            'property_slug' => $property->slug,
+            'domain' => $finding->domain instanceof Domain ? $finding->domain->domain : null,
+        ];
+    }
+
+    private function findingFingerprint(MonitoringFinding $finding, WebProperty $property): string
+    {
+        return 'domain_monitor.finding:'.hash('sha256', implode('|', [
+            $property->slug,
+            $finding->domain_id ?? '',
+            $finding->finding_type,
+            $finding->lane,
+        ]));
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function actionableEvidence(MonitoringFinding $finding): ?array
+    {
+        if (! str_contains($finding->finding_type, 'broken_links')) {
+            return null;
+        }
+
+        $evidence = is_array($finding->evidence) ? $finding->evidence : [];
+        $brokenLinks = collect(is_array($evidence['broken_links'] ?? null) ? $evidence['broken_links'] : [])
+            ->filter(fn (mixed $link): bool => is_array($link))
+            ->values();
+        $suppressedLinks = collect(is_array($evidence['suppressed_links'] ?? null) ? $evidence['suppressed_links'] : [])
+            ->filter(fn (mixed $link): bool => is_array($link))
+            ->values();
+        $sampleLimit = 5;
+        $totalCount = is_numeric($evidence['broken_links_count'] ?? null)
+            ? (int) $evidence['broken_links_count']
+            : $brokenLinks->count();
+
+        return [
+            'type' => 'broken_links',
+            'crawl_mode' => $finding->lane,
+            'captured_at' => $this->stringOrNull($evidence['captured_at'] ?? null) ?? $finding->last_detected_at?->toIso8601String(),
+            'detected_at' => $finding->last_detected_at?->toIso8601String(),
+            'total_count' => $totalCount,
+            'sample_limit' => $sampleLimit,
+            'truncated' => $brokenLinks->count() > $sampleLimit || $totalCount > $sampleLimit,
+            'links' => $brokenLinks
+                ->take($sampleLimit)
+                ->map(fn (array $link): array => $this->safeBrokenLinkEvidence($link, $finding))
+                ->values()
+                ->all(),
+            'suppressed_links_count' => is_numeric($evidence['suppressed_links_count'] ?? null)
+                ? (int) $evidence['suppressed_links_count']
+                : $suppressedLinks->count(),
+            'suppressed_links' => $suppressedLinks
+                ->take($sampleLimit)
+                ->map(fn (array $link): array => $this->safeBrokenLinkEvidence($link, $finding))
+                ->values()
+                ->all(),
+            'truncation_note' => $brokenLinks->count() > $sampleLimit || $totalCount > $sampleLimit
+                ? sprintf('Showing first %d broken-link evidence item(s); fetch the source Domain Monitor record for full protected crawl evidence.', $sampleLimit)
+                : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $link
+     * @return array<string, mixed>
+     */
+    private function safeBrokenLinkEvidence(array $link, MonitoringFinding $finding): array
+    {
+        $linkHref = $this->stringOrNull($link['url'] ?? null) ?? $this->stringOrNull($link['href'] ?? null);
+
+        return [
+            'source_page_url' => $this->stringOrNull($link['found_on'] ?? null)
+                ?? $this->stringOrNull($link['source_page_url'] ?? null),
+            'link_href' => $linkHref,
+            'final_url' => $this->stringOrNull($link['final_url'] ?? null)
+                ?? $this->stringOrNull($link['resolved_url'] ?? null)
+                ?? $linkHref,
+            'http_status' => is_numeric($link['status'] ?? null) ? (int) $link['status'] : null,
+            'failure_reason' => $this->stringOrNull($link['failure_reason'] ?? null)
+                ?? $this->stringOrNull($link['error'] ?? null)
+                ?? $this->stringOrNull($link['error_message'] ?? null),
+            'relationship' => $this->stringOrNull($link['relationship'] ?? null),
+            'classification' => $this->stringOrNull($link['classification'] ?? null)
+                ?? $this->stringOrNull($link['policy_classification'] ?? null)
+                ?? 'unclassified',
+            'policy_reason' => $this->stringOrNull($link['policy_reason'] ?? null),
+            'suppressed' => (bool) ($link['suppressed'] ?? false),
+            'suppression_reason' => $this->stringOrNull($link['suppression_reason'] ?? null),
+            'crawl_lane' => $finding->lane,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function ownerIssueLinkage(MonitoringFinding $finding, WebProperty $property): array
+    {
+        $evidence = is_array($finding->evidence) ? $finding->evidence : [];
+        $candidates = $this->ownerIssueCandidates($evidence);
+
+        if ($candidates === []) {
+            return [
+                'state' => 'current_owner_issue_missing',
+                'active_owner_issue' => null,
+                'related_owner_issues' => [],
+                'finding_identity' => $this->findingIdentity($finding, $property),
+            ];
+        }
+
+        $matching = collect($candidates)
+            ->filter(fn (array $candidate): bool => $this->ownerIssueMatchesFinding($candidate, $finding, $property))
+            ->values();
+        $active = $matching
+            ->first(fn (array $candidate): bool => ! $this->ownerIssueIsClosed($candidate));
+
+        if (is_array($active)) {
+            return [
+                'state' => 'active_owner_issue_current',
+                'active_owner_issue' => $this->safeOwnerIssue($active),
+                'related_owner_issues' => collect($candidates)
+                    ->reject(fn (array $candidate): bool => $candidate === $active)
+                    ->map(fn (array $candidate): array => $this->safeOwnerIssue($candidate))
+                    ->values()
+                    ->all(),
+                'finding_identity' => $this->findingIdentity($finding, $property),
+            ];
+        }
+
+        return [
+            'state' => $matching->isNotEmpty() ? 'current_owner_issue_closed' : 'stale_or_different_finding_owner_issue',
+            'active_owner_issue' => null,
+            'related_owner_issues' => collect($candidates)
+                ->map(fn (array $candidate): array => $this->safeOwnerIssue($candidate))
+                ->values()
+                ->all(),
+            'finding_identity' => $this->findingIdentity($finding, $property),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $evidence
+     * @return array<int, array<string, mixed>>
+     */
+    private function ownerIssueCandidates(array $evidence): array
+    {
+        $candidates = [];
+
+        foreach (['owner_issue', 'owner_issue_candidate'] as $key) {
+            if (is_array($evidence[$key] ?? null)) {
+                $candidates[] = $evidence[$key];
+            }
+        }
+
+        if (is_array($evidence['owner_issues'] ?? null)) {
+            foreach ($evidence['owner_issues'] as $candidate) {
+                if (is_array($candidate)) {
+                    $candidates[] = $candidate;
+                }
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function ownerIssueMatchesFinding(array $candidate, MonitoringFinding $finding, WebProperty $property): bool
+    {
+        $candidateIssueClass = $this->stringOrNull($candidate['issue_class'] ?? null)
+            ?? $this->stringOrNull($candidate['finding_type'] ?? null);
+        $candidateIssueId = $this->stringOrNull($candidate['issue_id'] ?? null);
+        $candidateFingerprint = $this->stringOrNull($candidate['finding_fingerprint'] ?? null)
+            ?? $this->stringOrNull($candidate['fingerprint'] ?? null);
+
+        if ($candidateIssueClass !== null && $candidateIssueClass !== $finding->finding_type) {
+            return false;
+        }
+
+        if ($candidateIssueId !== null && $candidateIssueId !== $finding->issue_id) {
+            return false;
+        }
+
+        if ($candidateFingerprint !== null && $candidateFingerprint !== $this->findingFingerprint($finding, $property)) {
+            return false;
+        }
+
+        return $candidateIssueClass !== null || $candidateIssueId !== null || $candidateFingerprint !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     */
+    private function ownerIssueIsClosed(array $candidate): bool
+    {
+        $state = strtolower((string) ($candidate['state'] ?? $candidate['status'] ?? ''));
+
+        return in_array($state, ['closed', 'done', 'resolved'], true);
+    }
+
+    /**
+     * @param  array<string, mixed>  $candidate
+     * @return array<string, mixed>
+     */
+    private function safeOwnerIssue(array $candidate): array
+    {
+        return [
+            'url' => $this->stringOrNull($candidate['url'] ?? null)
+                ?? $this->stringOrNull($candidate['html_url'] ?? null)
+                ?? $this->stringOrNull($candidate['owner_issue_url'] ?? null),
+            'repo' => $this->stringOrNull($candidate['repo'] ?? null)
+                ?? $this->stringOrNull($candidate['repository'] ?? null),
+            'number' => is_numeric($candidate['number'] ?? null) ? (int) $candidate['number'] : null,
+            'state' => $this->stringOrNull($candidate['state'] ?? null)
+                ?? $this->stringOrNull($candidate['status'] ?? null),
+            'issue_class' => $this->stringOrNull($candidate['issue_class'] ?? null)
+                ?? $this->stringOrNull($candidate['finding_type'] ?? null),
+            'issue_id' => $this->stringOrNull($candidate['issue_id'] ?? null),
+            'finding_fingerprint' => $this->stringOrNull($candidate['finding_fingerprint'] ?? null)
+                ?? $this->stringOrNull($candidate['fingerprint'] ?? null),
+            'relationship' => $this->stringOrNull($candidate['relationship'] ?? null) ?? 'related',
+        ];
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 }

--- a/docs/DOMAIN-MONITOR-API-INTEGRATION.md
+++ b/docs/DOMAIN-MONITOR-API-INTEGRATION.md
@@ -127,6 +127,62 @@ missing or drifted SPF, DKIM, DMARC, MX, return-path, bounce, or provider
 verification records. See `docs/MAIL-PLANE-DNS-TRACKING.md` for the full
 record shape and boundaries.
 
+`monitoring_summary.open_findings[]` is the Control-facing safe finding packet
+for current Domain Monitor source truth. Existing summary fields remain stable;
+new consumers may also use:
+
+- `finding_identity.issue_id`
+- `finding_identity.fingerprint`
+- `finding_identity.issue_class`
+- `finding_identity.lane`
+- `actionable_evidence`
+- `owner_issue_linkage`
+
+For `seo.broken_links` and related broken-link findings,
+`actionable_evidence` is bounded and intentionally safe for authenticated
+operator display. It includes:
+
+- `type: broken_links`
+- `crawl_mode`
+- `captured_at`
+- `detected_at`
+- `total_count`
+- `sample_limit`
+- `truncated`
+- `truncation_note`
+- `links[]`
+- `suppressed_links[]`
+
+Each exported link sample includes:
+
+- `source_page_url`
+- `link_href`
+- `final_url`
+- `http_status`
+- `failure_reason`
+- `relationship`
+- `classification`
+- `policy_reason`
+- `suppressed`
+- `suppression_reason`
+- `crawl_lane`
+
+This packet must not include raw crawler HTML, cookies, secrets, or unbounded
+crawl dumps. If `truncated` is true, Control should show the sample and route
+operators back to Domain Monitor for protected full evidence if needed.
+
+`owner_issue_linkage` tells consumers whether an owner issue is current for the
+specific finding identity. States include:
+
+- `current_owner_issue_missing`
+- `active_owner_issue_current`
+- `current_owner_issue_closed`
+- `stale_or_different_finding_owner_issue`
+
+Closed or mismatched owner issues are exported only as `related_owner_issues`,
+not as `active_owner_issue`, so Control can avoid reusing a closed issue from a
+different issue class as the current remediation owner.
+
 `hostname_link_policy` is the canonical hostname-level export for quote,
 booking, contact, and customer-portal link expectations. It is derived from the
 stored property targets plus known conversion surfaces, and uses per-slot

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -1221,6 +1221,199 @@ class RunMonitoringLaneCommandTest extends TestCase
         $this->assertSame(2, data_get($brokenLinksIssue, 'evidence.broken_links_count'));
     }
 
+    public function test_deep_audit_lane_suppresses_reachable_accepted_quote_handoffs(): void
+    {
+        $property = $this->makeProperty('backloading-au.com.au', 'Backloading AU');
+        $property->forceFill([
+            'target_household_quote_url' => 'https://quoting.backloading-au.com.au/quote/household',
+            'target_household_booking_url' => 'https://quoting.backloading-au.com.au/booking/create',
+            'target_vehicle_quote_url' => 'https://quoting.backloading-au.com.au/quote/vehicle',
+            'target_contact_us_page_url' => 'https://quoting.backloading-au.com.au/contact',
+        ])->save();
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksExpectation */
+        $brokenLinksExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'broken_links_count' => 1,
+            'pages_scanned' => 4,
+            'broken_links' => [
+                [
+                    'url' => 'https://quoting.backloading-au.com.au/quote/household',
+                    'status' => 200,
+                    'relationship' => 'external',
+                    'found_on' => 'https://backloading-au.com.au/',
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 1,
+                'pages_scanned' => 4,
+                'broken_links' => [
+                    [
+                        'url' => 'https://quoting.backloading-au.com.au/quote/household',
+                        'status' => 200,
+                        'relationship' => 'external',
+                        'found_on' => 'https://backloading-au.com.au/',
+                    ],
+                ],
+                'duration_ms' => 11,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $externalLinksExpectation */
+        $externalLinksExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $externalLinksExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 1,
+            'pages_scanned' => 4,
+            'external_links' => [
+                [
+                    'url' => 'https://quoting.backloading-au.com.au/quote/household',
+                    'host' => 'quoting.backloading-au.com.au',
+                    'relationship' => 'external',
+                    'found_on' => 'https://backloading-au.com.au/',
+                    'found_on_pages' => ['https://backloading-au.com.au/'],
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 4,
+                'external_links_count' => 1,
+                'unique_hosts_count' => 1,
+                'page_failures_count' => 0,
+                'external_links' => [
+                    [
+                        'url' => 'https://quoting.backloading-au.com.au/quote/household',
+                        'host' => 'quoting.backloading-au.com.au',
+                        'relationship' => 'external',
+                        'found_on' => 'https://backloading-au.com.au/',
+                        'found_on_pages' => ['https://backloading-au.com.au/'],
+                    ],
+                ],
+                'duration_ms' => 12,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseMissing('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'seo.broken_links',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+        $this->assertDatabaseMissing('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'cleanup.external_links_inventory',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+    }
+
+    public function test_deep_audit_lane_keeps_unreachable_accepted_quote_handoffs_actionable(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+
+        $property = $this->makeProperty('backloading-au.com.au', 'Backloading AU');
+
+        $brokenLinkHealthCheck = Mockery::mock(BrokenLinkHealthCheck::class);
+        /** @var Mockery\Expectation $brokenLinksExpectation */
+        $brokenLinksExpectation = $brokenLinkHealthCheck->shouldReceive('check');
+        $brokenLinksExpectation->once()->andReturn([
+            'is_valid' => false,
+            'verified' => true,
+            'broken_links_count' => 1,
+            'pages_scanned' => 4,
+            'broken_links' => [
+                [
+                    'url' => 'https://quoting.backloading-au.com.au/booking/create',
+                    'status' => 503,
+                    'relationship' => 'external',
+                    'found_on' => 'https://backloading-au.com.au/',
+                ],
+            ],
+            'error_message' => null,
+            'payload' => [
+                'broken_links_count' => 1,
+                'pages_scanned' => 4,
+                'broken_links' => [
+                    [
+                        'url' => 'https://quoting.backloading-au.com.au/booking/create',
+                        'status' => 503,
+                        'relationship' => 'external',
+                        'found_on' => 'https://backloading-au.com.au/',
+                    ],
+                ],
+                'duration_ms' => 11,
+            ],
+        ]);
+        $this->instance(BrokenLinkHealthCheck::class, $brokenLinkHealthCheck);
+
+        $externalLinkInventoryHealthCheck = Mockery::mock(ExternalLinkInventoryHealthCheck::class);
+        /** @var Mockery\Expectation $externalLinksClearExpectation */
+        $externalLinksClearExpectation = $externalLinkInventoryHealthCheck->shouldReceive('check');
+        $externalLinksClearExpectation->once()->andReturn([
+            'is_valid' => true,
+            'verified' => true,
+            'external_links_count' => 0,
+            'pages_scanned' => 4,
+            'external_links' => [],
+            'error_message' => null,
+            'payload' => [
+                'pages_scanned' => 4,
+                'external_links_count' => 0,
+                'unique_hosts_count' => 0,
+                'page_failures_count' => 0,
+                'external_links' => [],
+                'duration_ms' => 12,
+            ],
+        ]);
+        $this->instance(ExternalLinkInventoryHealthCheck::class, $externalLinkInventoryHealthCheck);
+        app()->forgetInstance(\App\Services\DomainHealthCheckRunner::class);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $deepAuditExpectation */
+        $deepAuditExpectation = $brain->shouldReceive('sendAsync');
+        $deepAuditExpectation->once()->withArgs(function (string $eventType, array $payload): bool {
+            $this->assertSame('domain_monitor.finding.opened', $eventType);
+            $this->assertSame('seo.broken_links', $payload['finding_type']);
+            $this->assertSame('accepted_app_handoff_failed', data_get($payload, 'evidence.verdict'));
+            $this->assertSame('accepted_app_handoff', data_get($payload, 'evidence.broken_links.0.classification'));
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'deep_audit',
+            '--property' => $property->slug,
+        ]));
+
+        $this->assertDatabaseHas('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'seo.broken_links',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $finding = MonitoringFinding::query()
+            ->where('web_property_id', $property->id)
+            ->where('finding_type', 'seo.broken_links')
+            ->firstOrFail();
+
+        $this->assertSame('accepted_app_handoff_failed', data_get($finding->evidence, 'verdict'));
+        $this->assertSame('accepted_app_handoff', data_get($finding->evidence, 'broken_links.0.classification'));
+    }
+
     public function test_deep_audit_lane_opens_external_link_inventory_findings_for_off_host_links(): void
     {
         config()->set('services.brain.base_url', 'https://brain.example.test');

--- a/tests/Feature/WebPropertyApiTest.php
+++ b/tests/Feature/WebPropertyApiTest.php
@@ -577,6 +577,97 @@ class WebPropertyApiTest extends TestCase
         $this->assertSame('suppressed', data_get($bookingPolicy, 'expected_links.household_quote.status'));
     }
 
+    public function test_monitoring_summary_exports_bounded_broken_link_evidence_and_owner_linkage(): void
+    {
+        config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
+
+        $domain = Domain::factory()->create([
+            'domain' => 'backloading-au.com.au',
+            'platform' => 'Astro',
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => 'backloading-au-com-au',
+            'name' => 'Backloading AU',
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://backloading-au.com.au',
+        ]);
+
+        WebPropertyDomain::create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        $links = collect(range(1, 6))
+            ->map(fn (int $index): array => [
+                'url' => 'https://backloading-au.com.au/missing-'.$index,
+                'status' => 404,
+                'relationship' => 'internal',
+                'found_on' => 'https://backloading-au.com.au/services/',
+                'classification' => 'internal',
+            ])
+            ->all();
+
+        $finding = MonitoringFinding::factory()->create([
+            'issue_id' => 'dm:backloading-au-com-au:seo-broken-links',
+            'lane' => 'deep_audit',
+            'finding_type' => 'seo.broken_links',
+            'issue_type' => 'cleanup',
+            'scope_type' => 'web_property',
+            'domain_id' => $domain->id,
+            'web_property_id' => $property->id,
+            'status' => MonitoringFinding::STATUS_OPEN,
+            'title' => 'Broken links found during deep audit crawl',
+            'summary' => 'Deep audit crawl found 6 broken link(s).',
+            'last_detected_at' => Carbon::parse('2026-05-20T10:15:00+10:00'),
+            'evidence' => [
+                'verdict' => 'broken_links_detected',
+                'pages_scanned' => 3,
+                'broken_links_count' => 6,
+                'broken_links' => $links,
+                'owner_issue' => [
+                    'url' => 'https://github.com/iamjasonhill/MM-fleet-program/issues/44',
+                    'repo' => 'iamjasonhill/MM-fleet-program',
+                    'number' => 44,
+                    'state' => 'closed',
+                    'issue_class' => 'cleanup.external_links_inventory',
+                ],
+            ],
+        ]);
+
+        $summaryResponse = $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties-summary')
+            ->assertOk()
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.issue_id', $finding->issue_id)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.finding_identity.issue_class', 'seo.broken_links')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.type', 'broken_links')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.total_count', 6)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.truncated', true)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.links.0.source_page_url', 'https://backloading-au.com.au/services/')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.links.0.link_href', 'https://backloading-au.com.au/missing-1')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.links.0.http_status', 404)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.links.0.classification', 'internal')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.owner_issue_linkage.state', 'stale_or_different_finding_owner_issue')
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.owner_issue_linkage.active_owner_issue', null)
+            ->assertJsonPath('web_properties.0.monitoring_summary.open_findings.0.owner_issue_linkage.related_owner_issues.0.number', 44);
+
+        $this->assertCount(
+            5,
+            $summaryResponse->json('web_properties.0.monitoring_summary.open_findings.0.actionable_evidence.links')
+        );
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer test-api-key',
+        ])->getJson('/api/web-properties/'.$property->slug)
+            ->assertOk()
+            ->assertJsonPath('data.monitoring_summary.open_findings.0.actionable_evidence.links.0.final_url', 'https://backloading-au.com.au/missing-1')
+            ->assertJsonPath('data.monitoring_summary.open_findings.0.owner_issue_linkage.state', 'stale_or_different_finding_owner_issue');
+    }
+
     public function test_web_properties_summary_represents_operational_app_shell_apex_without_marketing_handoffs(): void
     {
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
@@ -1253,7 +1344,7 @@ class WebPropertyApiTest extends TestCase
             'last_detected_at' => $detectedAt,
         ]);
 
-        $expected = $detectedAt->toIso8601String();
+        $expected = Carbon::parse($detectedAt->format('Y-m-d H:i:s'), 'Australia/Brisbane')->toIso8601String();
 
         $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
             ->getJson('/api/web-properties-summary')
@@ -1315,7 +1406,7 @@ class WebPropertyApiTest extends TestCase
             ]);
         });
 
-        $expected = $finishedAt->toIso8601String();
+        $expected = Carbon::parse($finishedAt->format('Y-m-d H:i:s'), 'Australia/Brisbane')->toIso8601String();
 
         $this->withHeaders(['Authorization' => 'Bearer test-api-key'])
             ->getJson('/api/web-properties-summary')


### PR DESCRIPTION
## Summary
- expose bounded actionable broken-link evidence and stable finding identity in web property summaries
- classify accepted quote/app handoff URLs before broken-link and external-link findings become actionable
- export owner issue linkage state so stale closed issues are related, not active owners for different findings
- document the Control-facing monitoring summary evidence contract

## Issues
Closes #232
Closes #233
Closes #234

## Checks
- vendor/bin/pint --dirty
- ./vendor/bin/phpstan analyse app/Services/PropertySiteSignalScanner.php app/Services/WebPropertyMonitoringSummaryBuilder.php app/Services/ExternalReferencePolicy.php --memory-limit=2G
- php artisan test tests/Feature/WebPropertyApiTest.php tests/Feature/RunMonitoringLaneCommandTest.php
- php artisan test (fails on unrelated existing local command-wrapper path-with-spaces tests and unrelated timestamp expectation tests: CommandFleetTechnicalSeoBrowserRendererTest, CommandFleetTechnicalSeoLighthouseRunnerTest, WebPropertyPlatformMigrationSummaryBuilderTest, SyncMmGoogleGa4CommandTest, WebPropertyAstroCutoverApiTest)