### PR TITLE
Reconcile Fleet SEO audit evidence into findings

### DIFF
--- a/app/Console/Commands/RunMonitoringLane.php
+++ b/app/Console/Commands/RunMonitoringLane.php
@@ -2,6 +2,8 @@
 
 namespace App\Console\Commands;
 
+use App\Models\FleetTechnicalSeoAuditResult;
+use App\Models\FleetTechnicalSeoAuditRun;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\WebProperty;
 use App\Services\ControllerMetadataDriftScanner;
@@ -111,9 +113,7 @@ class RunMonitoringLane extends Command
                     ],
                 ],
                 'fleet_astro_technical_seo' => $this->fleetAstroTechnicalSeoAudits(
-                    property: $property,
-                    siteScanner: $siteScanner,
-                    timeout: $timeout
+                    property: $property
                 ),
                 'controller_metadata' => [
                     'controller_metadata_drift' => [
@@ -328,23 +328,73 @@ class RunMonitoringLane extends Command
     /**
      * @return array<string, array{title: string, issue_type: string, audit: array<string, mixed>}>
      */
-    private function fleetAstroTechnicalSeoAudits(
-        WebProperty $property,
-        PropertySiteSignalScanner $siteScanner,
-        int $timeout
-    ): array {
-        return [
-            'fleet_technical_seo.indexability' => [
-                'title' => 'Fleet Astro technical SEO indexability drift detected',
-                'issue_type' => 'cleanup',
-                'audit' => $siteScanner->auditIndexability($property, $timeout),
-            ],
-            'fleet_technical_seo.redirect_policy' => [
-                'title' => 'Fleet Astro preferred-root redirect drift detected',
-                'issue_type' => 'cleanup',
-                'audit' => $siteScanner->auditRedirectPolicy($property, $timeout),
-            ],
-        ];
+    private function fleetAstroTechnicalSeoAudits(WebProperty $property): array
+    {
+        $latestRun = $property->fleetTechnicalSeoAuditRuns()
+            ->with('results')
+            ->whereNotNull('finished_at')
+            ->orderByDesc('started_at')
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (! $latestRun instanceof FleetTechnicalSeoAuditRun) {
+            return [];
+        }
+
+        /** @var Collection<int, FleetTechnicalSeoAuditResult> $results */
+        $results = $latestRun->results;
+
+        return $results
+            ->mapWithKeys(function (FleetTechnicalSeoAuditResult $result) use ($latestRun): array {
+                $findingType = 'fleet_technical_seo.'.$result->check_id;
+                $qualifiesForAttention = $this->fleetTechnicalSeoResultQualifiesForAttention($result);
+
+                return [
+                    $findingType => [
+                        'title' => 'Fleet technical SEO audit evidence requires attention',
+                        'issue_type' => 'cleanup',
+                        'audit' => [
+                            'status' => $qualifiesForAttention ? 'fail' : 'pass',
+                            'verdict' => $qualifiesForAttention ? 'qualified_failure' : 'evidence_only',
+                            'summary' => $qualifiesForAttention
+                                ? $this->fleetTechnicalSeoFailureSummary($result)
+                                : 'Latest Fleet technical SEO audit evidence does not qualify for Attention.',
+                            'evidence' => [
+                                'lane' => 'fleet_astro_technical_seo',
+                                'source' => 'fleet_technical_seo_audit_result',
+                                'audit_run_id' => $latestRun->id,
+                                'audit_result_id' => $result->id,
+                                'trigger_type' => $latestRun->trigger_type,
+                                'check_id' => $result->check_id,
+                                'target_type' => $result->target_type,
+                                'target_url' => $result->target_url,
+                                'result_status' => $result->result_status,
+                                'evidence_confidence' => $result->evidence_confidence,
+                                'owner_system' => $result->owner_system,
+                                'collector_evidence' => is_array($result->evidence) ? $result->evidence : [],
+                            ],
+                        ],
+                    ],
+                ];
+            })
+            ->all();
+    }
+
+    private function fleetTechnicalSeoResultQualifiesForAttention(FleetTechnicalSeoAuditResult $result): bool
+    {
+        return $result->result_status === FleetTechnicalSeoAuditResult::STATUS_FAIL
+            && $result->evidence_confidence === FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH
+            && is_string($result->owner_system)
+            && trim($result->owner_system) !== '';
+    }
+
+    private function fleetTechnicalSeoFailureSummary(FleetTechnicalSeoAuditResult $result): string
+    {
+        return sprintf(
+            'Latest Fleet technical SEO audit found high-confidence failure [%s]%s.',
+            $result->check_id,
+            is_string($result->target_url) && $result->target_url !== '' ? ' on '.$result->target_url : ''
+        );
     }
 
     /**

--- a/tests/Feature/RunMonitoringLaneCommandTest.php
+++ b/tests/Feature/RunMonitoringLaneCommandTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\Domain;
 use App\Models\DomainTag;
+use App\Models\FleetTechnicalSeoAuditResult;
+use App\Models\FleetTechnicalSeoAuditRun;
 use App\Models\MonitoringFinding;
 use App\Models\PropertyAnalyticsSource;
 use App\Models\PropertyRepository;
@@ -820,22 +822,43 @@ class RunMonitoringLaneCommandTest extends TestCase
         $nonFleetAstroProperty = $this->makeProperty('non-fleet-astro.example.au', 'Non Fleet Astro');
         $this->attachControllerRepository($nonFleetAstroProperty, 'non-fleet-astro', 'Astro');
 
-        Http::fake([
-            'https://fleet-astro.example.au/' => Http::response(
-                $this->homepageHtml(metaRobots: 'noindex,follow'),
-                200
-            ),
-            'https://fleet-astro.example.au/robots.txt' => Http::response("User-agent: *\nAllow: /\n", 200),
-            'http://fleet-astro.example.au/' => Http::response(
-                'ok',
-                200,
-                ['X-Guzzle-Redirect-History' => [], 'X-Guzzle-Redirect-Status-History' => []]
-            ),
-            'https://www.fleet-astro.example.au/' => Http::response(
-                'ok',
-                200,
-                ['X-Guzzle-Redirect-History' => [], 'X-Guzzle-Redirect-Status-History' => []]
-            ),
+        $this->createFleetTechnicalSeoAuditRun($fleetAstroProperty, [
+            [
+                'check_id' => 'robots.present_and_fetchable',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_FAIL,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH,
+                'owner_system' => 'domain-monitor',
+                'evidence' => ['status' => 404],
+            ],
+            [
+                'check_id' => 'canonical.production_origin_expected',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_FAIL,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH,
+                'owner_system' => 'domain-monitor',
+                'evidence' => ['canonical_url' => 'https://wrong.example.au/'],
+            ],
+            [
+                'check_id' => 'title.present_unique_and_relevant',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_MANUAL_REVIEW,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_MEDIUM,
+                'owner_system' => 'site-repo',
+            ],
+        ]);
+        $this->createFleetTechnicalSeoAuditRun($fleetWordpressProperty, [
+            [
+                'check_id' => 'robots.present_and_fetchable',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_FAIL,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH,
+                'owner_system' => 'domain-monitor',
+            ],
+        ]);
+        $this->createFleetTechnicalSeoAuditRun($nonFleetAstroProperty, [
+            [
+                'check_id' => 'robots.present_and_fetchable',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_FAIL,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH,
+                'owner_system' => 'domain-monitor',
+            ],
         ]);
 
         $brain = Mockery::mock(BrainEventClient::class);
@@ -845,8 +868,8 @@ class RunMonitoringLaneCommandTest extends TestCase
         $fleetTechnicalSeoExpectation->twice()->withArgs(function (string $eventType, array $payload): bool {
             $this->assertSame('domain_monitor.finding.opened', $eventType);
             $this->assertContains($payload['finding_type'], [
-                'fleet_technical_seo.indexability',
-                'fleet_technical_seo.redirect_policy',
+                'fleet_technical_seo.robots.present_and_fetchable',
+                'fleet_technical_seo.canonical.production_origin_expected',
             ]);
             $this->assertSame('cleanup', $payload['issue_type']);
 
@@ -859,15 +882,19 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $this->assertDatabaseHas('monitoring_findings', [
             'web_property_id' => $fleetAstroProperty->id,
-            'finding_type' => 'fleet_technical_seo.indexability',
+            'finding_type' => 'fleet_technical_seo.robots.present_and_fetchable',
             'issue_type' => 'cleanup',
             'status' => MonitoringFinding::STATUS_OPEN,
         ]);
         $this->assertDatabaseHas('monitoring_findings', [
             'web_property_id' => $fleetAstroProperty->id,
-            'finding_type' => 'fleet_technical_seo.redirect_policy',
+            'finding_type' => 'fleet_technical_seo.canonical.production_origin_expected',
             'issue_type' => 'cleanup',
             'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+        $this->assertDatabaseMissing('monitoring_findings', [
+            'web_property_id' => $fleetAstroProperty->id,
+            'finding_type' => 'fleet_technical_seo.title.present_unique_and_relevant',
         ]);
         $this->assertDatabaseMissing('monitoring_findings', [
             'web_property_id' => $fleetWordpressProperty->id,
@@ -886,12 +913,88 @@ class RunMonitoringLaneCommandTest extends TestCase
 
         $this->assertIsArray($issues);
         /** @var array<int, array<string, mixed>> $issues */
-        $matchingIssue = collect($issues)->firstWhere('issue_class', 'fleet_technical_seo.indexability');
+        $matchingIssue = collect($issues)->firstWhere('issue_class', 'fleet_technical_seo.robots.present_and_fetchable');
 
         $this->assertIsArray($matchingIssue);
         $this->assertSame('should_fix', $matchingIssue['severity']);
         $this->assertSame('monitoring_lane', $matchingIssue['execution_surface']);
         $this->assertSame('fleet_astro_technical_seo', data_get($matchingIssue, 'evidence.lane'));
+    }
+
+    public function test_fleet_astro_technical_seo_lane_recovers_when_latest_audit_evidence_no_longer_qualifies(): void
+    {
+        config()->set('services.brain.base_url', 'https://brain.example.test');
+        config()->set('services.brain.api_key', 'test-key');
+        config()->set('domain_monitor.fleet_focus.tag_name', 'fleet.live');
+
+        $property = $this->makeProperty('fleet-recovered.example.au', 'Fleet Recovered');
+        $this->attachFleetFocusTag($property);
+        $this->attachControllerRepository($property, 'fleet-recovered', 'Astro');
+
+        $findingType = 'fleet_technical_seo.robots.present_and_fetchable';
+        $issueId = app(\App\Services\DetectedIssueIdentityService::class)->makeIssueId(
+            (string) $property->primary_domain_id,
+            $property->slug,
+            $findingType
+        );
+
+        $openFinding = MonitoringFinding::factory()->create([
+            'issue_id' => $issueId,
+            'web_property_id' => $property->id,
+            'domain_id' => $property->primary_domain_id,
+            'lane' => 'fleet_astro_technical_seo',
+            'finding_type' => $findingType,
+            'issue_type' => 'cleanup',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+
+        $this->createFleetTechnicalSeoAuditRun($property, [
+            [
+                'check_id' => 'robots.present_and_fetchable',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_PASS,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_HIGH,
+                'owner_system' => 'domain-monitor',
+            ],
+            [
+                'check_id' => 'sitemap.canonical_endpoint_fetchable',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_FAIL,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_LOW,
+                'owner_system' => 'domain-monitor',
+            ],
+            [
+                'check_id' => 'title.present_unique_and_relevant',
+                'result_status' => FleetTechnicalSeoAuditResult::STATUS_MANUAL_REVIEW,
+                'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_MEDIUM,
+                'owner_system' => 'site-repo',
+            ],
+        ]);
+
+        $brain = Mockery::mock(BrainEventClient::class);
+        $this->instance(BrainEventClient::class, $brain);
+        /** @var Mockery\Expectation $recoveredExpectation */
+        $recoveredExpectation = $brain->shouldReceive('sendAsync');
+        $recoveredExpectation->once()->withArgs(function (string $eventType, array $payload) use ($openFinding): bool {
+            $this->assertSame('domain_monitor.finding.recovered', $eventType);
+            $this->assertSame($openFinding->issue_id, $payload['issue_id']);
+
+            return true;
+        });
+
+        $this->assertSame(0, Artisan::call('monitoring:run-lane', [
+            'lane' => 'fleet_astro_technical_seo',
+        ]));
+
+        $this->assertSame(MonitoringFinding::STATUS_RECOVERED, $openFinding->refresh()->status);
+        $this->assertDatabaseMissing('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'fleet_technical_seo.sitemap.canonical_endpoint_fetchable',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
+        $this->assertDatabaseMissing('monitoring_findings', [
+            'web_property_id' => $property->id,
+            'finding_type' => 'fleet_technical_seo.title.present_unique_and_relevant',
+            'status' => MonitoringFinding::STATUS_OPEN,
+        ]);
     }
 
     public function test_critical_live_lane_reports_redirect_policy_mismatches(): void
@@ -1994,6 +2097,38 @@ class RunMonitoringLaneCommandTest extends TestCase
         ]);
 
         return $property;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $results
+     */
+    private function createFleetTechnicalSeoAuditRun(WebProperty $property, array $results): FleetTechnicalSeoAuditRun
+    {
+        $run = FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $property->id,
+            'trigger_type' => 'fleet_technical_seo_deep',
+            'started_at' => now(),
+            'finished_at' => now(),
+            'summary_counts' => [
+                'pass' => collect($results)->where('result_status', FleetTechnicalSeoAuditResult::STATUS_PASS)->count(),
+                'fail' => collect($results)->where('result_status', FleetTechnicalSeoAuditResult::STATUS_FAIL)->count(),
+                'manual_review' => collect($results)->where('result_status', FleetTechnicalSeoAuditResult::STATUS_MANUAL_REVIEW)->count(),
+                'unknown' => collect($results)->where('result_status', FleetTechnicalSeoAuditResult::STATUS_UNKNOWN)->count(),
+                'not_applicable' => collect($results)->where('result_status', FleetTechnicalSeoAuditResult::STATUS_NOT_APPLICABLE)->count(),
+            ],
+        ]);
+
+        foreach ($results as $result) {
+            FleetTechnicalSeoAuditResult::factory()->create(array_merge([
+                'fleet_technical_seo_audit_run_id' => $run->id,
+                'target_type' => 'web_property',
+                'target_url' => null,
+                'evidence' => [],
+                'owner_system' => 'domain-monitor',
+            ], $result));
+        }
+
+        return $run;
     }
 
     private function attachGa4Source(WebProperty $property, string $measurementId): void


### PR DESCRIPTION
## Summary
- make `monitoring:run-lane fleet_astro_technical_seo` reconcile latest finished Fleet technical SEO audit results instead of re-running live scanner checks
- promote only high-confidence failed audit results with an owner system into `MonitoringFinding` records
- recover existing Fleet SEO findings when the latest audit result no longer qualifies for Attention
- keep manual-review, unknown, pass, not-applicable, and low-confidence evidence out of Control Attention by default

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/RunMonitoringLaneCommandTest.php --filter='fleet_astro_technical_seo'`
- `php artisan test tests/Feature/WebPropertyFleetTechnicalSeoAuditSummaryApiTest.php`
- `./vendor/bin/phpstan analyse app/Console/Commands/RunMonitoringLane.php tests/Feature/RunMonitoringLaneCommandTest.php --memory-limit=2G`
- `php -l app/Console/Commands/RunMonitoringLane.php`
- `php -l tests/Feature/RunMonitoringLaneCommandTest.php`

Closes #240
