### PR TITLE
Make Fleet SEO audit finding promotion explicit

### DIFF
--- a/app/Console/Commands/RunFleetTechnicalSeoAuditCommand.php
+++ b/app/Console/Commands/RunFleetTechnicalSeoAuditCommand.php
@@ -12,7 +12,8 @@ class RunFleetTechnicalSeoAuditCommand extends Command
     protected $signature = 'monitoring:run-fleet-technical-seo-audit
                             {--property= : Web property slug to audit}
                             {--domain= : Domain selector to resolve to a web property}
-                            {--url-cap=25 : Maximum URLs to include in the bounded deterministic crawl}';
+                            {--url-cap=25 : Maximum URLs to include in the bounded deterministic crawl}
+                            {--promote-findings : Promote qualifying failures/recoveries into MonitoringFinding records}';
 
     protected $description = 'Run the deterministic Fleet technical SEO audit slice for one web property.';
 
@@ -55,8 +56,9 @@ class RunFleetTechnicalSeoAuditCommand extends Command
         }
 
         $urlCap = max(1, (int) $this->option('url-cap'));
+        $promoteFindings = (bool) $this->option('promote-findings');
         $property = $properties->firstOrFail();
-        $run = $runner->run($property, $urlCap, 'operator_requested');
+        $run = $runner->run($property, $urlCap, 'operator_requested', $promoteFindings);
         $counts = $run->summary_counts ?? [];
 
         $this->info(sprintf(

--- a/app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php
+++ b/app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php
@@ -30,6 +30,7 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
                             {--domain=* : Domain selector(s) to resolve to web properties}
                             {--limit=5 : Conservative maximum number of eligible properties to audit}
                             {--url-cap= : Maximum URLs to include in each bounded per-property audit}
+                            {--promote-findings : Promote qualifying failures/recoveries into MonitoringFinding records}
                             {--dry-run : List selected properties without creating audit runs}
                             {--continue-on-failure : Continue auditing remaining properties after one property fails}';
 
@@ -47,6 +48,7 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
 
         $limit = max(1, (int) $this->option('limit'));
         $urlCap = $this->urlCap($profile);
+        $promoteFindings = (bool) $this->option('promote-findings');
         $dryRun = (bool) $this->option('dry-run');
         $continueOnFailure = (bool) $this->option('continue-on-failure');
         $properties = $this->selectedProperties($limit, $profile);
@@ -67,11 +69,12 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
         if ($dryRun) {
             foreach ($properties as $property) {
                 $this->line(sprintf(
-                    '[dry-run] %s (%s) profile=%s url_cap=%d',
+                    '[dry-run] %s (%s) profile=%s url_cap=%d promote_findings=%s',
                     $property->slug,
                     $property->primaryDomainName() ?? 'no-domain',
                     $profile ?? 'operator_requested_estate',
-                    $urlCap
+                    $urlCap,
+                    $promoteFindings ? 'yes' : 'no'
                 ));
             }
 
@@ -84,7 +87,7 @@ class RunFleetTechnicalSeoEstateAuditCommand extends Command
             $this->line(sprintf('Running Fleet technical SEO audit for [%s]...', $property->slug));
 
             try {
-                $run = $runner->run($property, $urlCap, $profile ?? 'operator_requested_estate');
+                $run = $runner->run($property, $urlCap, $profile ?? 'operator_requested_estate', $promoteFindings);
                 $counts = $run->summary_counts ?? [];
 
                 $this->info(sprintf(

--- a/app/Services/FleetTechnicalSeoAuditRunner.php
+++ b/app/Services/FleetTechnicalSeoAuditRunner.php
@@ -61,7 +61,7 @@ class FleetTechnicalSeoAuditRunner
         private readonly FleetTechnicalSeoLighthouseRunner $lighthouseRunner,
     ) {}
 
-    public function run(WebProperty $property, int $urlCap = 25, string $triggerType = 'manual'): FleetTechnicalSeoAuditRun
+    public function run(WebProperty $property, int $urlCap = 25, string $triggerType = 'manual', bool $promoteFindings = false): FleetTechnicalSeoAuditRun
     {
         $property->loadMissing(['primaryDomain', 'primaryDomain.tags', 'propertyDomains.domain', 'conversionSurfaces', 'analyticsSources.latestSearchConsoleCoverage']);
         $urlCap = max(1, $urlCap);
@@ -85,7 +85,7 @@ class FleetTechnicalSeoAuditRunner
                 $this->storeResult($run, $property, $checkId, FleetTechnicalSeoAuditResult::STATUS_NOT_APPLICABLE, 'high', [
                     'reason' => $eligibility['reason'],
                     'property_slug' => $property->slug,
-                ], null);
+                ], null, $promoteFindings);
             }
 
             return $this->finishRun($run, [
@@ -111,7 +111,8 @@ class FleetTechnicalSeoAuditRunner
                 status: $result['status'],
                 confidence: $result['confidence'],
                 evidence: $result['evidence'],
-                targetUrl: $result['target_url'] ?? null
+                targetUrl: $result['target_url'] ?? null,
+                promoteFindings: $promoteFindings
             );
         }
 
@@ -862,13 +863,13 @@ class FleetTechnicalSeoAuditRunner
     /**
      * @param  array<string, mixed>  $evidence
      */
-    private function storeResult(FleetTechnicalSeoAuditRun $run, WebProperty $property, string $checkId, string $status, string $confidence, array $evidence, ?string $targetUrl): void
+    private function storeResult(FleetTechnicalSeoAuditRun $run, WebProperty $property, string $checkId, string $status, string $confidence, array $evidence, ?string $targetUrl, bool $promoteFindings): void
     {
         $definition = self::CHECKS[$checkId];
         $findingId = null;
         $evidence = $this->evidenceWithReviewWorkflow($property, $checkId, $status, $definition, $evidence);
 
-        if ($definition['signal'] === 'failure' && $confidence === FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH) {
+        if ($promoteFindings && $definition['signal'] === 'failure' && $confidence === FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH) {
             $findingType = 'fleet_technical_seo.'.$checkId;
             $primaryDomain = $property->primaryDomainModel();
 

--- a/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
+++ b/tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php
@@ -80,7 +80,7 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         $this->assertDatabaseCount('monitoring_findings', 0);
     }
 
-    public function test_high_confidence_failure_creates_attention_finding_and_links_result(): void
+    public function test_high_confidence_failure_stores_evidence_without_finding_by_default(): void
     {
         $property = $this->makeProperty('robots-fail-site', 'robots-fail.example');
         $this->fakeHealthySite('https://robots-fail.example', [
@@ -90,6 +90,28 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
             '--property' => $property->slug,
             '--url-cap' => 10,
+        ]));
+
+        $result = FleetTechnicalSeoAuditResult::query()
+            ->where('check_id', 'robots.present_and_fetchable')
+            ->firstOrFail();
+
+        $this->assertSame(FleetTechnicalSeoAuditResult::STATUS_FAIL, $result->result_status);
+        $this->assertNull($result->monitoring_finding_id);
+        $this->assertDatabaseCount('monitoring_findings', 0);
+    }
+
+    public function test_promote_findings_option_creates_attention_finding_and_links_result(): void
+    {
+        $property = $this->makeProperty('robots-promoted-site', 'robots-promoted.example');
+        $this->fakeHealthySite('https://robots-promoted.example', [
+            'robots_status' => 404,
+        ]);
+
+        $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
+            '--property' => $property->slug,
+            '--url-cap' => 10,
+            '--promote-findings' => true,
         ]));
 
         $finding = MonitoringFinding::query()
@@ -337,6 +359,7 @@ class RunFleetTechnicalSeoAuditCommandTest extends TestCase
         $this->assertSame(0, Artisan::call('monitoring:run-fleet-technical-seo-audit', [
             '--property' => $property->slug,
             '--url-cap' => 10,
+            '--promote-findings' => true,
         ]));
 
         $result = FleetTechnicalSeoAuditResult::query()

--- a/tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php
+++ b/tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php
@@ -52,7 +52,7 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
         $this->assertStringContainsString('Running Fleet technical SEO audit for [eligible-site]', $output);
         $this->assertStringNotContainsString('domain-asset-site', $output);
         $this->assertSame([
-            ['slug' => $eligible->slug, 'url_cap' => 7, 'trigger_type' => 'operator_requested_estate'],
+            ['slug' => $eligible->slug, 'url_cap' => 7, 'trigger_type' => 'operator_requested_estate', 'promote_findings' => false],
         ], $runner->calls);
         $this->assertDatabaseCount('fleet_technical_seo_audit_runs', 1);
     }
@@ -72,7 +72,7 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
         $this->assertSame(0, $exitCode);
         $this->assertStringContainsString('profile [fleet_technical_seo_smoke]', $output);
         $this->assertSame([
-            ['slug' => $property->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $property->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
         ], $runner->calls);
     }
 
@@ -90,7 +90,24 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
 
         $this->assertSame(0, $exitCode);
         $this->assertSame([
-            ['slug' => $property->slug, 'url_cap' => 9, 'trigger_type' => 'fleet_technical_seo_deep'],
+            ['slug' => $property->slug, 'url_cap' => 9, 'trigger_type' => 'fleet_technical_seo_deep', 'promote_findings' => false],
+        ], $runner->calls);
+    }
+
+    public function test_promote_findings_option_is_passed_to_estate_runner(): void
+    {
+        $property = $this->makeProperty('promoted-site', 'promoted.example');
+        $runner = new FleetTechnicalSeoEstateAuditRunnerFake;
+        $this->app->instance(FleetTechnicalSeoAuditRunner::class, $runner);
+
+        $exitCode = Artisan::call('monitoring:run-fleet-technical-seo-estate-audit', [
+            '--property' => [$property->slug],
+            '--promote-findings' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame([
+            ['slug' => $property->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate', 'promote_findings' => true],
         ], $runner->calls);
     }
 
@@ -130,9 +147,9 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
 
         $this->assertSame(0, $exitCode);
         $this->assertSame([
-            ['slug' => $neverAudited->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
-            ['slug' => $otherProfileOnly->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
-            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $neverAudited->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
+            ['slug' => $otherProfileOnly->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
+            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
         ], $runner->calls);
     }
 
@@ -159,8 +176,8 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
 
         $this->assertSame(0, $exitCode);
         $this->assertSame([
-            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
-            ['slug' => $target->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke'],
+            ['slug' => $stale->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
+            ['slug' => $target->slug, 'url_cap' => 3, 'trigger_type' => 'fleet_technical_seo_smoke', 'promote_findings' => false],
         ], $runner->calls);
     }
 
@@ -194,7 +211,7 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
         $this->assertSame(0, $exitCode);
         $this->assertStringContainsString('target-site', Artisan::output());
         $this->assertSame([
-            ['slug' => $target->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate'],
+            ['slug' => $target->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate', 'promote_findings' => false],
         ], $runner->calls);
         $this->assertDatabaseCount('fleet_technical_seo_audit_runs', 1);
     }
@@ -217,8 +234,8 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
         $this->assertStringContainsString('Failed [first-site]: fixture failure', $output);
         $this->assertStringContainsString('Completed [second-site]', $output);
         $this->assertSame([
-            ['slug' => $first->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate'],
-            ['slug' => $second->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate'],
+            ['slug' => $first->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate', 'promote_findings' => false],
+            ['slug' => $second->slug, 'url_cap' => 25, 'trigger_type' => 'operator_requested_estate', 'promote_findings' => false],
         ], $runner->calls);
         $this->assertDatabaseCount('fleet_technical_seo_audit_runs', 1);
     }
@@ -257,7 +274,7 @@ class RunFleetTechnicalSeoEstateAuditCommandTest extends TestCase
 class FleetTechnicalSeoEstateAuditRunnerFake extends FleetTechnicalSeoAuditRunner
 {
     /**
-     * @var list<array{slug: string, url_cap: int, trigger_type: string}>
+     * @var list<array{slug: string, url_cap: int, trigger_type: string, promote_findings: bool}>
      */
     public array $calls = [];
 
@@ -268,12 +285,13 @@ class FleetTechnicalSeoEstateAuditRunnerFake extends FleetTechnicalSeoAuditRunne
 
     public function __construct() {}
 
-    public function run(WebProperty $property, int $urlCap = 25, string $triggerType = 'manual'): FleetTechnicalSeoAuditRun
+    public function run(WebProperty $property, int $urlCap = 25, string $triggerType = 'manual', bool $promoteFindings = false): FleetTechnicalSeoAuditRun
     {
         $this->calls[] = [
             'slug' => $property->slug,
             'url_cap' => $urlCap,
             'trigger_type' => $triggerType,
+            'promote_findings' => $promoteFindings,
         ];
 
         if (isset($this->failures[$property->slug])) {


### PR DESCRIPTION
## Summary
- add explicit `--promote-findings` to Fleet technical SEO single-property and estate audit commands
- keep audit runs/results evidence-only by default by gating `MonitoringFinding` writes in the runner
- add focused tests for default evidence-only behavior and explicit promotion behavior

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php tests/Feature/RunFleetTechnicalSeoAuditCommandTest.php`
- `./vendor/bin/phpstan analyse app/Services/FleetTechnicalSeoAuditRunner.php app/Console/Commands/RunFleetTechnicalSeoEstateAuditCommand.php app/Console/Commands/RunFleetTechnicalSeoAuditCommand.php --memory-limit=2G`

Closes #238
