### PR TITLE
Schedule Fleet SEO collector batches

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -813,6 +813,23 @@ Schedule::command('monitoring:run-lane fleet_astro_technical_seo')
     ->at('09:10')
     ->timezone('UTC');
 
+// Fleet technical SEO estate audits are collectors: they store audit evidence
+// only. Control Attention publication remains owned by monitoring finding
+// publisher/reconciler paths, not by these scheduled collection batches.
+Schedule::command('monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_smoke --limit=5 --continue-on-failure')
+    ->daily()
+    ->at('10:05')
+    ->timezone('UTC')
+    ->withoutOverlapping();
+
+// Deep collector coverage is freshness-rotated and spread across daily batches
+// so every eligible Fleet site can refresh weekly without one large sweep.
+Schedule::command('monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_deep --limit=5 --continue-on-failure')
+    ->daily()
+    ->at('10:35')
+    ->timezone('UTC')
+    ->withoutOverlapping();
+
 // Refresh fleet automation coverage after active GA4/Search Console evidence has had time to settle.
 Schedule::command('analytics:refresh-automation-coverage')
     ->daily()

--- a/tests/Feature/FleetTechnicalSeoCollectorScheduleTest.php
+++ b/tests/Feature/FleetTechnicalSeoCollectorScheduleTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class FleetTechnicalSeoCollectorScheduleTest extends TestCase
+{
+    public function test_fleet_technical_seo_collectors_are_scheduled_as_evidence_only_batches(): void
+    {
+        $exitCode = Artisan::call('schedule:list', [
+            '--no-ansi' => true,
+        ]);
+
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString(
+            'monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_smoke --limit=5 --continue-on-failure',
+            $output
+        );
+        $this->assertStringContainsString(
+            'monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_deep --limit=5 --continue-on-failure',
+            $output
+        );
+        $this->assertStringNotContainsString('--promote-findings', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- schedule daily Fleet technical SEO smoke and deep collector batches with freshness-rotated profiles
- keep the scheduled collectors evidence-only by omitting `--promote-findings`
- add a schedule-list regression test for the collector command shapes

## Schedule shape
- smoke: `10:05 UTC` daily, `--profile=fleet_technical_seo_smoke --limit=5`
- deep: `10:35 UTC` daily, `--profile=fleet_technical_seo_deep --limit=5`

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/FleetTechnicalSeoCollectorScheduleTest.php tests/Feature/RunFleetTechnicalSeoEstateAuditCommandTest.php`
- `php artisan schedule:list --no-ansi | rg 'run-fleet-technical-seo-estate-audit|fleet_astro_technical_seo'`
- `php artisan monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_smoke --dry-run --limit=1`
- `php artisan monitoring:run-fleet-technical-seo-estate-audit --profile=fleet_technical_seo_deep --dry-run --limit=1`
- `php -l routes/console.php`

Closes #239
