### PR TITLE
Add Discount Backloading brand style extraction drafts

### DIFF
--- a/app/Console/Commands/ExtractBrandStyleSurfaceDraft.php
+++ b/app/Console/Commands/ExtractBrandStyleSurfaceDraft.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\BrandStyle\MarketingSiteStyleExtractor;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ExtractBrandStyleSurfaceDraft extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'brand-surfaces:extract-style-draft
+        {hostname : App-served hostname to draft style metadata for}
+        {--write : Write the draft JSON under storage/app/private/brand-style-drafts}
+        {--path= : Optional storage path when --write is used}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Extract a bounded review-only brand style draft from a marketing site.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(MarketingSiteStyleExtractor $extractor): int
+    {
+        $hostname = $this->normalizeHostname((string) $this->argument('hostname'));
+        $metadata = $this->metadataForHostname($hostname);
+
+        if ($metadata === []) {
+            $this->error("No published brand-surface metadata found for {$hostname}.");
+
+            return self::FAILURE;
+        }
+
+        $sourceMarketingDomain = $this->normalizeHostname((string) ($metadata['owning_marketing_domain'] ?? ''));
+
+        if ($sourceMarketingDomain === '') {
+            $this->error("No owning marketing domain configured for {$hostname}.");
+
+            return self::FAILURE;
+        }
+
+        $draft = $extractor->extract(
+            hostname: $hostname,
+            sourceMarketingDomain: $sourceMarketingDomain,
+            publishedMetadata: $metadata,
+        );
+
+        $encodedDraft = json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        $this->line($encodedDraft === false ? '{}' : $encodedDraft);
+
+        if ($draft['proposal_status'] === 'extraction_failed') {
+            return self::FAILURE;
+        }
+
+        if ((bool) $this->option('write')) {
+            $path = $this->writeDraft($hostname, $draft);
+            $this->info("Draft written to storage/app/private/{$path}");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function metadataForHostname(string $hostname): array
+    {
+        $hostnames = config('domain_monitor.published_brand_surfaces.hostnames', []);
+        $metadata = is_array($hostnames) ? ($hostnames[$hostname] ?? []) : [];
+
+        return is_array($metadata) ? $metadata : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $draft
+     */
+    private function writeDraft(string $hostname, array $draft): string
+    {
+        $pathOption = $this->option('path');
+        $path = is_string($pathOption) && trim($pathOption) !== ''
+            ? trim($pathOption)
+            : sprintf('brand-style-drafts/%s-%s.json', Str::slug($hostname), now()->utc()->format('Ymd-His'));
+
+        Storage::disk('local')->put($path, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        return $path;
+    }
+
+    private function normalizeHostname(string $hostname): string
+    {
+        return Str::of($hostname)
+            ->lower()
+            ->replaceStart('https://', '')
+            ->replaceStart('http://', '')
+            ->before('/')
+            ->trim('.')
+            ->toString();
+    }
+}

--- a/app/Services/BrandStyle/MarketingSiteStyleExtractor.php
+++ b/app/Services/BrandStyle/MarketingSiteStyleExtractor.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Services\BrandStyle;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class MarketingSiteStyleExtractor
+{
+    /**
+     * @param  array<string, mixed>  $publishedMetadata
+     * @return array<string, mixed>
+     */
+    public function extract(string $hostname, string $sourceMarketingDomain, array $publishedMetadata = []): array
+    {
+        $sourceUrl = 'https://'.$this->normalizeHostname($sourceMarketingDomain);
+        $response = Http::timeout(10)
+            ->accept('text/html')
+            ->get($sourceUrl);
+
+        if (! $response->successful()) {
+            return [
+                'hostname' => $hostname,
+                'source_marketing_domain' => $sourceMarketingDomain,
+                'proposal_status' => 'extraction_failed',
+                'approval_status' => 'blocked',
+                'review_reason' => sprintf('Marketing site returned HTTP %d during style extraction.', $response->status()),
+                'candidate' => [],
+                'evidence' => [],
+                'publish_gate' => [
+                    'can_publish' => false,
+                    'reason' => 'extraction_failed',
+                ],
+            ];
+        }
+
+        $html = $response->body();
+        $capturedAt = now()->toIso8601String();
+        $brand = $this->brandCandidate($html, $publishedMetadata);
+        $theme = $this->themeCandidate($html, $publishedMetadata);
+        $copy = $this->copyCandidate($html, $publishedMetadata);
+
+        return [
+            'hostname' => $hostname,
+            'source_marketing_domain' => $sourceMarketingDomain,
+            'property_slug' => $publishedMetadata['property_slug'] ?? null,
+            'surface_slug' => $publishedMetadata['surface_slug'] ?? null,
+            'journey_type' => $publishedMetadata['journey_type'] ?? null,
+            'proposal_status' => 'draft_review_required',
+            'approval_status' => 'needs_review',
+            'review_reason' => 'Marketing-site style extraction requires review before it can annotate the published surface.',
+            'candidate' => [
+                'brand' => $brand,
+                'theme' => $theme,
+                'copy' => $copy,
+            ],
+            'evidence' => $this->evidence($sourceUrl, $capturedAt, $brand, $theme, $copy),
+            'publish_gate' => [
+                'can_publish' => false,
+                'reason' => 'draft_requires_human_or_trusted_review',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $publishedMetadata
+     * @return array<string, mixed>
+     */
+    private function brandCandidate(string $html, array $publishedMetadata): array
+    {
+        $configuredBrand = is_array($publishedMetadata['brand'] ?? null) ? $publishedMetadata['brand'] : [];
+        $displayName = $this->metaContent($html, 'og:site_name')
+            ?? $this->title($html)
+            ?? ($configuredBrand['display_name'] ?? null);
+
+        return array_filter([
+            'display_name' => $displayName,
+            'brand_key' => $configuredBrand['brand_key'] ?? null,
+            'tagline' => $configuredBrand['tagline'] ?? null,
+            'mark_text' => $configuredBrand['mark_text'] ?? null,
+        ], fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $publishedMetadata
+     * @return array<string, mixed>
+     */
+    private function themeCandidate(string $html, array $publishedMetadata): array
+    {
+        $configuredTheme = is_array($publishedMetadata['theme'] ?? null) ? $publishedMetadata['theme'] : [];
+        $colors = $this->safeHexColors($html);
+        $fontFamily = $this->firstFontFamily($html);
+        $accent = array_key_exists(0, $colors) ? $colors[0] : null;
+        $accentStrong = array_key_exists(1, $colors) ? $colors[1] : null;
+
+        return [
+            'theme_key' => $configuredTheme['theme_key'] ?? null,
+            'mode' => 'auto',
+            'fonts' => array_filter([
+                'body_family' => $fontFamily,
+                'heading_family' => $fontFamily,
+            ]),
+            'colors' => array_filter([
+                'accent' => $accent,
+                'accent_strong' => $accentStrong,
+            ]),
+            'exact_tokens' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $publishedMetadata
+     * @return array<string, mixed>
+     */
+    private function copyCandidate(string $html, array $publishedMetadata): array
+    {
+        $configuredCopy = is_array($publishedMetadata['copy'] ?? null) ? $publishedMetadata['copy'] : [];
+
+        return array_filter([
+            'headline' => $this->heading($html) ?? ($configuredCopy['headline'] ?? null),
+            'subheading' => $this->metaContent($html, 'description') ?? ($configuredCopy['subheading'] ?? null),
+        ], fn (mixed $value): bool => $value !== null && $value !== '');
+    }
+
+    /**
+     * @param  array<string, mixed>  $brand
+     * @param  array<string, mixed>  $theme
+     * @param  array<string, mixed>  $copy
+     * @return array<int, array<string, mixed>>
+     */
+    private function evidence(string $sourceUrl, string $capturedAt, array $brand, array $theme, array $copy): array
+    {
+        return collect([
+            ['field' => 'brand.display_name', 'value' => $brand['display_name'] ?? null],
+            ['field' => 'theme.fonts.body_family', 'value' => $theme['fonts']['body_family'] ?? null],
+            ['field' => 'theme.colors.accent', 'value' => $theme['colors']['accent'] ?? null],
+            ['field' => 'copy.headline', 'value' => $copy['headline'] ?? null],
+            ['field' => 'copy.subheading', 'value' => $copy['subheading'] ?? null],
+        ])
+            ->filter(fn (array $item): bool => $item['value'] !== null && $item['value'] !== '')
+            ->map(fn (array $item): array => [
+                'field' => $item['field'],
+                'value' => $item['value'],
+                'source_url' => $sourceUrl,
+                'source_type' => 'marketing_site_extraction',
+                'confidence' => 'medium',
+                'captured_at' => $capturedAt,
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function safeHexColors(string $html): array
+    {
+        preg_match_all('/#[0-9a-fA-F]{6}\b/', $html, $matches);
+
+        $colors = collect($matches[0])
+            ->map(fn (string $color): string => Str::lower($color))
+            ->reject(fn (string $color): bool => in_array($color, ['#000000', '#ffffff'], true))
+            ->unique()
+            ->values();
+
+        return array_values($colors
+            ->take(2)
+            ->all());
+    }
+
+    private function firstFontFamily(string $html): ?string
+    {
+        if (! preg_match('/font-family\s*:\s*([^;}]+)/i', $html, $matches)) {
+            return null;
+        }
+
+        $family = trim((string) Str::of($matches[1])->before(',')->trim(" \t\n\r\0\x0B'\""));
+
+        return preg_match('/^[A-Za-z0-9 -]{1,60}$/', $family) === 1 ? $family : null;
+    }
+
+    private function metaContent(string $html, string $name): ?string
+    {
+        $quotedName = preg_quote($name, '/');
+
+        foreach ([
+            '/<meta[^>]+(?:name|property)=["\']'.$quotedName.'["\'][^>]+content=["\']([^"\']+)["\'][^>]*>/i',
+            '/<meta[^>]+content=["\']([^"\']+)["\'][^>]+(?:name|property)=["\']'.$quotedName.'["\'][^>]*>/i',
+        ] as $pattern) {
+            if (preg_match($pattern, $html, $matches)) {
+                return $this->cleanText($matches[1]);
+            }
+        }
+
+        return null;
+    }
+
+    private function title(string $html): ?string
+    {
+        if (! preg_match('/<title[^>]*>(.*?)<\/title>/is', $html, $matches)) {
+            return null;
+        }
+
+        return $this->cleanText($matches[1]);
+    }
+
+    private function heading(string $html): ?string
+    {
+        if (! preg_match('/<h1[^>]*>(.*?)<\/h1>/is', $html, $matches)) {
+            return null;
+        }
+
+        return $this->cleanText($matches[1]);
+    }
+
+    private function cleanText(string $text): ?string
+    {
+        $cleaned = trim(html_entity_decode(strip_tags($text), ENT_QUOTES | ENT_HTML5));
+
+        return $cleaned === '' ? null : Str::limit($cleaned, 180, '');
+    }
+
+    private function normalizeHostname(string $hostname): string
+    {
+        return Str::of($hostname)
+            ->lower()
+            ->replaceStart('https://', '')
+            ->replaceStart('http://', '')
+            ->before('/')
+            ->trim('.')
+            ->toString();
+    }
+}

--- a/app/Services/BrandStyleSurfaceDraftBuilder.php
+++ b/app/Services/BrandStyleSurfaceDraftBuilder.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class BrandStyleSurfaceDraftBuilder
@@ -58,15 +59,38 @@ class BrandStyleSurfaceDraftBuilder
     private function proposals(): array
     {
         $configuredProposals = config('domain_monitor.published_brand_surfaces.brand_style_proposals', []);
+        $storedProposals = $this->storedProposals();
 
         if (! is_array($configuredProposals)) {
-            return [];
+            $configuredProposals = [];
         }
 
-        return collect($configuredProposals)
+        return collect($storedProposals)
+            ->merge($configuredProposals)
             ->map(fn (mixed $proposal, mixed $hostname): ?array => $this->proposalRecord($hostname, $proposal))
             ->filter()
             ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function storedProposals(): array
+    {
+        return collect(Storage::disk('local')->files('brand-style-drafts'))
+            ->filter(fn (string $path): bool => Str::endsWith($path, '.json'))
+            ->mapWithKeys(function (string $path): array {
+                $proposal = json_decode((string) Storage::disk('local')->get($path), true);
+
+                if (! is_array($proposal)) {
+                    return [];
+                }
+
+                $hostname = $this->normalizeHostname($proposal['hostname'] ?? null);
+
+                return $hostname === null ? [] : [$hostname => $proposal];
+            })
             ->all();
     }
 
@@ -103,13 +127,7 @@ class BrandStyleSurfaceDraftBuilder
             'approved_by' => $approvalStatus === 'approved' ? ($proposal['approved_by'] ?? null) : null,
             'approved_at' => $approvalStatus === 'approved' ? ($proposal['approved_at'] ?? null) : null,
             'review_reason' => $proposal['review_reason'] ?? null,
-            'candidate' => [
-                'brand' => $proposal['brand'] ?? ($publishedMetadata['brand'] ?? []),
-                'theme' => $proposal['theme'] ?? ($publishedMetadata['theme'] ?? []),
-                'copy' => $proposal['copy'] ?? ($publishedMetadata['copy'] ?? []),
-                'contact' => $proposal['contact'] ?? ($publishedMetadata['contact'] ?? []),
-                'links' => $proposal['links'] ?? ($publishedMetadata['links'] ?? []),
-            ],
+            'candidate' => $this->candidate($proposal, $publishedMetadata),
             'evidence' => $this->evidence($proposal, $sourceDomain),
             'publish_gate' => [
                 'can_publish' => $approvalStatus === 'approved',
@@ -117,6 +135,24 @@ class BrandStyleSurfaceDraftBuilder
                     ? 'approved_brand_style_surface'
                     : 'draft_requires_human_or_trusted_review',
             ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $proposal
+     * @param  array<string, mixed>  $publishedMetadata
+     * @return array<string, mixed>
+     */
+    private function candidate(array $proposal, array $publishedMetadata): array
+    {
+        $candidate = is_array($proposal['candidate'] ?? null) ? $proposal['candidate'] : [];
+
+        return [
+            'brand' => $candidate['brand'] ?? ($proposal['brand'] ?? ($publishedMetadata['brand'] ?? [])),
+            'theme' => $candidate['theme'] ?? ($proposal['theme'] ?? ($publishedMetadata['theme'] ?? [])),
+            'copy' => $candidate['copy'] ?? ($proposal['copy'] ?? ($publishedMetadata['copy'] ?? [])),
+            'contact' => $candidate['contact'] ?? ($proposal['contact'] ?? ($publishedMetadata['contact'] ?? [])),
+            'links' => $candidate['links'] ?? ($proposal['links'] ?? ($publishedMetadata['links'] ?? [])),
         ];
     }
 

--- a/config/domain_monitor.php
+++ b/config/domain_monitor.php
@@ -737,8 +737,10 @@ return [
                 ],
             ],
             'mymoveportal.discountbackloading.com.au' => [
+                'property_slug' => 'discountbackloading-com-au',
                 'surface_slug' => 'discountbackloading-mymoveportal-quote-v1',
                 'surface_type' => 'quote',
+                'journey_type' => 'mixed_quote',
                 'canonical_role' => 'primary',
                 'owning_marketing_domain' => 'discountbackloading.com.au',
                 'brand' => [

--- a/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
+++ b/docs/PUBLISHED-BRAND-SURFACES-CONTRACT.md
@@ -22,6 +22,12 @@ Draft/review endpoint:
 
 This read-only feed exposes app-host to source-marketing-domain proposals, candidate brand/style facts, evidence, confidence, and approval status. Draft or `needs_review` proposals are review evidence only and must not be treated as published MoverooCombined runtime truth.
 
+Draft extraction command:
+
+`php artisan brand-surfaces:extract-style-draft {hostname} --write`
+
+This command resolves an app-served hostname to its configured owning marketing domain, fetches the marketing site HTML, extracts only bounded candidate fields, and writes a review-only JSON draft under `storage/app/private/brand-style-drafts`. The draft endpoint reads those stored draft artifacts, but the published endpoint only annotates surfaces after `approval_status=approved`.
+
 ## Envelope
 
 Required fields:
@@ -159,3 +165,4 @@ Example payload fixtures live in:
 - `docs/fixtures/published-brand-surfaces/second-pilot-batch.json`
 - `docs/fixtures/published-brand-surfaces/third-pilot-batch.json`
 - `docs/fixtures/published-brand-surfaces/final-runtime-closeout.json`
+- `docs/fixtures/published-brand-surfaces/discountbackloading-style-draft.json`

--- a/docs/fixtures/published-brand-surfaces/discountbackloading-style-draft.json
+++ b/docs/fixtures/published-brand-surfaces/discountbackloading-style-draft.json
@@ -1,0 +1,57 @@
+{
+  "hostname": "mymoveportal.discountbackloading.com.au",
+  "source_marketing_domain": "discountbackloading.com.au",
+  "property_slug": "discountbackloading-com-au",
+  "surface_slug": "discountbackloading-mymoveportal-quote-v1",
+  "journey_type": "mixed_quote",
+  "proposal_status": "draft_review_required",
+  "approval_status": "needs_review",
+  "review_reason": "Marketing-site style extraction requires review before it can annotate the published surface.",
+  "candidate": {
+    "brand": {
+      "display_name": "Discount Backloading",
+      "brand_key": "discountbackloading",
+      "tagline": "Backloading and moving quotes",
+      "mark_text": "DB"
+    },
+    "theme": {
+      "theme_key": "discountbackloading",
+      "mode": "auto",
+      "fonts": {
+        "body_family": "Montserrat",
+        "heading_family": "Montserrat"
+      },
+      "colors": {
+        "accent": "#f97316",
+        "accent_strong": "#7c2d12"
+      },
+      "exact_tokens": []
+    },
+    "copy": {
+      "headline": "Save on your interstate move",
+      "subheading": "Affordable backloading quotes across Australia."
+    }
+  },
+  "evidence": [
+    {
+      "field": "brand.display_name",
+      "value": "Discount Backloading",
+      "source_url": "https://discountbackloading.com.au",
+      "source_type": "marketing_site_extraction",
+      "confidence": "medium",
+      "captured_at": "2026-05-20T00:00:00+10:00"
+    },
+    {
+      "field": "theme.colors.accent",
+      "value": "#f97316",
+      "source_url": "https://discountbackloading.com.au",
+      "source_type": "marketing_site_extraction",
+      "confidence": "medium",
+      "captured_at": "2026-05-20T00:00:00+10:00"
+    }
+  ],
+  "publish_gate": {
+    "can_publish": false,
+    "reason": "draft_requires_human_or_trusted_review"
+  }
+}

--- a/tests/Feature/BrandStyleSurfaceExtractionCommandTest.php
+++ b/tests/Feature/BrandStyleSurfaceExtractionCommandTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class BrandStyleSurfaceExtractionCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_extracts_a_review_only_discount_backloading_style_draft(): void
+    {
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <head>
+                        <title>Discount Backloading</title>
+                        <meta name="description" content="Affordable backloading quotes across Australia.">
+                        <meta property="og:site_name" content="Discount Backloading">
+                        <style>
+                            :root { --brand-orange: #f97316; --brand-brown: #7c2d12; }
+                            body { font-family: "Montserrat", sans-serif; }
+                        </style>
+                    </head>
+                    <body>
+                        <h1>Save on your interstate move</h1>
+                    </body>
+                </html>
+                HTML, 200, ['Content-Type' => 'text/html']),
+        ]);
+
+        $this->assertSame(0, Artisan::call('brand-surfaces:extract-style-draft', [
+            'hostname' => 'mymoveportal.discountbackloading.com.au',
+        ]));
+
+        $output = Artisan::output();
+
+        $this->assertStringContainsString('"hostname": "mymoveportal.discountbackloading.com.au"', $output);
+        $this->assertStringContainsString('"source_marketing_domain": "discountbackloading.com.au"', $output);
+        $this->assertStringContainsString('"property_slug": "discountbackloading-com-au"', $output);
+        $this->assertStringContainsString('"journey_type": "mixed_quote"', $output);
+        $this->assertStringContainsString('"approval_status": "needs_review"', $output);
+        $this->assertStringContainsString('"accent": "#f97316"', $output);
+        $this->assertStringContainsString('"body_family": "Montserrat"', $output);
+        $this->assertStringContainsString('"source_type": "marketing_site_extraction"', $output);
+    }
+
+    public function test_written_extraction_drafts_are_exposed_by_draft_api_but_not_published(): void
+    {
+        Storage::fake('local');
+        Http::fake([
+            'https://discountbackloading.com.au' => Http::response(<<<'HTML'
+                <html>
+                    <head>
+                        <meta name="description" content="Backloading quote help.">
+                        <style>body { font-family: "Montserrat"; color: #f97316; }</style>
+                    </head>
+                    <body><h1>Discount moving quotes</h1></body>
+                </html>
+                HTML, 200, ['Content-Type' => 'text/html']),
+        ]);
+        config()->set('services.domain_monitor.moveroo_removals_api_key', 'moveroo-runtime-token');
+
+        $this->assertSame(0, Artisan::call('brand-surfaces:extract-style-draft', [
+            'hostname' => 'mymoveportal.discountbackloading.com.au',
+            '--write' => true,
+            '--path' => 'brand-style-drafts/discountbackloading.json',
+        ]));
+
+        Storage::disk('local')->assertExists('brand-style-drafts/discountbackloading.json');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer moveroo-runtime-token',
+        ])->getJson('/api/published-brand-surface-drafts?hostname=mymoveportal.discountbackloading.com.au')
+            ->assertOk()
+            ->assertJsonCount(1, 'proposals')
+            ->assertJsonPath('proposals.0.hostname', 'mymoveportal.discountbackloading.com.au')
+            ->assertJsonPath('proposals.0.approval_status', 'needs_review')
+            ->assertJsonPath('proposals.0.publish_gate.can_publish', false)
+            ->assertJsonPath('proposals.0.candidate.theme.colors.accent', '#f97316')
+            ->assertJsonPath('proposals.0.evidence.0.source_type', 'marketing_site_extraction');
+
+        $this->withHeaders([
+            'Authorization' => 'Bearer moveroo-runtime-token',
+        ])->getJson('/api/published-brand-surfaces?hostname=mymoveportal.discountbackloading.com.au')
+            ->assertOk()
+            ->assertJsonCount(0, 'surfaces');
+    }
+
+    public function test_extraction_requires_a_known_published_app_hostname(): void
+    {
+        $this->assertSame(1, Artisan::call('brand-surfaces:extract-style-draft', [
+            'hostname' => 'unknown.discountbackloading.com.au',
+        ]));
+
+        $this->assertStringContainsString(
+            'No published brand-surface metadata found for unknown.discountbackloading.com.au.',
+            Artisan::output(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `brand-surfaces:extract-style-draft {hostname}` to extract bounded review-only style draft metadata from a configured owning marketing domain
- let the existing draft feed read stored JSON drafts from `storage/app/private/brand-style-drafts` while keeping publication gated by `approval_status=approved`
- add the Discount Backloading fixture, app-host metadata, contract notes, and tests for draft-only versus published behavior

## Scope
- Domain Monitor only
- first extractor target: `discountbackloading.com.au` -> `mymoveportal.discountbackloading.com.au`
- no MoverooCombined changes
- no DNS, redirects, cron, secrets, billing, or live website changes
- no raw CSS, scripts, arbitrary classes, or builder payloads are published

## Checks
- `jq empty docs/fixtures/published-brand-surfaces/discountbackloading-style-draft.json`
- `git diff --check`
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/BrandStyleSurfaceExtractionCommandTest.php tests/Feature/PublishedBrandSurfaceApiTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=2G app/Services/BrandStyleSurfaceDraftBuilder.php app/Services/BrandStyle/MarketingSiteStyleExtractor.php app/Console/Commands/ExtractBrandStyleSurfaceDraft.php tests/Feature/BrandStyleSurfaceExtractionCommandTest.php`
- `php artisan brand-surfaces:extract-style-draft mymoveportal.discountbackloading.com.au` read-only live smoke succeeded
- `composer pr:preflight --no-interaction` passed Pint and PHPStan, then hit existing unrelated local full-suite baseline failures in command-runner path quoting and timezone timestamp expectations

Closes #223.
