### PR TITLE
Seed Discount Backloading authoritative brand surface

### DIFF
--- a/app/Services/PublishedBrandSurfaceFeedBuilder.php
+++ b/app/Services/PublishedBrandSurfaceFeedBuilder.php
@@ -22,6 +22,7 @@ class PublishedBrandSurfaceFeedBuilder
      *   generated_by: string,
      *   notes: array<int, string>,
      *   pilot: array{host_allowlist: array<int, string>, scope: string},
+     *   authoritative: array{host_allowlist: array<int, string>, owning_marketing_domains: array<int, string>, scope: string},
      *   surfaces: array<int, array<string, mixed>>
      * }
      */
@@ -29,6 +30,7 @@ class PublishedBrandSurfaceFeedBuilder
     {
         $publishedAt = now();
         $allowlist = $this->pilotHostAllowlist();
+        $authoritativeHostnames = $this->authoritativeHostAllowlist($allowlist);
         $requestedHostname = $this->normalizeHostname($hostname);
         $hostnames = $requestedHostname === null
             ? $allowlist
@@ -48,6 +50,11 @@ class PublishedBrandSurfaceFeedBuilder
                 'host_allowlist' => $allowlist,
                 'scope' => 'moveroo_v1_pilot',
             ],
+            'authoritative' => [
+                'host_allowlist' => $authoritativeHostnames,
+                'owning_marketing_domains' => $this->authoritativeMarketingDomains($authoritativeHostnames),
+                'scope' => 'moveroo_v1_authoritative_seed',
+            ],
             'surfaces' => $this->surfacesForHostnames($hostnames),
         ];
     }
