### PR TITLE
Add Fleet SEO audit profiles and freshness rotation

### DIFF
--- a/app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php
+++ b/app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php
@@ -10,11 +10,26 @@ use Illuminate\Support\Collection;
 
 class RunFleetTechnicalSeoEstateAuditCommand extends Command
 {
+    private const PROFILE_SMOKE = 'fleet_technical_seo_smoke';
+
+    private const PROFILE_DEEP = 'fleet_technical_seo_deep';
+
+    private const DEFAULT_URL_CAP = 25;
+
+    /**
+     * @var array<string, int>
+     */
+    private const PROFILE_URL_CAPS = [
+        self::PROFILE_SMOKE => 3,
+        self::PROFILE_DEEP => 25,
+    ];
+
     protected $signature = 'monitoring:run-fleet-technical-seo-estate-audit
+                            {--profile= : Optional scheduled audit profile: fleet_technical_seo_smoke or fleet_technical_seo_deep}
                             {--property=* : Web property slug(s) to include}
                             {--domain=* : Domain selector(s) to resolve to web properties}
                             {--limit=5 : Conservative maximum number of eligible properties to audit}
-                            {--url-cap=25 : Maximum URLs to include in each bounded per-property audit}
+                            {--url-cap= : Maximum URLs to include in each bounded per-property audit}
                             {--dry-run : List selected properties without creating audit runs}
                             {--continue-on-failure : Continue auditing remaining properties after one property fails}';
 
@@ -22,11 +37,19 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
 
     public function handle(FleetTechnicalSeoAuditRunner $runner): int
     {
+        try {
+            $profile = $this->profile();
+        } catch (\InvalidArgumentException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
         $limit = max(1, (int) $this->option('limit'));
-        $urlCap = max(1, (int) $this->option('url-cap'));
+        $urlCap = $this->urlCap($profile);
         $dryRun = (bool) $this->option('dry-run');
         $continueOnFailure = (bool) $this->option('continue-on-failure');
-        $properties = $this->selectedProperties($limit);
+        $properties = $this->selectedProperties($limit, $profile);
 
         if ($properties->isEmpty()) {
             $this->warn('No eligible web properties matched the Fleet technical SEO estate audit scope.');
@@ -35,14 +58,21 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
         }
 
         $this->info(sprintf(
-            'Selected %d eligible web %s for Fleet technical SEO estate audit.',
+            'Selected %d eligible web %s for Fleet technical SEO estate audit%s.',
             $properties->count(),
-            $properties->count() === 1 ? 'property' : 'properties'
+            $properties->count() === 1 ? 'property' : 'properties',
+            $profile !== null ? ' profile ['.$profile.']' : ''
         ));
 
         if ($dryRun) {
             foreach ($properties as $property) {
-                $this->line(sprintf('[dry-run] %s (%s)', $property->slug, $property->primaryDomainName() ?? 'no-domain'));
+                $this->line(sprintf(
+                    '[dry-run] %s (%s) profile=%s url_cap=%d',
+                    $property->slug,
+                    $property->primaryDomainName() ?? 'no-domain',
+                    $profile ?? 'operator_requested_estate',
+                    $urlCap
+                ));
             }
 
             return self::SUCCESS;
@@ -54,7 +84,7 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
             $this->line(sprintf('Running Fleet technical SEO audit for [%s]...', $property->slug));
 
             try {
-                $run = $runner->run($property, $urlCap, 'operator_requested_estate');
+                $run = $runner->run($property, $urlCap, $profile ?? 'operator_requested_estate');
                 $counts = $run->summary_counts ?? [];
 
                 $this->info(sprintf(
@@ -92,14 +122,23 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
     /**
      * @return Collection<int, WebProperty>
      */
-    private function selectedProperties(int $limit): Collection
+    private function selectedProperties(int $limit, ?string $profile): Collection
     {
         $propertyOptions = $this->optionStrings('property');
         $domainOptions = $this->optionStrings('domain');
+        $usesExplicitSelectors = $propertyOptions !== [] || $domainOptions !== [];
 
         /** @var Collection<int, WebProperty> $properties */
         $properties = WebProperty::query()
-            ->with(['primaryDomain', 'primaryDomain.tags', 'propertyDomains.domain', 'conversionSurfaces'])
+            ->with([
+                'primaryDomain',
+                'primaryDomain.tags',
+                'propertyDomains.domain',
+                'conversionSurfaces',
+                'fleetTechnicalSeoAuditRuns' => fn ($query) => $profile !== null
+                    ? $query->where('trigger_type', $profile)->whereNotNull('finished_at')
+                    : $query,
+            ])
             ->when(
                 $propertyOptions !== [],
                 fn (Builder $query) => $query->whereIn('slug', $propertyOptions)
@@ -121,10 +160,58 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
             ->orderBy('slug')
             ->get()
             ->filter(fn (WebProperty $property): bool => $property->coverageEligibility()['eligible'])
+            ->when(
+                $profile !== null && ! $usesExplicitSelectors,
+                fn (Collection $properties): Collection => $properties
+                    ->sortBy(fn (WebProperty $property): int => $this->profileFreshnessSortValue($property))
+            )
             ->take($limit)
             ->values();
 
         return $properties;
+    }
+
+    private function profile(): ?string
+    {
+        $profile = $this->option('profile');
+
+        if ($profile === null || trim((string) $profile) === '') {
+            return null;
+        }
+
+        $profile = trim((string) $profile);
+        if (! array_key_exists($profile, self::PROFILE_URL_CAPS)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown Fleet technical SEO audit profile [%s]. Expected one of: %s.',
+                $profile,
+                implode(', ', array_keys(self::PROFILE_URL_CAPS))
+            ));
+        }
+
+        return $profile;
+    }
+
+    private function urlCap(?string $profile): int
+    {
+        $option = $this->option('url-cap');
+        if (is_numeric($option)) {
+            return max(1, (int) $option);
+        }
+
+        if ($profile !== null) {
+            return self::PROFILE_URL_CAPS[$profile];
+        }
+
+        return self::DEFAULT_URL_CAP;
+    }
+
+    private function profileFreshnessSortValue(WebProperty $property): int
+    {
+        /** @var \Illuminate\Database\Eloquent\Collection<int, \App\Models\FleetTechnicalSeoAuditRun> $runs */
+        $runs = $property->getRelation('fleetTechnicalSeoAuditRuns');
+        $latestRun = $runs->first();
+
+        return $latestRun?->finished_at?->getTimestamp() ?? 0;
     }
 
     /**

--- a/docs/FLEET-ASTRO-TECHNICAL-SEO-MONITORING-PLAN.md
+++ b/docs/FLEET-ASTRO-TECHNICAL-SEO-MONITORING-PLAN.md
@@ -15,6 +15,11 @@ It should provide the recurring live verification layer that proves whether
 Fleet-managed public sites are still meeting that standard after launch or
 during rollout.
 
+The audit rationalisation goal is to reduce duplicate operator noise and unclear
+ownership first. Runtime load still matters, but the primary design test is
+whether operators can tell which system owns the evidence, which system owns the
+fix, and which findings deserve Control Attention.
+
 ## Upstream Standard Sources
 
 This plan should stay aligned to the existing Fleet-owned documents:
@@ -121,6 +126,16 @@ confidence, weak crawler signals, flaky external dependencies, and ambiguous
 evidence should be stored as audit evidence or `unknown`, not promoted to
 Attention automatically.
 
+Only `MonitoringFinding` records are allowed to create or update Control
+Attention. Health checks, Fleet technical SEO audit runs, and estate audit
+batches are evidence collectors. They may update stored evidence and summaries,
+but they should reach Control only by being promoted into a
+`MonitoringFinding` under explicit promotion rules, normally:
+
+- `result_status = fail`
+- `evidence_confidence = high`
+- a clear owning property, owner system, and remediation route exist
+
 The full runtime audit is a bounded crawl, not a homepage-only check. The
 default URL set for an eligible `WebProperty` should include:
 
@@ -168,11 +183,155 @@ per-property URL cap, include dry-run support, and only use browser/Lighthouse
 evidence when the repo-owned commands are configured. A deliberate full-estate
 mode can come later once runtime duration, evidence quality, and Attention noise
 are trusted.
+
+The scheduled runtime model should use two estate audit cadences:
+
+- a daily low-cap smoke/regression pass over Fleet-focus properties
+- a weekly deeper evidence refresh over the same eligible Fleet-focus scope
+
+Name these scheduled Fleet runtime profiles explicitly:
+
+- `fleet_technical_seo_smoke`: daily, low-cap, freshness-rotated, intended to
+  detect obvious regressions quickly. Initial URL cap: 3.
+- `fleet_technical_seo_deep`: weekly coverage, freshness-rotated and spread
+  across batches, intended to refresh broader crawl/render evidence for every
+  eligible site. Initial URL cap: 25.
+
+The existing `monitoring:run-lane fleet_astro_technical_seo` lane should remain
+in place for the first rationalisation slice, but its domain role is publisher
+or reconciler rather than primary evidence collector. The
+`fleet_technical_seo_smoke` and `fleet_technical_seo_deep` profiles collect
+catalog evidence into audit runs and results. The monitoring lane promotes
+qualified evidence into `MonitoringFinding` records for Control Attention.
+
+Scheduled `fleet_technical_seo_smoke` and `fleet_technical_seo_deep` runs should
+not promote findings directly. They are collectors. Promotion should be deferred
+to the `fleet_astro_technical_seo` monitoring lane, which reads latest
+qualifying evidence and updates `MonitoringFinding` records under the explicit
+promotion rules. This keeps Control Attention deterministic and avoids duplicate
+promotion paths.
+
+Manual or operator-requested Fleet technical SEO runs should collect evidence
+immediately. They should not update Control Attention unless promotion is
+explicitly requested, for example with a `--promote-findings` style option.
+This preserves the fix-verification workflow while keeping scheduled collector
+runs quiet by default.
+
+Every eligible site should be checked for every applicable audit at least once
+per week. Weekly coverage does not require one large sweep: the work may be
+spread across multiple scheduled batches so production load stays predictable.
+The invariant is complete weekly coverage, not a single weekly command
+execution.
+
+Scheduled estate batches should use freshness-aware rotation. Each batch should
+select the most stale eligible `WebProperty` records for the requested audit
+profile, based on latest completed successful audit evidence for that property
+and profile. A scheduler must not repeatedly audit the same first N properties
+by database order while leaving other eligible properties stale.
+
+Use these canonical audit profiles when reasoning about coverage:
+
+- `Domain Health Profile`: DNS, HTTP, SSL, uptime, email security, security
+  headers, SEO fundamentals, broken links, and external links.
+- `Monitoring Lane Profile`: durable finding publisher lanes such as
+  `critical_live`, `marketing_integrity`, `seo_agent_readiness`, and
+  `deep_audit`.
+- `Fleet Technical SEO Runtime Profile`: Fleet catalog checks, rendered/mobile
+  evidence, quote/contact target checks, legacy route stance, and imported
+  MM-Google evidence consumption as used by the runtime catalog.
+- `Imported Evidence Profile`: MM-Google, Search Console, GA4 imports, API
+  enrichment, and live rechecks.
+
+Coverage units differ by profile:
+
+- `Domain Health Profile` is `Domain` scoped.
+- `Monitoring Lane Profile` is `WebProperty` scoped.
+- `Fleet Technical SEO Runtime Profile` is `WebProperty` scoped.
+- `Imported Evidence Profile` is source-entity scoped and mapped back to
+  `WebProperty`, such as a `PropertyAnalyticsSource`, Search Console property,
+  or GA4 binding.
+
+Weekly coverage has two metrics:
+
+- `attempted_coverage`: the scheduler attempted the applicable audit for the
+  unit during the coverage window.
+- `complete_coverage`: the audit reached a usable status during the coverage
+  window.
+
+Statuses that count as complete coverage:
+
+- `pass`
+- `fail`
+- `not_applicable`
+- `manual_review`
+
+Statuses that do not count as complete coverage:
+
+- `unknown`
+- command failure
+- timeout
+- skipped due to crawl or scheduler cap
+
+`unknown` still counts as attempted coverage so the scheduler does not hammer
+the same property repeatedly in a single day. Durable unknowns must not be left
+to circle forever: when an unknown cannot be resolved by retry, fallback
+evidence, or current docs/code, Domain Monitor should create or route a
+deduped GitHub investigation issue.
+
+Route durable unknown investigation issues by source of ambiguity:
+
+- Domain Monitor issue: crawler, audit, evidence extraction, classification, or
+  stored-evidence ambiguity.
+- Fleet issue: missing or unclear Fleet standard, site implementation
+  ambiguity, or site repo evidence needed.
+- MM-Google issue: missing, stale, or inconsistent GA4, Search Console, or
+  Google-side exported evidence.
+- Bossman or Control issue: ownership cannot be determined after Domain Monitor
+  has classified the unknown as an ownership-routing problem.
+
+Each unknown investigation issue should include the audit profile, coverage
+unit, check ID, affected property or domain, latest evidence, retry count, owner
+classification, and dedupe key.
+
+Scheduled audits should not create GitHub issues directly for every unknown.
+They should write an investigation candidate, such as `owner_issue_candidate`,
+with enough evidence and a stable dedupe key. A separate unknown-triage command
+or operator review queue should create GitHub issues only when the unknown is
+still unresolved after a threshold, such as two attempts or 24 hours, and owner
+classification is confident.
+
+When this cadence is first enabled, run the initial weekly deeper pass within
+the next 12 hours so Control and Fleet start from fresh evidence rather than
+waiting for the next normal weekly window.
+
+The initial `fleet_technical_seo_deep` catch-up should run as spread batches,
+not one large sweep. It should use the weekly deep profile, `url-cap=25`,
+continue-on-failure behavior, and evidence-only collection by default. After
+the catch-up batches finish, run the publisher or reconciler lane once so
+Control Attention reflects only qualified findings from the fresh evidence.
+
+Implement this rationalisation in narrow slices. The first implementation slice
+should be the scheduling and rotation foundation:
+
+- add named audit profiles `fleet_technical_seo_smoke` and
+  `fleet_technical_seo_deep`
+- add freshness-aware property selection for scheduled estate batches
+- add evidence-only scheduled collector mode
+- add schedule entries for the collector profiles
+- support the initial catch-up path without automatic promotion
+
+Do not include automatic durable-unknown GitHub issue creation in the first
+slice. Build unknown triage as a later slice after scheduled coverage and
+collector/publisher boundaries are stable.
+
 The repo-owned conservative command is
 `php artisan monitoring:run-fleet-technical-seo-estate-audit`. It defaults to a
-limit of five eligible properties, supports `--dry-run`, `--limit`, `--url-cap`,
-`--property`, `--domain`, and `--continue-on-failure`, and still creates one
-audit run per selected `WebProperty`.
+limit of five eligible properties, supports `--profile`, `--dry-run`,
+`--limit`, `--url-cap`, `--property`, `--domain`, and
+`--continue-on-failure`, and still creates one audit run per selected
+`WebProperty`. When `--profile` is provided, unscoped batches use
+freshness-aware rotation for that profile instead of selecting the first N
+properties by slug.
 
 Only `fail` should open or update a runtime finding for Control Attention by
 default. `unknown` should create an owning-repo GitHub issue when the evidence

--- a/docs/adr/2026-05-20-audit-rationalisation-collector-publisher-coverage.md
+++ b/docs/adr/2026-05-20-audit-rationalisation-collector-publisher-coverage.md
@@ -1,0 +1,88 @@
+# ADR: Audit Rationalisation, Collector/Publisher Boundary, and Weekly Coverage
+
+Date: 2026-05-20
+
+## Status
+
+Accepted
+
+## Context
+
+Domain Monitor has several audit paths that overlap in the operator surface:
+
+- domain health checks
+- monitoring lanes
+- Fleet technical SEO audit runs
+- imported Search Console, GA4, and MM-Google evidence
+
+The richer Fleet technical SEO runtime audit can now detect rendered/mobile,
+quote/contact, legacy route, and imported-evidence issues that older checks did
+not cover. Without a clear model, those audit paths can create duplicate Control
+Attention, unclear ownership, or repeated unknown results that never become
+actionable work.
+
+The primary rationalisation problem is duplicate operator noise and unclear
+ownership. Runtime load matters, but it is secondary to making the evidence,
+owner, and Control Attention path explicit.
+
+## Decision
+
+Domain Monitor will separate audit collectors from finding publishers.
+
+Scheduled audit collectors store evidence and summaries. They do not update
+Control Attention directly. Control Attention is updated only through
+`MonitoringFinding` records under explicit promotion rules.
+
+The Fleet technical SEO runtime program will use named audit profiles:
+
+- `fleet_technical_seo_smoke`: daily low-cap smoke/regression evidence
+  collection. Initial URL cap: 3.
+- `fleet_technical_seo_deep`: weekly deeper evidence refresh. Initial URL cap:
+  25.
+
+Weekly coverage is required for every eligible site and every applicable audit,
+but it does not need to happen as one large sweep. Scheduled batches must use
+freshness-aware rotation so the most stale eligible properties are selected
+first and the same first N properties are not audited repeatedly.
+
+The existing `monitoring:run-lane fleet_astro_technical_seo` lane remains in the
+first implementation slice as the publisher/reconciler. It reads latest
+qualifying audit evidence and promotes only eligible failures into
+`MonitoringFinding` records.
+
+Durable `unknown` results should not loop forever. Scheduled audits should write
+investigation candidates with evidence and dedupe keys. A later unknown-triage
+slice will create GitHub issues only after thresholds such as repeated attempts
+or 24 hours and confident owner classification.
+
+## Consequences
+
+Positive consequences:
+
+- Control Attention has one deliberate publishing path.
+- Fleet technical SEO evidence can become richer without increasing operator
+  noise by default.
+- Weekly coverage can be spread across batches to protect production load.
+- Unknown results become an explicit investigation queue rather than silent
+  recurring uncertainty.
+
+Trade-offs:
+
+- More scheduling and coverage state is required.
+- Operators must understand the difference between collected evidence and
+  promoted findings.
+- Manual runs need an explicit promotion option if an operator wants immediate
+  Control Attention updates from fresh evidence.
+
+## Implementation Notes
+
+The first implementation slice should add:
+
+- named audit profiles for smoke and deep Fleet technical SEO runtime coverage
+- freshness-aware property selection for scheduled estate batches
+- evidence-only scheduled collector mode
+- schedule entries for collector profiles
+- a safe initial catch-up path for the deep profile within 12 hours of enablement
+
+Automatic durable-unknown GitHub issue creation is intentionally out of scope
+for the first slice.

--- a/tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php
+++ b/tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php
@@ -57,6 +57,128 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
         $this->assertDatabaseCount('fleet_technical_seo_audit_runs', 1);
     }
 
+    public function test_profile_defaults_set_url_cap_and_trigger_type(): void
+    {
+        $property = $this->makeProperty('smoke-site', 'smoke.example');
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--profile' => 'fleet_technical_seo_smoke',
+            '--limit' => 1,
+        ]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('profile [fleet_technical_seo_smoke]', $output);
+        $this->assertSame([
+            ['slug' => $property->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+        ], $runner->calls);
+    }
+
+    public function test_profile_url_cap_can_be_overridden(): void
+    {
+        $property = $this->makeProperty('deep-site', 'deep.example');
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--profile' => 'fleet_technical_seo_deep',
+            '--limit' => 1,
+            '--url-cap' => 9,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            ['slug' => $property->slug, 'url_cap' => 9, 'trigger_type' => 'fleet_technical_seo_deep'],
+        ], $runner->calls);
+    }
+
+    public function test_profile_batches_select_most_stale_eligible_properties_first(): void
+    {
+        $fresh = $this->makeProperty('fresh-site', 'fresh.example');
+        $neverAudited = $this->makeProperty('never-audited-site', 'never-audited.example');
+        $stale = $this->makeProperty('stale-site', 'stale.example');
+        $otherProfileOnly = $this->makeProperty('other-profile-site', 'other-profile.example');
+
+        FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $fresh->id,
+            'trigger_type' => 'fleet_technical_seo_smoke',
+            'started_at' => now()->subHour(),
+            'finished_at' => now()->subHour()->addMinute(),
+        ]);
+        FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $stale->id,
+            'trigger_type' => 'fleet_technical_seo_smoke',
+            'started_at' => now()->subDays(6),
+            'finished_at' => now()->subDays(6)->addMinute(),
+        ]);
+        FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $otherProfileOnly->id,
+            'trigger_type' => 'fleet_technical_seo_deep',
+            'started_at' => now()->subMinutes(30),
+            'finished_at' => now()->subMinutes(29),
+        ]);
+
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--profile' => 'fleet_technical_seo_smoke',
+            '--limit' => 3,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            ['slug' => $neverAudited->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $otherProfileOnly->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+        ], $runner->calls);
+    }
+
+    public function test_explicit_selectors_do_not_use_freshness_rotation(): void
+    {
+        $target = $this->makeProperty('target-site', 'target.example');
+        $stale = $this->makeProperty('stale-site', 'stale.example');
+
+        FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $target->id,
+            'trigger_type' => 'fleet_technical_seo_smoke',
+            'started_at' => now(),
+            'finished_at' => now(),
+        ]);
+
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--profile' => 'fleet_technical_seo_smoke',
+            '--property' => [$target->slug, $stale->slug],
+            '--limit' => 10,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $target->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+        ], $runner->calls);
+    }
+
+    public function test_unknown_profile_fails_before_auditing(): void
+    {
+        $this->makeProperty('profile-site', 'profile.example');
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--profile' => 'fleet_technical_seo_nope',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Unknown Fleet technical SEO audit profile', Artisan::output());
+        $this->assertSame([], $runner->calls);
+    }
+
     public function test_command_can_scope_to_a_domain_selector(): void
     {
         $target = $this->makeProperty('target-site', 'target.example');


### PR DESCRIPTION
## Summary
- document the audit rationalisation collector/publisher decision and ADR
- add `--profile` support for Fleet SEO smoke/deep estate audit profiles
- default smoke to `url-cap=3` and deep to `url-cap=25`
- rotate unscoped profile batches by oldest completed profile audit first
- keep explicit `--property` and `--domain` selectors deterministic

## Issue
Closes #237

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php`
- `./vendor/bin/phpstan analyse app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php --memory-limit=2G`
