### PR TITLE
Add .au compliance failure report

### DIFF
--- a/app/Console/Commands/ReportAuComplianceFailures.php
+++ b/app/Console/Commands/ReportAuComplianceFailures.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\SynergyCredential;
+use App\Services\AuComplianceFailureReport;
+use App\Services\SynergyWholesaleClient;
+use Illuminate\Console\Command;
+use Throwable;
+
+class ReportAuComplianceFailures extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'domains:report-au-compliance-failures
+                            {--output-dir= : Directory for Markdown and CSV report artifacts}
+                            {--dry-run : Build and print the report summary without writing files}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a read-only .au compliance failure report from current Synergy truth and local domain metadata';
+
+    public function __construct(private readonly AuComplianceFailureReport $report)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $credential = SynergyCredential::query()->where('is_active', true)->first();
+
+        if (! $credential) {
+            $this->error('No active Synergy Wholesale credentials found.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            $client = SynergyWholesaleClient::fromEncryptedCredentials(
+                $credential->reseller_id,
+                $credential->api_key_encrypted,
+                $credential->api_url
+            );
+
+            $synergyFailures = $client->listNonCompliantAuDomains();
+        } catch (Throwable) {
+            $this->error('Unable to retrieve non-compliant .au domains from Synergy Wholesale. Check credentials/API availability; credentials were not logged.');
+
+            return Command::FAILURE;
+        }
+
+        if ($synergyFailures === null) {
+            $this->error('Unable to retrieve non-compliant .au domains from Synergy Wholesale. Check credentials/API availability; credentials were not logged.');
+
+            return Command::FAILURE;
+        }
+
+        $report = $this->report->build($synergyFailures);
+
+        $this->info('Generated .au compliance failure report summary:');
+        $this->line('Generated at: '.$report['generated_at']);
+        $this->line('Total failing domains: '.$report['total_failing_domains']);
+        $this->line('Matched local domains: '.$report['matched_local_domains']);
+        $this->line('Unmatched Synergy domains: '.$report['unmatched_synergy_domains']);
+
+        if ($this->option('dry-run')) {
+            $this->warn('Dry run only: no report files were written and no Domain Monitor or Synergy records were changed.');
+
+            return Command::SUCCESS;
+        }
+
+        $outputDirectory = (string) ($this->option('output-dir') ?: AuComplianceFailureReport::DEFAULT_OUTPUT_DIR);
+        $paths = $this->report->write($report, $outputDirectory);
+
+        $this->info('Markdown report: '.$paths['markdown']);
+        $this->info('CSV report: '.$paths['csv']);
+        $this->warn('Report only: no COR, DNS, renewal, registrant, Domain Monitor, or Synergy records were changed.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Services/AuComplianceFailureReport.php
+++ b/app/Services/AuComplianceFailureReport.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Domain;
+use App\Models\DomainAlert;
+use App\Models\DomainComplianceCheck;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class AuComplianceFailureReport
+{
+    public const DEFAULT_OUTPUT_DIR = '/Users/jasonhill/Projects/Business/vault/domains/compliance/reports';
+
+    public const STATUS_NEEDS_REVIEW = 'needs review';
+
+    public const STATUS_NEEDS_OLD_ENTITY_LOOKUP = 'needs old entity lookup';
+
+    /**
+     * @var array<int, string>
+     */
+    public const WORKFLOW_STATUSES = [
+        self::STATUS_NEEDS_REVIEW,
+        self::STATUS_NEEDS_OLD_ENTITY_LOOKUP,
+        'needs current eligible entity selected',
+        'cor draft needed',
+        'cor ready for synergy',
+        'submitted in synergy',
+        'resolved',
+        'parked for later',
+    ];
+
+    /**
+     * @var array<int, string>
+     */
+    private const HEADERS = [
+        'domain',
+        'synergy_failure_reason',
+        'local_record_status',
+        'manual_workflow_status',
+        'local_registrant_name',
+        'registrant_id_type',
+        'registrant_id',
+        'eligibility_type',
+        'eligibility_valid',
+        'eligibility_last_check',
+        'expiry_date',
+        'auto_renew',
+        'renewal_required',
+        'can_renew',
+        'registrar',
+        'latest_compliance_check_date',
+        'latest_compliance_check_result',
+        'latest_compliance_check_reason',
+        'open_compliance_alert_state',
+        'open_compliance_alert_triggered_at',
+    ];
+
+    /**
+     * @param  array<int, array{domain: string, reason: string|null}>  $synergyFailures
+     * @return array{generated_at: string, total_failing_domains: int, matched_local_domains: int, unmatched_synergy_domains: int, rows: array<int, array<string, string>>}
+     */
+    public function build(array $synergyFailures, ?Carbon $generatedAt = null): array
+    {
+        $generatedAt ??= now();
+        $failuresByDomain = $this->normaliseSynergyFailures($synergyFailures);
+        $domains = $this->localDomains(array_keys($failuresByDomain));
+
+        $rows = [];
+        foreach ($failuresByDomain as $domainName => $reason) {
+            $domain = $domains->get($domainName);
+            $rows[] = $this->row($domainName, $reason, $domain);
+        }
+
+        return [
+            'generated_at' => $generatedAt->toIso8601String(),
+            'total_failing_domains' => count($rows),
+            'matched_local_domains' => collect($rows)->where('local_record_status', 'matched')->count(),
+            'unmatched_synergy_domains' => collect($rows)->where('local_record_status', 'not in local domain table')->count(),
+            'rows' => $rows,
+        ];
+    }
+
+    /**
+     * @param  array{generated_at: string, total_failing_domains: int, matched_local_domains: int, unmatched_synergy_domains: int, rows: array<int, array<string, string>>}  $report
+     * @return array{markdown: string, csv: string}
+     */
+    public function render(array $report): array
+    {
+        return [
+            'markdown' => $this->renderMarkdown($report),
+            'csv' => $this->renderCsv($report['rows']),
+        ];
+    }
+
+    /**
+     * @param  array{generated_at: string, total_failing_domains: int, matched_local_domains: int, unmatched_synergy_domains: int, rows: array<int, array<string, string>>}  $report
+     * @return array{markdown: string, csv: string}
+     */
+    public function write(array $report, string $outputDirectory): array
+    {
+        if (! is_dir($outputDirectory)) {
+            mkdir($outputDirectory, 0755, true);
+        }
+
+        $safeTimestamp = Carbon::parse($report['generated_at'])->format('Ymd-His');
+        $paths = [
+            'markdown' => rtrim($outputDirectory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR."au-compliance-failures-{$safeTimestamp}.md",
+            'csv' => rtrim($outputDirectory, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR."au-compliance-failures-{$safeTimestamp}.csv",
+        ];
+
+        $rendered = $this->render($report);
+
+        file_put_contents($paths['markdown'], $rendered['markdown']);
+        file_put_contents($paths['csv'], $rendered['csv']);
+
+        return $paths;
+    }
+
+    /**
+     * @param  array<int, array{domain: string, reason: string|null}>  $synergyFailures
+     * @return array<string, string>
+     */
+    private function normaliseSynergyFailures(array $synergyFailures): array
+    {
+        $failures = [];
+
+        foreach ($synergyFailures as $failure) {
+            $domain = strtolower(trim($failure['domain']));
+
+            if ($domain === '') {
+                continue;
+            }
+
+            $failures[$domain] = trim((string) ($failure['reason'] ?? '')) ?: 'No Synergy failure reason supplied';
+        }
+
+        ksort($failures);
+
+        return $failures;
+    }
+
+    /**
+     * @param  array<int, string>  $domainNames
+     * @return Collection<string, Domain>
+     */
+    private function localDomains(array $domainNames): Collection
+    {
+        if ($domainNames === []) {
+            return collect();
+        }
+
+        return Domain::query()
+            ->with([
+                'alerts' => fn ($query) => $query
+                    ->where('alert_type', 'compliance_issue')
+                    ->whereNull('resolved_at')
+                    ->latest('triggered_at'),
+                'complianceChecks',
+            ])
+            ->whereIn('domain', $domainNames)
+            ->get()
+            ->keyBy(fn (Domain $domain): string => strtolower($domain->domain));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(string $domainName, string $reason, ?Domain $domain): array
+    {
+        $latestCheck = $domain?->complianceChecks->first();
+        $openAlert = $domain?->alerts->first();
+
+        return [
+            'domain' => $domainName,
+            'synergy_failure_reason' => $reason,
+            'local_record_status' => $domain ? 'matched' : 'not in local domain table',
+            'manual_workflow_status' => $domain ? self::STATUS_NEEDS_REVIEW : self::STATUS_NEEDS_OLD_ENTITY_LOOKUP,
+            'local_registrant_name' => $this->nullableString($domain?->registrant_name),
+            'registrant_id_type' => $this->nullableString($domain?->registrant_id_type),
+            'registrant_id' => $this->nullableString($domain?->registrant_id),
+            'eligibility_type' => $this->nullableString($domain?->eligibility_type),
+            'eligibility_valid' => $this->nullableBool($domain?->eligibility_valid),
+            'eligibility_last_check' => $domain?->eligibility_last_check?->toDateString() ?? '',
+            'expiry_date' => $domain?->expires_at?->toDateString() ?? '',
+            'auto_renew' => $this->nullableBool($domain?->auto_renew),
+            'renewal_required' => $this->nullableBool($domain?->renewal_required),
+            'can_renew' => $this->nullableBool($domain?->can_renew),
+            'registrar' => $this->nullableString($domain?->registrar),
+            'latest_compliance_check_date' => $latestCheck instanceof DomainComplianceCheck ? $latestCheck->checked_at->toIso8601String() : '',
+            'latest_compliance_check_result' => $latestCheck instanceof DomainComplianceCheck ? ($latestCheck->is_compliant ? 'compliant' : 'non-compliant') : '',
+            'latest_compliance_check_reason' => $latestCheck instanceof DomainComplianceCheck ? $this->nullableString($latestCheck->compliance_reason) : '',
+            'open_compliance_alert_state' => $openAlert instanceof DomainAlert ? 'open '.$openAlert->severity : 'none',
+            'open_compliance_alert_triggered_at' => $openAlert instanceof DomainAlert ? $openAlert->triggered_at->toIso8601String() : '',
+        ];
+    }
+
+    private function nullableString(?string $value): string
+    {
+        return $value ?? '';
+    }
+
+    private function nullableBool(?bool $value): string
+    {
+        return match ($value) {
+            true => 'yes',
+            false => 'no',
+            null => '',
+        };
+    }
+
+    /**
+     * @param  array{generated_at: string, total_failing_domains: int, matched_local_domains: int, unmatched_synergy_domains: int, rows: array<int, array<string, string>>}  $report
+     */
+    private function renderMarkdown(array $report): string
+    {
+        $lines = [
+            '# .au Compliance Failure Report',
+            '',
+            '## Summary',
+            '',
+            '- Generated at: '.$report['generated_at'],
+            '- Total failing domains: '.$report['total_failing_domains'],
+            '- Matched local domains: '.$report['matched_local_domains'],
+            '- Unmatched Synergy domains: '.$report['unmatched_synergy_domains'],
+            '',
+            '## Recommended Next Actions',
+            '',
+            '- Review each failing domain before preparing any COR or evidence pack.',
+            '- Look up the old registrant ABN, ACN, or business-name basis where the report is incomplete.',
+            '- Select a current eligible entity and prepare the COR evidence pack outside Domain Monitor.',
+            '- Submit any COR manually in Synergy Wholesale; this report does not change Synergy, DNS, renewal, or registrant records.',
+            '',
+            '## Workflow Status Values',
+            '',
+            implode(', ', self::WORKFLOW_STATUSES),
+            '',
+            '## Failing Domains',
+            '',
+        ];
+
+        $lines[] = '| '.implode(' | ', self::HEADERS).' |';
+        $lines[] = '| '.implode(' | ', array_fill(0, count(self::HEADERS), '---')).' |';
+
+        foreach ($report['rows'] as $row) {
+            $lines[] = '| '.implode(' | ', array_map(fn (string $header): string => $this->markdownCell($row[$header] ?? ''), self::HEADERS)).' |';
+        }
+
+        return implode(PHP_EOL, $lines).PHP_EOL;
+    }
+
+    /**
+     * @param  array<int, array<string, string>>  $rows
+     */
+    private function renderCsv(array $rows): string
+    {
+        $handle = fopen('php://temp', 'r+');
+
+        if ($handle === false) {
+            return '';
+        }
+
+        fputcsv($handle, self::HEADERS);
+
+        foreach ($rows as $row) {
+            fputcsv($handle, array_map(fn (string $header): string => $row[$header] ?? '', self::HEADERS));
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle);
+        fclose($handle);
+
+        return $csv === false ? '' : $csv;
+    }
+
+    private function markdownCell(string $value): string
+    {
+        return str_replace(["\n", '|'], [' ', '\\|'], $value);
+    }
+}

--- a/docs/AU-COMPLIANCE-FAILURE-REPORT.md
+++ b/docs/AU-COMPLIANCE-FAILURE-REPORT.md
@@ -1,0 +1,55 @@
+# .au Compliance Failure Report
+
+Domain Monitor can generate a read-only work queue for current Synergy Wholesale `.au` eligibility/compliance failures.
+
+Run a dry summary without writing files:
+
+```bash
+php artisan domains:report-au-compliance-failures --dry-run
+```
+
+Write Markdown and CSV artifacts to the default business-vault reports folder:
+
+```bash
+php artisan domains:report-au-compliance-failures
+```
+
+Default output directory:
+
+```text
+/Users/jasonhill/Projects/Business/vault/domains/compliance/reports
+```
+
+Write to a caller-provided directory:
+
+```bash
+php artisan domains:report-au-compliance-failures --output-dir=/path/to/reports
+```
+
+The command uses Synergy Wholesale `listAuNonCompliantDomains` through `SynergyWholesaleClient::listNonCompliantAuDomains()` as current Synergy truth, then enriches matching local `Domain` records with registrant, eligibility, expiry, renewal, registrar, latest compliance-check, and open compliance-alert state.
+
+Rows where Synergy reports a failing domain that does not exist locally are still included with `local_record_status` set to `not in local domain table`.
+
+Manual workflow status values are:
+
+```text
+needs review
+needs old entity lookup
+needs current eligible entity selected
+cor draft needed
+cor ready for synergy
+submitted in synergy
+resolved
+parked for later
+```
+
+Use the generated Markdown/CSV as the business-vault COR remediation queue. The operator workflow is:
+
+1. Review each failing domain and Synergy failure reason.
+2. Look up the old registrant ABN, ACN, or business-name basis where needed.
+3. Select the current eligible entity outside Domain Monitor.
+4. Prepare the COR/evidence pack in the business vault.
+5. Submit the change manually in Synergy Wholesale.
+6. Re-run the report after Synergy and Domain Monitor compliance checks refresh.
+
+The command does not expose Synergy API credentials and does not perform COR, DNS, renewal, registrant-update, Domain Monitor mutation, or Synergy mutation actions.

--- a/tests/Feature/AuComplianceFailureReportCommandTest.php
+++ b/tests/Feature/AuComplianceFailureReportCommandTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Domain;
+use App\Models\DomainAlert;
+use App\Models\DomainComplianceCheck;
+use App\Models\SynergyCredential;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Mockery;
+use Tests\TestCase;
+
+class AuComplianceFailureReportCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->reportDirectory());
+
+        parent::tearDown();
+    }
+
+    public function test_it_generates_markdown_and_csv_reports_for_current_synergy_failures(): void
+    {
+        $credential = SynergyCredential::factory()->create(['is_active' => true]);
+        $domain = Domain::factory()->create([
+            'domain' => 'example.com.au',
+            'registrar' => 'Synergy Wholesale',
+            'expires_at' => '2026-08-14',
+            'auto_renew' => true,
+            'registrant_name' => 'Old Example Pty Ltd',
+            'registrant_id_type' => 'ABN',
+            'registrant_id' => '12345678901',
+            'eligibility_type' => 'Company',
+            'eligibility_valid' => false,
+            'eligibility_last_check' => '2026-05-19',
+            'renewal_required' => true,
+            'can_renew' => false,
+        ]);
+
+        DomainComplianceCheck::query()->create([
+            'domain_id' => $domain->id,
+            'is_compliant' => false,
+            'compliance_reason' => 'Registrant ABN is no longer eligible',
+            'source' => 'synergy',
+            'checked_at' => now()->subHour(),
+            'payload' => ['source' => 'test'],
+        ]);
+
+        DomainAlert::factory()->create([
+            'domain_id' => $domain->id,
+            'alert_type' => 'compliance_issue',
+            'severity' => 'critical',
+            'triggered_at' => now()->subMinutes(30),
+            'resolved_at' => null,
+        ]);
+
+        $this->mockSynergyClient($credential, [
+            ['domain' => 'example.com.au', 'reason' => 'Synergy says registrant eligibility failed'],
+        ]);
+
+        $this->artisan('domains:report-au-compliance-failures', [
+            '--output-dir' => $this->reportDirectory(),
+        ])->assertSuccessful();
+
+        $markdown = $this->singleReportContents('md');
+        $csv = $this->singleReportContents('csv');
+
+        $this->assertStringContainsString('Total failing domains: 1', $markdown);
+        $this->assertStringContainsString('Matched local domains: 1', $markdown);
+        $this->assertStringContainsString('example.com.au', $markdown);
+        $this->assertStringContainsString('Synergy says registrant eligibility failed', $markdown);
+        $this->assertStringContainsString('Old Example Pty Ltd', $markdown);
+        $this->assertStringContainsString('needs review', $markdown);
+        $this->assertStringContainsString('open critical', $markdown);
+        $this->assertStringContainsString('domain,synergy_failure_reason,local_record_status,manual_workflow_status', $csv);
+        $this->assertStringContainsString('example.com.au', $csv);
+    }
+
+    public function test_it_includes_synergy_failures_missing_from_the_local_domain_table(): void
+    {
+        $credential = SynergyCredential::factory()->create(['is_active' => true]);
+
+        $this->mockSynergyClient($credential, [
+            ['domain' => 'missing.com.au', 'reason' => 'No matching registrant evidence'],
+        ]);
+
+        $this->artisan('domains:report-au-compliance-failures', [
+            '--output-dir' => $this->reportDirectory(),
+        ])->assertSuccessful();
+
+        $markdown = $this->singleReportContents('md');
+
+        $this->assertStringContainsString('Unmatched Synergy domains: 1', $markdown);
+        $this->assertStringContainsString('missing.com.au', $markdown);
+        $this->assertStringContainsString('not in local domain table', $markdown);
+        $this->assertStringContainsString('needs old entity lookup', $markdown);
+    }
+
+    public function test_it_generates_empty_reports_when_synergy_has_no_failures(): void
+    {
+        $credential = SynergyCredential::factory()->create(['is_active' => true]);
+
+        $this->mockSynergyClient($credential, []);
+
+        $this->artisan('domains:report-au-compliance-failures', [
+            '--output-dir' => $this->reportDirectory(),
+        ])->assertSuccessful();
+
+        $markdown = $this->singleReportContents('md');
+        $csv = $this->singleReportContents('csv');
+
+        $this->assertStringContainsString('Total failing domains: 0', $markdown);
+        $this->assertStringContainsString('Matched local domains: 0', $markdown);
+        $this->assertStringContainsString('Unmatched Synergy domains: 0', $markdown);
+        $this->assertStringContainsString('domain,synergy_failure_reason,local_record_status,manual_workflow_status', $csv);
+    }
+
+    public function test_it_reports_synergy_api_failures_without_writing_report_files(): void
+    {
+        $credential = SynergyCredential::factory()->create(['is_active' => true]);
+
+        $this->mockSynergyClient($credential, null);
+
+        $this->artisan('domains:report-au-compliance-failures', [
+            '--output-dir' => $this->reportDirectory(),
+        ])->assertFailed()
+            ->expectsOutputToContain('Unable to retrieve non-compliant .au domains from Synergy Wholesale.');
+
+        $this->assertDirectoryDoesNotExist($this->reportDirectory());
+    }
+
+    public function test_dry_run_does_not_write_report_files(): void
+    {
+        $credential = SynergyCredential::factory()->create(['is_active' => true]);
+
+        $this->mockSynergyClient($credential, [
+            ['domain' => 'example.com.au', 'reason' => 'Synergy says registrant eligibility failed'],
+        ]);
+
+        $this->artisan('domains:report-au-compliance-failures', [
+            '--output-dir' => $this->reportDirectory(),
+            '--dry-run' => true,
+        ])->assertSuccessful()
+            ->expectsOutputToContain('Dry run only: no report files were written');
+
+        $this->assertDirectoryDoesNotExist($this->reportDirectory());
+    }
+
+    /**
+     * @param  array<int, array{domain: string, reason: string|null}>|null  $failures
+     */
+    private function mockSynergyClient(SynergyCredential $credential, ?array $failures): void
+    {
+        $synergyAlias = Mockery::mock('alias:App\Services\SynergyWholesaleClient');
+        $synergyClient = Mockery::mock();
+
+        $synergyAlias->shouldReceive('fromEncryptedCredentials')
+            ->with($credential->reseller_id, $credential->api_key_encrypted, $credential->api_url)
+            ->andReturn($synergyClient);
+
+        $synergyClient->shouldReceive('listNonCompliantAuDomains')
+            ->once()
+            ->andReturn($failures);
+    }
+
+    private function reportDirectory(): string
+    {
+        return storage_path('framework/testing/au-compliance-report');
+    }
+
+    private function singleReportContents(string $extension): string
+    {
+        $files = File::glob($this->reportDirectory()."/*.{$extension}");
+
+        $this->assertCount(1, $files);
+
+        return (string) file_get_contents($files[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add read-only `domains:report-au-compliance-failures` Artisan command for current Synergy .au compliance failures
- Generate Markdown and CSV work-queue artifacts with local registrant, eligibility, renewal, compliance-check, and open-alert context
- Document the business-vault COR remediation workflow and add focused command tests

## Scope
- Read-only report/export for issue #236
- No COR, DNS, renewal, registrant, Domain Monitor data, or Synergy mutations

## Verification
- `vendor/bin/pint --dirty`
- `./vendor/bin/phpstan analyse app/Services/AuComplianceFailureReport.php --memory-limit=2G --no-progress`
- `php artisan test tests/Feature/AuComplianceFailureReportCommandTest.php`
- `php artisan domains:report-au-compliance-failures --dry-run` failed cleanly in this workspace because Synergy retrieval was unavailable; no files were written and credentials were not logged

Closes #236