@@ -65,6 +72,45 @@ class PublishedBrandSurfaceFeedBuilder
 
         return collect($allowlist)
             ->map(fn (mixed $hostname): ?string => $this->normalizeHostname($hostname))
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, string>  $pilotHostnames
+     * @return array<int, string>
+     */
+    private function authoritativeHostAllowlist(array $pilotHostnames): array
+    {
+        $authoritativeHostnames = config('domain_monitor.published_brand_surfaces.authoritative_host_allowlist', []);
+
+        if (! is_array($authoritativeHostnames)) {
+            return [];
+        }
+
+        return collect($authoritativeHostnames)
+            ->map(fn (mixed $hostname): ?string => $this->normalizeHostname($hostname))
+            ->filter()
+            ->filter(fn (string $hostname): bool => in_array($hostname, $pilotHostnames, true))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<int, string>  $authoritativeHostnames
+     * @return array<int, string>
+     */
+    private function authoritativeMarketingDomains(array $authoritativeHostnames): array
+    {
+        return collect($authoritativeHostnames)
+            ->map(function (string $hostname): ?string {
+                $marketingDomain = $this->metadataForHostname($hostname)['owning_marketing_domain'] ?? null;
+
+                return $this->normalizeHostname($marketingDomain);
+            })
             ->filter()
             ->unique()
             ->values()
@@ -148,7 +194,7 @@ class PublishedBrandSurfaceFeedBuilder
         $updatedAt = $surface->verified_at ?? $property->updated_at ?? now();
         $journeyType = $surface->journey_type;
 
-        return $this->withBrandStyleSource($hostname, [
+        return $this->withBrandStyleSource($hostname, $this->withAuthority($hostname, $metadata, [
             'hostname' => $hostname,
             'property_slug' => $property->slug,
             'surface_slug' => $metadata['surface_slug'] ?? $this->defaultSurfaceSlug($property, $hostname),
@@ -171,7 +217,7 @@ class PublishedBrandSurfaceFeedBuilder
             'contact' => $this->contact($metadata),
             'analytics' => $this->analytics($property, $hostname, $journeyType, $analyticsSource, $eventAssignment),
             'provenance' => $this->provenance($metadata),
-        ]);
+        ]));
     }
 
     /**
@@ -191,7 +237,7 @@ class PublishedBrandSurfaceFeedBuilder
         $updatedAt = $property->updated_at ?? now();
         $journeyType = 'mixed_quote';
 
-        return $this->withBrandStyleSource($hostname, [
+        return $this->withBrandStyleSource($hostname, $this->withAuthority($hostname, $metadata, [
             'hostname' => $hostname,
             'property_slug' => $property->slug,
             'surface_slug' => $metadata['surface_slug'] ?? $this->defaultSurfaceSlug($property, $hostname),
@@ -214,7 +260,7 @@ class PublishedBrandSurfaceFeedBuilder
             'contact' => $this->contact($metadata),
             'analytics' => $this->analytics($property, $hostname, $journeyType, $analyticsSource, $eventAssignment),
             'provenance' => $this->provenance($metadata),
-        ]);
+        ]));
     }
 
     /**
@@ -272,7 +318,7 @@ class PublishedBrandSurfaceFeedBuilder
         $updatedAt = $property->updated_at ?? now();
         $journeyType = is_string($metadata['journey_type'] ?? null) ? $metadata['journey_type'] : null;
 
-        return $this->withBrandStyleSource($hostname, [
+        return $this->withBrandStyleSource($hostname, $this->withAuthority($hostname, $metadata, [
             'hostname' => $hostname,
             'property_slug' => $property->slug,
             'surface_slug' => $metadata['surface_slug'] ?? $this->defaultSurfaceSlug($property, $hostname),
@@ -295,7 +341,7 @@ class PublishedBrandSurfaceFeedBuilder
             'contact' => $this->contact($metadata),
             'analytics' => $this->analytics($property, $hostname, $journeyType, $analyticsSource, $eventAssignment),
             'provenance' => $this->provenance($metadata),
-        ]);
+        ]));
     }
 
     /**
@@ -480,6 +526,42 @@ class PublishedBrandSurfaceFeedBuilder
             'allow_provider_login_links' => false,
             'allow_admin_links' => false,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @return array<string, string>|null
+     */
+    private function authority(string $hostname, array $metadata): ?array
+    {
+        if (! in_array($hostname, $this->authoritativeHostAllowlist($this->pilotHostAllowlist()), true)) {
+            return null;
+        }
+
+        return [
+            'mode' => 'authoritative',
+            'owning_marketing_domain' => (string) ($metadata['owning_marketing_domain'] ?? ''),
+            'runtime_renderer_owner' => 'MoverooCombined',
+            'fallback_policy' => 'strict_no_local_brand_fallback',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     * @param  array<string, mixed>  $surface
+     * @return array<string, mixed>
+     */
+    private function withAuthority(string $hostname, array $metadata, array $surface): array
+    {
+        $authority = $this->authority($hostname, $metadata);
+
+        if ($authority === null) {
+            return $surface;
+        }
+
+        return array_merge($surface, [
+            'authority' => $authority,
+        ]);
     }
 
     /**

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -164,6 +164,9 @@ return [
             'moving.allianceremovals.com.au',
             'quoteandbook.mover.com.au',
         ],
+        'authoritative_host_allowlist' => [
+            'mymoveportal.discountbackloading.com.au',
+        ],
         'classified_runtime_hostnames' => [
             'acraustralia.com' => [
                 'classification' => 'non_moveroocombined',

--- a/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
+++ b/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
@@ -32,11 +32,14 @@ Required fields:
 - `published_at`: ISO-8601 publication timestamp
 - `generated_by`: publisher identity
 - `pilot.host_allowlist`: explicit pilot hostname allowlist
+- `authoritative.host_allowlist`: explicit subset of pilot hosts Domain Monitor is prepared to be authoritative for
 - `surfaces`: published surface objects
 
 ## Pilot Scope
 
 The publisher only emits hostnames listed in `domain_monitor.published_brand_surfaces.pilot_host_allowlist`.
+
+The publisher may also mark a smaller authoritative subset in `domain_monitor.published_brand_surfaces.authoritative_host_allowlist`. Authoritative hostnames must also be present in the pilot allowlist; this field is a consumer signal only and does not widen the export.
 
 Current pilot hostnames:
 
@@ -108,6 +111,10 @@ Final runtime closeout classification:
 - Classifications cover marketing apexes, aliases, retired Moveroo subdomains, legacy vehicle/runtime hosts, personal/non-business hosts, redirect utilities, and non-MoverooCombined hosts.
 - This closes the Domain Monitor publisher side of the runtime-only list without changing MoverooCombined code, live websites, DNS, redirects, cron, secrets, or deployment settings.
 
+Authoritative seed:
+
+- `mymoveportal.discountbackloading.com.au`: first authoritative app-served surface for the `discountbackloading.com.au` marketing domain. Domain Monitor publishes the concrete quote, booking, contact, brand, theme, ownership, and analytics metadata before MoverooCombined treats the host as authoritative.
+
 `quoting.vehicle.net.au` is legacy quoting and is not the active #2084 pilot test host. Discount Backloading is the selected pilot because Domain Monitor production records the current property-specific quote portal and target links:
 
 - production URL: `https://discountbackloading.com.au`
@@ -128,6 +135,7 @@ Each surface includes:
 - public contact links: `contact`
 - parent/canonical relationship: `owning_marketing_domain`, `controller_owner`, `controller_repo`
 - ownership metadata: `ownership.published_truth_owner`, `ownership.runtime_renderer_owner`, `ownership.site_repo_owner`, `ownership.portfolio_routing_owner`
+- authority metadata: optional `authority` is present only for the current authoritative subset
 - telemetry linkage: `analytics.status`, `analytics.runtime_context_key`, `analytics.property_slug`, `analytics.site_key`, `analytics.journey_type`, optional GA4 and event-contract mirrors
 - approved brand-style source metadata: optional `brand_style_source` is present only when a draft proposal has been explicitly approved
 - non-sensitive provenance: `provenance.approved_by`, `provenance.approved_at`, `provenance.source`, `provenance.change_ref`
@@ -139,7 +147,8 @@ Each surface includes:
 - No redirect policy decisions from #210.
 - Hostnames outside the pilot allowlist are intentionally omitted, even when present in Domain Monitor data.
 - Brand-style drafts are never published merely because extraction or reviewed metadata exists; only `approval_status=approved` proposals can annotate the published feed.
-- Consumers must validate again before rendering and keep local fallback behavior during the pilot.
+- Consumers must validate again before rendering; local fallback behavior remains for non-authoritative pilot hostnames.
+- Consumers must not treat authoritative hostnames as permission to broaden beyond the listed hostnames or owning marketing domains.
 
 ## Fixtures
 

--- a/docs/fixtures/published-brand-surfaces/discountbackloading-quote.json
+++ b/docs/fixtures/published-brand-surfaces/discountbackloading-quote.json
@@ -8,6 +8,11 @@
     "host_allowlist": ["mymoveportal.discountbackloading.com.au"],
     "scope": "moveroo_v1_pilot"
   },
+  "authoritative": {
+    "host_allowlist": ["mymoveportal.discountbackloading.com.au"],
+    "owning_marketing_domains": ["discountbackloading.com.au"],
+    "scope": "moveroo_v1_authoritative_seed"
+  },
   "surfaces": [
     {
       "hostname": "mymoveportal.discountbackloading.com.au",
@@ -83,6 +88,12 @@
         "journey_type": "mixed_quote",
         "ga4": {"measurement_id": "G-DISCOUNT01"},
         "event_contract": {"key": "discountbackloading-full-funnel-v1", "version": "v1", "rollout_status": "instrumented"}
+      },
+      "authority": {
+        "mode": "authoritative",
+        "owning_marketing_domain": "discountbackloading.com.au",
+        "runtime_renderer_owner": "MoverooCombined",
+        "fallback_policy": "strict_no_local_brand_fallback"
       },
       "provenance": {
         "approved_by": "domain-monitor",

--- a/tests/Feature/PublishedBrandSurfaceApiTest.php
+++ b/tests/Feature/PublishedBrandSurfaceApiTest.php
@@ -110,6 +110,9 @@ class PublishedBrandSurfaceApiTest extends TestCase
             ->assertJsonPath('pilot.host_allowlist.2', 'quotes.interstate-removals.com.au')
             ->assertJsonPath('pilot.host_allowlist.3', 'quoting.movingcars.com.au')
             ->assertJsonPath('pilot.host_allowlist.4', 'portal.supercheapcartransport.com.au')
+            ->assertJsonPath('authoritative.scope', 'moveroo_v1_authoritative_seed')
+            ->assertJsonPath('authoritative.host_allowlist.0', 'mymoveportal.discountbackloading.com.au')
+            ->assertJsonPath('authoritative.owning_marketing_domains.0', 'discountbackloading.com.au')
             ->assertJsonPath('surfaces.0.hostname', 'quotes.moveroo.com.au')
             ->assertJsonPath('surfaces.0.property_slug', 'moveroo-com-au')
             ->assertJsonPath('surfaces.0.surface_slug', 'moveroo-quotes-household-v1')
@@ -141,6 +144,10 @@ class PublishedBrandSurfaceApiTest extends TestCase
             ->assertJsonPath('surfaces.1.links.vehicle_quote_url', 'https://mymoveportal.discountbackloading.com.au/quote/vehicle')
             ->assertJsonPath('surfaces.1.links.booking_url', 'https://mymoveportal.discountbackloading.com.au/booking/create')
             ->assertJsonPath('surfaces.1.links.contact_url', 'https://mymoveportal.discountbackloading.com.au/contact')
+            ->assertJsonPath('surfaces.1.authority.mode', 'authoritative')
+            ->assertJsonPath('surfaces.1.authority.owning_marketing_domain', 'discountbackloading.com.au')
+            ->assertJsonPath('surfaces.1.authority.runtime_renderer_owner', 'MoverooCombined')
+            ->assertJsonPath('surfaces.1.authority.fallback_policy', 'strict_no_local_brand_fallback')
             ->assertJsonMissingPath('surfaces.1.links.customer_portal_url')
             ->assertJsonPath('surfaces.2.hostname', 'quotes.interstate-removals.com.au')
             ->assertJsonPath('surfaces.2.property_slug', 'interstate-removals-com-au')
@@ -163,6 +170,10 @@ class PublishedBrandSurfaceApiTest extends TestCase
         config()->set('services.domain_monitor.moveroo_removals_api_key', 'moveroo-runtime-token');
         config()->set('domain_monitor.published_brand_surfaces.pilot_host_allowlist', [
             'quotes.moveroo.com.au',
+        ]);
+        config()->set('domain_monitor.published_brand_surfaces.authoritative_host_allowlist', [
+            'mymoveportal.discountbackloading.com.au',
+            'quotes.full-estate.com.au',
         ]);
 
         $this->createPilotSurface(
@@ -193,6 +204,8 @@ class PublishedBrandSurfaceApiTest extends TestCase
             'Authorization' => 'Bearer moveroo-runtime-token',
         ])->getJson('/api/published-brand-surfaces')
             ->assertOk()
+            ->assertJsonCount(0, 'authoritative.host_allowlist')
+            ->assertJsonCount(0, 'authoritative.owning_marketing_domains')
             ->assertJsonCount(1, 'surfaces')
             ->assertJsonPath('surfaces.0.hostname', 'quotes.moveroo.com.au');
 


### PR DESCRIPTION
## Summary
- add a Domain Monitor authoritative subset for the first Discount Backloading runtime host
- publish `authoritative` envelope metadata and per-surface `authority` metadata for `mymoveportal.discountbackloading.com.au`
- update the Published Brand Surfaces contract, Discount Backloading fixture, and API tests so MoverooCombined has concrete publisher truth before strict consumption work starts

## Scope
- Domain Monitor publisher side only
- `discountbackloading.com.au` marketing domain only, via app host `mymoveportal.discountbackloading.com.au`
- no MoverooCombined changes
- no DNS, redirects, cron, secrets, billing, or live website changes
- does not implement the full marketing-site style extractor from #223 yet

## Checks
- `jq empty docs/fixtures/published-brand-surfaces/discountbackloading-quote.json`
- `git diff --check`
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/PublishedBrandSurfaceApiTest.php`
- `composer pr:preflight --no-interaction` *(Pint and PHPStan passed; full PHPUnit hit existing unrelated baseline failures in command-runner path quoting and timezone timestamp expectations)*

Related to #223.
