### PR TITLE
Add Fleet SEO unknown triage candidates

### DIFF
--- a/app/Console/Commands/TriageFleetTechnicalSeoUnknownsCommand.php
+++ b/app/Console/Commands/TriageFleetTechnicalSeoUnknownsCommand.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FleetTechnicalSeoAuditResult;
+use App\Models\FleetTechnicalSeoUnknownTriageCandidate;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class TriageFleetTechnicalSeoUnknownsCommand extends Command
+{
+    protected $signature = 'monitoring:triage-fleet-technical-seo-unknowns
+                            {--threshold=2 : Minimum repeated unknown results before candidate creation}
+                            {--min-age-hours=24 : Minimum age of oldest matching unknown before candidate creation}
+                            {--limit=50 : Maximum candidates to create or list}
+                            {--dry-run : List candidates without writing records}';
+
+    protected $description = 'Create durable review candidates for repeated Fleet technical SEO unknown audit evidence.';
+
+    public function handle(): int
+    {
+        $threshold = max(1, (int) $this->option('threshold'));
+        $minAgeHours = max(0, (int) $this->option('min-age-hours'));
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+        $cutoff = now()->subHours($minAgeHours);
+
+        $groups = $this->unknownResultGroups();
+        $candidates = $groups
+            ->map(fn (Collection $results): ?array => $this->candidateForGroup($results, $threshold, $cutoff))
+            ->filter()
+            ->take($limit)
+            ->values();
+
+        if ($candidates->isEmpty()) {
+            $this->info('No Fleet technical SEO unknown triage candidates met the threshold.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($candidates as $candidate) {
+            $this->line(sprintf(
+                '%s %s %s retry_count=%d owner=%s',
+                $dryRun ? '[dry-run]' : '[candidate]',
+                $candidate['property_slug'],
+                $candidate['check_id'],
+                $candidate['retry_count'],
+                $candidate['owner_route']
+            ));
+
+            if ($dryRun) {
+                continue;
+            }
+
+            FleetTechnicalSeoUnknownTriageCandidate::query()->updateOrCreate(
+                ['dedupe_key' => $candidate['dedupe_key']],
+                $candidate
+            );
+        }
+
+        $this->info(sprintf(
+            '%s %d Fleet technical SEO unknown triage candidate(s).',
+            $dryRun ? 'Listed' : 'Stored',
+            $candidates->count()
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return Collection<string, Collection<int, FleetTechnicalSeoAuditResult>>
+     */
+    private function unknownResultGroups(): Collection
+    {
+        if (
+            ! Schema::hasTable('fleet_technical_seo_audit_results')
+            || ! Schema::hasTable('fleet_technical_seo_audit_runs')
+            || ! Schema::hasTable('fleet_technical_seo_unknown_triage_candidates')
+        ) {
+            return collect();
+        }
+
+        $results = FleetTechnicalSeoAuditResult::query()
+            ->with(['auditRun.webProperty.primaryDomain'])
+            ->where('result_status', FleetTechnicalSeoAuditResult::STATUS_UNKNOWN)
+            ->whereHas('auditRun', fn ($query) => $query->whereNotNull('finished_at'))
+            ->get();
+
+        return collect($results)
+            ->groupBy(fn (FleetTechnicalSeoAuditResult $result): string => $this->dedupeKeyForResult($result));
+    }
+
+    /**
+     * @param  Collection<int, FleetTechnicalSeoAuditResult>  $results
+     * @return array<string, mixed>|null
+     */
+    private function candidateForGroup(Collection $results, int $threshold, Carbon $cutoff): ?array
+    {
+        if ($results->count() < $threshold) {
+            return null;
+        }
+
+        $sorted = $results->sortBy(fn (FleetTechnicalSeoAuditResult $result): int => $result->auditRun->started_at?->getTimestamp() ?? 0)->values();
+        $first = $sorted->first();
+        $latest = $sorted->last();
+
+        if (! $first instanceof FleetTechnicalSeoAuditResult || ! $latest instanceof FleetTechnicalSeoAuditResult) {
+            return null;
+        }
+
+        $firstSeenAt = $first->auditRun->started_at ?? $first->created_at;
+        if ($firstSeenAt instanceof Carbon && $firstSeenAt->greaterThan($cutoff)) {
+            return null;
+        }
+
+        $property = $latest->auditRun->webProperty;
+        $primaryDomain = $property->primaryDomainModel();
+        $ownerRoute = $this->ownerRouteForResult($latest);
+        $coverageUnit = $this->coverageUnitForResult($property->slug, $latest);
+        $auditProfile = $latest->auditRun->trigger_type;
+        $dedupeKey = $this->dedupeKey($auditProfile, $coverageUnit, $latest->check_id, $ownerRoute);
+        $payload = [
+            'audit_profile' => $auditProfile,
+            'coverage_unit' => $coverageUnit,
+            'check_id' => $latest->check_id,
+            'property_slug' => $property->slug,
+            'domain' => $primaryDomain?->domain,
+            'owner_route' => $ownerRoute,
+            'retry_count' => $results->count(),
+            'dedupe_key' => $dedupeKey,
+            'first_seen_at' => $firstSeenAt?->toIso8601String(),
+            'last_seen_at' => ($latest->auditRun->started_at ?? $latest->created_at)?->toIso8601String(),
+            'latest_audit_run_id' => $latest->auditRun->id,
+            'latest_audit_result_id' => $latest->id,
+            'latest_evidence' => is_array($latest->evidence) ? $latest->evidence : [],
+        ];
+
+        return [
+            'dedupe_key' => $dedupeKey,
+            'web_property_id' => $property->id,
+            'domain_id' => $primaryDomain?->id,
+            'property_slug' => $property->slug,
+            'audit_profile' => $auditProfile,
+            'coverage_unit' => $coverageUnit,
+            'check_id' => $latest->check_id,
+            'owner_route' => $ownerRoute,
+            'latest_audit_run_id' => $latest->auditRun->id,
+            'latest_audit_result_id' => $latest->id,
+            'retry_count' => $results->count(),
+            'first_seen_at' => $firstSeenAt,
+            'last_seen_at' => $latest->auditRun->started_at ?? $latest->created_at,
+            'status' => FleetTechnicalSeoUnknownTriageCandidate::STATUS_OPEN,
+            'candidate_payload' => $payload,
+        ];
+    }
+
+    private function dedupeKeyForResult(FleetTechnicalSeoAuditResult $result): string
+    {
+        $property = $result->auditRun->webProperty;
+        $ownerRoute = $this->ownerRouteForResult($result);
+
+        return $this->dedupeKey(
+            $result->auditRun->trigger_type,
+            $this->coverageUnitForResult($property->slug, $result),
+            $result->check_id,
+            $ownerRoute
+        );
+    }
+
+    private function dedupeKey(string $auditProfile, string $coverageUnit, string $checkId, string $ownerRoute): string
+    {
+        return hash('sha256', implode('|', [$auditProfile, $coverageUnit, $checkId, $ownerRoute]));
+    }
+
+    private function coverageUnitForResult(string $propertySlug, FleetTechnicalSeoAuditResult $result): string
+    {
+        if ($result->target_url !== null && trim($result->target_url) !== '') {
+            return 'url:'.trim($result->target_url);
+        }
+
+        return 'web_property:'.$propertySlug;
+    }
+
+    private function ownerRouteForResult(FleetTechnicalSeoAuditResult $result): string
+    {
+        $ownerSystem = strtolower(trim((string) $result->owner_system));
+
+        if ($ownerSystem === 'mm-google' || str_starts_with($result->check_id, 'analytics.')) {
+            return 'mm-google';
+        }
+
+        if (in_array($ownerSystem, ['fleet', 'site-repo'], true)) {
+            return 'fleet';
+        }
+
+        if ($ownerSystem === 'domain-monitor') {
+            return 'domain-monitor';
+        }
+
+        return 'control';
+    }
+}

--- a/app/Models/FleetTechnicalSeoUnknownTriageCandidate.php
+++ b/app/Models/FleetTechnicalSeoUnknownTriageCandidate.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property string $dedupe_key
+ * @property string $web_property_id
+ * @property string|null $domain_id
+ * @property string $property_slug
+ * @property string $audit_profile
+ * @property string $coverage_unit
+ * @property string $check_id
+ * @property string $owner_route
+ * @property string $latest_audit_run_id
+ * @property string $latest_audit_result_id
+ * @property int $retry_count
+ * @property \Illuminate\Support\Carbon|null $first_seen_at
+ * @property \Illuminate\Support\Carbon|null $last_seen_at
+ * @property string $status
+ * @property array<string, mixed> $candidate_payload
+ */
+class FleetTechnicalSeoUnknownTriageCandidate extends Model
+{
+    /** @use HasFactory<\Database\Factories\FleetTechnicalSeoUnknownTriageCandidateFactory> */
+    use HasFactory;
+
+    public const STATUS_OPEN = 'open';
+
+    protected $fillable = [
+        'dedupe_key',
+        'web_property_id',
+        'domain_id',
+        'property_slug',
+        'audit_profile',
+        'coverage_unit',
+        'check_id',
+        'owner_route',
+        'latest_audit_run_id',
+        'latest_audit_result_id',
+        'retry_count',
+        'first_seen_at',
+        'last_seen_at',
+        'status',
+        'candidate_payload',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'retry_count' => 'integer',
+            'first_seen_at' => 'datetime',
+            'last_seen_at' => 'datetime',
+            'candidate_payload' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<WebProperty, $this>
+     */
+    public function webProperty(): BelongsTo
+    {
+        return $this->belongsTo(WebProperty::class);
+    }
+
+    /**
+     * @return BelongsTo<Domain, $this>
+     */
+    public function domain(): BelongsTo
+    {
+        return $this->belongsTo(Domain::class);
+    }
+
+    /**
+     * @return BelongsTo<FleetTechnicalSeoAuditRun, $this>
+     */
+    public function latestAuditRun(): BelongsTo
+    {
+        return $this->belongsTo(FleetTechnicalSeoAuditRun::class, 'latest_audit_run_id');
+    }
+
+    /**
+     * @return BelongsTo<FleetTechnicalSeoAuditResult, $this>
+     */
+    public function latestAuditResult(): BelongsTo
+    {
+        return $this->belongsTo(FleetTechnicalSeoAuditResult::class, 'latest_audit_result_id');
+    }
+}

--- a/database/factories/FleetTechnicalSeoUnknownTriageCandidateFactory.php
+++ b/database/factories/FleetTechnicalSeoUnknownTriageCandidateFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FleetTechnicalSeoAuditResult;
+use App\Models\FleetTechnicalSeoAuditRun;
+use App\Models\FleetTechnicalSeoUnknownTriageCandidate;
+use App\Models\WebProperty;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<FleetTechnicalSeoUnknownTriageCandidate>
+ */
+class FleetTechnicalSeoUnknownTriageCandidateFactory extends Factory
+{
+    public function definition(): array
+    {
+        $property = WebProperty::factory();
+        $run = FleetTechnicalSeoAuditRun::factory();
+        $result = FleetTechnicalSeoAuditResult::factory();
+        $checkId = fake()->randomElement(['robots.present_and_fetchable', 'analytics.google_evidence_owned_by_mm_google']);
+        $auditProfile = 'fleet_technical_seo_deep';
+        $coverageUnit = 'web_property:'.fake()->slug();
+        $ownerRoute = fake()->randomElement(['domain-monitor', 'fleet', 'mm-google', 'control']);
+
+        return [
+            'dedupe_key' => hash('sha256', $auditProfile.'|'.$coverageUnit.'|'.$checkId.'|'.$ownerRoute.'|'.Str::uuid()->toString()),
+            'web_property_id' => $property,
+            'domain_id' => null,
+            'property_slug' => fake()->slug(),
+            'audit_profile' => $auditProfile,
+            'coverage_unit' => $coverageUnit,
+            'check_id' => $checkId,
+            'owner_route' => $ownerRoute,
+            'latest_audit_run_id' => $run,
+            'latest_audit_result_id' => $result,
+            'retry_count' => 2,
+            'first_seen_at' => now()->subDay(),
+            'last_seen_at' => now(),
+            'status' => FleetTechnicalSeoUnknownTriageCandidate::STATUS_OPEN,
+            'candidate_payload' => ['check_id' => $checkId],
+        ];
+    }
+}

--- a/database/migrations/2026_05_20_031353_create_fleet_technical_seo_unknown_triage_candidates_table.php
+++ b/database/migrations/2026_05_20_031353_create_fleet_technical_seo_unknown_triage_candidates_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fleet_technical_seo_unknown_triage_candidates', function (Blueprint $table): void {
+            $table->id();
+            $table->string('dedupe_key', 255)->unique();
+            $table->uuid('web_property_id');
+            $table->uuid('domain_id')->nullable();
+            $table->string('property_slug');
+            $table->string('audit_profile', 80);
+            $table->string('coverage_unit', 2048);
+            $table->string('check_id', 160);
+            $table->string('owner_route', 40);
+            $table->uuid('latest_audit_run_id');
+            $table->uuid('latest_audit_result_id');
+            $table->unsignedInteger('retry_count');
+            $table->timestamp('first_seen_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->string('status', 40)->default('open');
+            $table->json('candidate_payload');
+            $table->timestamps();
+
+            $table->foreign('web_property_id')->references('id')->on('web_properties')->cascadeOnDelete();
+            $table->foreign('domain_id')->references('id')->on('domains')->nullOnDelete();
+            $table->foreign('latest_audit_run_id')->references('id')->on('fleet_technical_seo_audit_runs')->cascadeOnDelete();
+            $table->foreign('latest_audit_result_id')->references('id')->on('fleet_technical_seo_audit_results')->cascadeOnDelete();
+            $table->index(['status', 'owner_route']);
+            $table->index(['audit_profile', 'check_id']);
+            $table->index(['web_property_id', 'last_seen_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fleet_technical_seo_unknown_triage_candidates');
+    }
+};

--- a/tests/Feature/TriageFleetTechnicalSeoUnknownsCommandTest.php
+++ b/tests/Feature/TriageFleetTechnicalSeoUnknownsCommandTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\FleetTechnicalSeoAuditResult;
+use App\Models\FleetTechnicalSeoAuditRun;
+use App\Models\FleetTechnicalSeoUnknownTriageCandidate;
+use App\Models\WebProperty;
+use App\Models\WebPropertyDomain;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class TriageFleetTechnicalSeoUnknownsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_creates_deduped_unknown_triage_candidate_after_threshold(): void
+    {
+        $property = $this->makeProperty('unknown.example.au');
+
+        $this->createUnknownResult($property, now()->subHours(30), [
+            'check_id' => 'robots.present_and_fetchable',
+            'owner_system' => 'domain-monitor',
+            'evidence' => ['error' => 'timeout one'],
+        ]);
+        $latestResult = $this->createUnknownResult($property, now()->subHours(2), [
+            'check_id' => 'robots.present_and_fetchable',
+            'owner_system' => 'domain-monitor',
+            'evidence' => ['error' => 'timeout two'],
+        ]);
+
+        $exitCode = Artisan::call('monitoring:triage-fleet-technical-seo-unknowns', [
+            '--threshold' => 2,
+            '--min-age-hours' => 24,
+        ]);
+
+        $candidate = FleetTechnicalSeoUnknownTriageCandidate::query()->firstOrFail();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('unknown-example-au', $candidate->property_slug);
+        $this->assertSame('fleet_technical_seo_deep', $candidate->audit_profile);
+        $this->assertSame('web_property:unknown-example-au', $candidate->coverage_unit);
+        $this->assertSame('robots.present_and_fetchable', $candidate->check_id);
+        $this->assertSame('domain-monitor', $candidate->owner_route);
+        $this->assertSame(2, $candidate->retry_count);
+        $this->assertSame($latestResult->id, $candidate->latest_audit_result_id);
+        $this->assertSame('timeout two', data_get($candidate->candidate_payload, 'latest_evidence.error'));
+    }
+
+    public function test_it_waits_for_threshold_and_minimum_age(): void
+    {
+        $property = $this->makeProperty('young-unknown.example.au');
+
+        $this->createUnknownResult($property, now()->subHours(2), [
+            'check_id' => 'sitemap.canonical_endpoint_fetchable',
+            'owner_system' => 'domain-monitor',
+        ]);
+        $this->createUnknownResult($property, now()->subHour(), [
+            'check_id' => 'sitemap.canonical_endpoint_fetchable',
+            'owner_system' => 'domain-monitor',
+        ]);
+
+        $exitCode = Artisan::call('monitoring:triage-fleet-technical-seo-unknowns', [
+            '--threshold' => 2,
+            '--min-age-hours' => 24,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('fleet_technical_seo_unknown_triage_candidates', 0);
+        $this->assertStringContainsString('No Fleet technical SEO unknown triage candidates met the threshold.', Artisan::output());
+    }
+
+    public function test_dry_run_lists_without_storing_candidate(): void
+    {
+        $property = $this->makeProperty('dry-run-unknown.example.au');
+
+        $this->createUnknownResult($property, now()->subHours(30), [
+            'check_id' => 'analytics.google_evidence_owned_by_mm_google',
+            'owner_system' => 'MM-Google',
+        ]);
+        $this->createUnknownResult($property, now()->subHours(3), [
+            'check_id' => 'analytics.google_evidence_owned_by_mm_google',
+            'owner_system' => 'MM-Google',
+        ]);
+
+        $exitCode = Artisan::call('monitoring:triage-fleet-technical-seo-unknowns', [
+            '--threshold' => 2,
+            '--min-age-hours' => 24,
+            '--dry-run' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertDatabaseCount('fleet_technical_seo_unknown_triage_candidates', 0);
+        $this->assertStringContainsString('[dry-run] dry-run-unknown-example-au analytics.google_evidence_owned_by_mm_google retry_count=2 owner=mm-google', Artisan::output());
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    private function createUnknownResult(WebProperty $property, \DateTimeInterface $startedAt, array $attributes = []): FleetTechnicalSeoAuditResult
+    {
+        $run = FleetTechnicalSeoAuditRun::factory()->create([
+            'web_property_id' => $property->id,
+            'trigger_type' => 'fleet_technical_seo_deep',
+            'started_at' => $startedAt,
+            'finished_at' => \Illuminate\Support\Carbon::instance($startedAt)->addMinutes(3),
+        ]);
+
+        return FleetTechnicalSeoAuditResult::factory()->create(array_merge([
+            'fleet_technical_seo_audit_run_id' => $run->id,
+            'check_id' => 'robots.present_and_fetchable',
+            'target_type' => 'web_property',
+            'target_url' => null,
+            'result_status' => FleetTechnicalSeoAuditResult::STATUS_UNKNOWN,
+            'evidence_confidence' => FleetTechnicalSeoAuditResult::CONFIDENCE_LOW,
+            'evidence' => [],
+            'owner_system' => 'domain-monitor',
+        ], $attributes));
+    }
+
+    private function makeProperty(string $domainName): WebProperty
+    {
+        $domain = Domain::factory()->create([
+            'domain' => $domainName,
+            'is_active' => true,
+        ]);
+        $property = WebProperty::factory()->create([
+            'slug' => str($domainName)->replace('.', '-')->toString(),
+            'name' => $domainName,
+            'status' => 'active',
+            'property_type' => 'marketing_site',
+            'primary_domain_id' => $domain->id,
+            'production_url' => 'https://'.$domainName.'/',
+        ]);
+
+        WebPropertyDomain::query()->create([
+            'web_property_id' => $property->id,
+            'domain_id' => $domain->id,
+            'usage_type' => 'primary',
+            'is_canonical' => true,
+        ]);
+
+        return $property;
+    }
+}

--- a/tests/Feature/WebPropertyFleetTechnicalSeoAuditSummaryApiTest.php
+++ b/tests/Feature/WebPropertyFleetTechnicalSeoAuditSummaryApiTest.php
@@ -114,6 +114,7 @@ class WebPropertyFleetTechnicalSeoAuditSummaryApiTest extends TestCase
         config()->set('services.domain_monitor.brain_api_key', 'test-api-key');
 
         $property = $this->makeProperty('pre-migration-site', 'pre-migration.example');
+        Schema::dropIfExists('fleet_technical_seo_unknown_triage_candidates');
         Schema::dropIfExists('fleet_technical_seo_audit_results');
         Schema::dropIfExists('fleet_technical_seo_audit_runs');
         Schema::dropIfExists('web_property_conversion_surfaces');


### PR DESCRIPTION
## Summary
- add durable Fleet technical SEO unknown triage candidates
- add `monitoring:triage-fleet-technical-seo-unknowns` to dedupe repeated unknown audit results after threshold/age gates
- classify owner route as `domain-monitor`, `fleet`, `mm-google`, or `control`
- keep automatic GitHub issue creation out of scope; this stores/list candidates only

## Checks
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/TriageFleetTechnicalSeoUnknownsCommandTest.php`
- `./vendor/bin/phpstan analyse app/Console/Commands/TriageFleetTechnicalSeoUnknownsCommand.php app/Models/FleetTechnicalSeoUnknownTriageCandidate.php tests/Feature/TriageFleetTechnicalSeoUnknownsCommandTest.php --memory-limit=2G`
- `php artisan monitoring:triage-fleet-technical-seo-unknowns --dry-run --threshold=2 --min-age-hours=24`
- PHP syntax checks for touched PHP files

Closes #241
